### PR TITLE
fix: Replace allauth element tags with standard form rendering

### DIFF
--- a/plfog/settings.py
+++ b/plfog/settings.py
@@ -143,6 +143,7 @@ LOGOUT_REDIRECT_URL = "/"
 SOCIALACCOUNT_ADAPTER = "plfog.adapters.AutoAdminSocialAccountAdapter"
 ACCOUNT_ADAPTER = "plfog.adapters.AdminRedirectAccountAdapter"
 SOCIALACCOUNT_LOGIN_ON_GET = True
+ALLAUTH_TRUSTED_PROXY_COUNT = int(os.environ.get("ALLAUTH_TRUSTED_PROXY_COUNT", "0"))
 
 # Auto-admin: comma-separated list of email domains that get admin privileges on social login.
 # Empty/unset means no auto-admin. Malformed values raise ValueError at startup.

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load allauth %}
 
 {% block title %}Log In - Past Lives{% endblock %}
 
@@ -18,17 +17,11 @@
             Continue with Google
         </a>
         <div class="divider"><span>or</span></div>
-        {% element form form=form method="POST" action=action %}
+        <form method="POST">
             {% csrf_token %}
-            {% slot body %}
-                {% for field in form %}
-                    {% element field field=field %}{% endelement %}
-                {% endfor %}
-            {% endslot %}
-            {% slot actions %}
-                <button type="submit" class="btn btn--primary btn--full">Log In</button>
-            {% endslot %}
-        {% endelement %}
+            {{ form.as_p }}
+            <button type="submit" class="btn btn--primary btn--full">Log In</button>
+        </form>
         <div class="auth-links">
             <p>Don't have an account? <a href="{% url 'account_signup' %}">Sign up</a></p>
         </div>

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load allauth %}
 
 {% block title %}Sign Up - Past Lives{% endblock %}
 
@@ -18,17 +17,11 @@
             Sign up with Google
         </a>
         <div class="divider"><span>or</span></div>
-        {% element form form=form method="POST" action=action %}
+        <form method="POST">
             {% csrf_token %}
-            {% slot body %}
-                {% for field in form %}
-                    {% element field field=field %}{% endelement %}
-                {% endfor %}
-            {% endslot %}
-            {% slot actions %}
-                <button type="submit" class="btn btn--primary btn--full">Sign Up</button>
-            {% endslot %}
-        {% endelement %}
+            {{ form.as_p }}
+            <button type="submit" class="btn btn--primary btn--full">Sign Up</button>
+        </form>
         <div class="auth-links">
             <p>Already have an account? <a href="{% url 'account_login' %}">Log in</a></p>
         </div>


### PR DESCRIPTION
## Summary
- Replace broken allauth `{% element %}` tags with standard Django form rendering in login/signup templates
- Add `ALLAUTH_TRUSTED_PROXY_COUNT` env var for proxy IP resolution behind nginx

## Test plan
- [x] `pytest` — all tests pass
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy` — clean