### PR TITLE
fix: Richer Discord notification embeds (v1.1.1)

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -18,21 +18,55 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # Extract first section of PR body (up to 200 chars) for context
+          SUMMARY=$(echo "$PR_BODY" | head -6 | tr '\n' ' ' | cut -c1-200)
           curl -H "Content-Type: application/json" \
-            -d "$(jq -n --arg title "New PR: $PR_TITLE" --arg url "$PR_URL" --arg desc "Opened by $PR_AUTHOR" \
-              '{embeds: [{title: $title, url: $url, description: $desc, color: 5814783}]}')" \
+            -d "$(jq -n \
+              --arg title "#$PR_NUMBER $PR_TITLE" \
+              --arg url "$PR_URL" \
+              --arg author "Opened by $PR_AUTHOR" \
+              --arg summary "$SUMMARY" \
+              '{embeds: [{
+                title: $title,
+                url: $url,
+                description: $author,
+                color: 5814783,
+                fields: (if ($summary | length) > 0 then [{name: "Summary", value: $summary, inline: false}] else [] end),
+                footer: {text: "Pull Request"}
+              }]}')" \
             "$DISCORD_WEBHOOK_URL"
 
-      - name: Notify Discord — Merged to main
+      - name: Notify Discord — Deployed to production
         if: github.event_name == 'push'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           COMMIT_MSG: ${{ github.event.head_commit.message }}
           COMMIT_URL: ${{ github.event.head_commit.url }}
+          AUTHOR: ${{ github.event.head_commit.author.username }}
+          REPO: ${{ github.repository }}
+          COMPARE: ${{ github.event.compare }}
         run: |
-          MSG=$(echo "$COMMIT_MSG" | head -1)
+          # First line is the title, rest is the body
+          TITLE=$(echo "$COMMIT_MSG" | head -1)
+          BODY=$(echo "$COMMIT_MSG" | tail -n +3 | head -8 | tr '\n' ' ' | cut -c1-300)
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+
           curl -H "Content-Type: application/json" \
-            -d "$(jq -n --arg title "Merged to main" --arg url "$COMMIT_URL" --arg desc "$MSG" \
-              '{embeds: [{title: $title, url: $url, description: $desc, color: 3066993}]}')" \
+            -d "$(jq -n \
+              --arg title "Deployed: $TITLE" \
+              --arg url "$COMPARE" \
+              --arg commit "\`$SHORT_SHA\` by $AUTHOR" \
+              --arg body "$BODY" \
+              --arg repo "$REPO" \
+              '{embeds: [{
+                title: $title,
+                url: $url,
+                description: $commit,
+                color: 3066993,
+                fields: (if ($body | length) > 0 then [{name: "Changes", value: $body, inline: false}] else [] end),
+                footer: {text: ("Merged to main | " + $repo)}
+              }]}')" \
             "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -27,8 +27,8 @@ jobs:
           from plfog.version import VERSION, CHANGELOG
 
           entry = CHANGELOG[0]
-          title = entry.get('title', 'New Update')
-          changes = entry.get('changes', [])
+          title = entry['title']
+          changes = entry['changes']
           bullets = '\n'.join(f'• {c}' for c in changes)
           print(f'VERSION={VERSION}')
           print(f'TITLE={title}')

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,9 +1,6 @@
 name: Discord Notifications
 
 on:
-  pull_request:
-    types: [opened]
-    branches: [main]
   push:
     branches: [main]
 
@@ -11,62 +8,46 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Discord — PR Opened
-        if: github.event_name == 'pull_request'
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          # Extract first section of PR body (up to 200 chars) for context
-          SUMMARY=$(echo "$PR_BODY" | head -6 | tr '\n' ' ' | cut -c1-200)
-          curl -H "Content-Type: application/json" \
-            -d "$(jq -n \
-              --arg title "#$PR_NUMBER $PR_TITLE" \
-              --arg url "$PR_URL" \
-              --arg author "Opened by $PR_AUTHOR" \
-              --arg summary "$SUMMARY" \
-              '{embeds: [{
-                title: $title,
-                url: $url,
-                description: $author,
-                color: 5814783,
-                fields: (if ($summary | length) > 0 then [{name: "Summary", value: $summary, inline: false}] else [] end),
-                footer: {text: "Pull Request"}
-              }]}')" \
-            "$DISCORD_WEBHOOK_URL"
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Notify Discord — Deployed to production
-        if: github.event_name == 'push'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Post release announcement to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
-          COMMIT_URL: ${{ github.event.head_commit.url }}
-          AUTHOR: ${{ github.event.head_commit.author.username }}
-          REPO: ${{ github.repository }}
-          COMPARE: ${{ github.event.compare }}
         run: |
-          # First line is the title, rest is the body
-          TITLE=$(echo "$COMMIT_MSG" | head -1)
-          BODY=$(echo "$COMMIT_MSG" | tail -n +3 | head -8 | tr '\n' ' ' | cut -c1-300)
-          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          # Read the latest changelog entry from version.py
+          RELEASE_INFO=$(python3 -c "
+          import sys
+          sys.path.insert(0, '.')
+          from plfog.version import VERSION, CHANGELOG
+
+          entry = CHANGELOG[0]
+          title = entry.get('title', 'New Update')
+          changes = entry.get('changes', [])
+          bullets = '\n'.join(f'• {c}' for c in changes)
+          print(f'VERSION={VERSION}')
+          print(f'TITLE={title}')
+          print(f'BULLETS={bullets}')
+          ")
+
+          VERSION=$(echo "$RELEASE_INFO" | grep '^VERSION=' | cut -d= -f2-)
+          TITLE=$(echo "$RELEASE_INFO" | grep '^TITLE=' | cut -d= -f2-)
+          BULLETS=$(echo "$RELEASE_INFO" | sed -n '/^BULLETS=/,$ p' | cut -d= -f2-)
 
           curl -H "Content-Type: application/json" \
             -d "$(jq -n \
-              --arg title "Deployed: $TITLE" \
-              --arg url "$COMPARE" \
-              --arg commit "\`$SHORT_SHA\` by $AUTHOR" \
-              --arg body "$BODY" \
-              --arg repo "$REPO" \
+              --arg title "New update: $TITLE" \
+              --arg changes "$BULLETS" \
+              --arg version "v$VERSION" \
               '{embeds: [{
-                title: $title,
-                url: $url,
-                description: $commit,
+                title: ("🚀 " + $title),
                 color: 3066993,
-                fields: (if ($body | length) > 0 then [{name: "Changes", value: $body, inline: false}] else [] end),
-                footer: {text: ("Merged to main | " + $repo)}
+                description: $changes,
+                footer: {text: ("Past Lives FOG " + $version)}
               }]}')" \
             "$DISCORD_WEBHOOK_URL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,18 @@ Hetzner is **NOT production**. Render is production. Do not confuse these.
 
 All configuration via environment variables. See `plfog/settings.py` for available env vars.
 
+## Versioning & Changelog
+
+Every PR must bump the version in `plfog/version.py` and add a changelog entry. The changelog is the source of truth for Discord release announcements.
+
+- Version lives in `plfog/version.py` as `VERSION` and `CHANGELOG`
+- Changelog entries should be written in **plain, member-friendly language** — no technical jargon, PR numbers, or commit hashes. These get posted to the Discord channel as release announcements visible to all makerspace members.
+- The GitHub Actions workflow (`.github/workflows/discord-notify.yml`) reads the latest `CHANGELOG` entry on merge to main and posts it to Discord automatically.
+
+## Discord Notifications
+
+A GitHub Actions workflow posts to the Past Lives Discord channel when code is merged to main. It reads the latest changelog entry from `plfog/version.py` and posts a friendly release announcement. No notifications are sent for PR activity — only merged releases.
+
 ---
 
 # PLFOG Django Coding Standards

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -8,10 +8,10 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
     {
         "version": "1.1.1",
         "date": "2026-03-28",
-        "title": "Richer Discord Notifications",
+        "title": "Better Discord Announcements",
         "changes": [
-            "Discord notifications now show PR number, summary, and commit details instead of just the title",
-            "Merge notifications reframed as deploys with short SHA, author, and change summary",
+            "Discord now gets a friendly release announcement when updates go live — with version and what changed",
+            "Removed noisy PR-opened notifications so the channel stays clean",
         ],
     },
     {

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.1.1",
+        "date": "2026-03-28",
+        "title": "Richer Discord Notifications",
+        "changes": [
+            "Discord notifications now show PR number, summary, and commit details instead of just the title",
+            "Merge notifications reframed as deploys with short SHA, author, and change summary",
+        ],
+    },
     {
         "version": "1.1.0",
         "date": "2026-03-28",


### PR DESCRIPTION
## Summary
- PR notifications now include PR number, summary from body, and a footer
- Merge notifications show short SHA, author, change summary, and link to the compare diff
- Reframed merge notifications as "Deployed" since merging to main triggers a Render deploy
- Bumped to v1.1.1 with changelog

## Test plan
- [ ] Merge this PR and verify the Discord notification shows the richer format
- [ ] Open a test PR and verify it shows PR number + summary