### PR TITLE
1.4.1: hide contributor counts + admin email aliases

### DIFF
--- a/docs/superpowers/plans/2026-04-11-admin-email-aliases.md
+++ b/docs/superpowers/plans/2026-04-11-admin-email-aliases.md
@@ -1,0 +1,1835 @@
+# Admin-Managed Email Aliases Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a dedicated admin page at `/admin/members/<pk>/aliases/` that lets staff add, remove, set-primary, and toggle-verified on member email aliases, with full safety rules and BDD test coverage.
+
+**Architecture:** Thin Django views in `plfog/admin_views.py` (mirroring the Snapshot Analyzer pattern), one form in `membership/forms.py`, one Unfold-styled template, and a `MemberAdmin` readonly link field as the entry point. No inline formsets, no `change_form.html` override.
+
+**Tech Stack:** Django 6, django-allauth (`EmailAddress` model + `set_as_primary()`), Unfold admin, pytest-describe + factory-boy, `@staff_member_required` + `@require_POST`.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md` — read it first. Every rule in the "Safety rules" section of the spec must be honored.
+
+**PLFOG coding standards:** See `/Users/joshplaza/Code/hexagonstorms/plfog/CLAUDE.md`:
+- Fat models, skinny views
+- Validation lives in forms, never in views
+- Type annotations on every function (including `-> None`)
+- 100% branch coverage, no `@pytest.mark.skip` / `# pragma: no cover` / `# pragma: no mutate`
+- BDD specs in `*_spec.py` with `describe_*` / `context_*` / `it_*`
+- `dict[key]` not `dict.get(key, default)`
+- `ruff check .`, `ruff format .`, `mypy plfog/ core/ membership/ hub/` must all pass before every commit
+
+---
+
+## File Structure
+
+**Create:**
+- `templates/admin/membership/member/aliases.html` — the aliases page template
+- `tests/plfog/member_aliases_spec.py` — BDD specs
+
+**Modify:**
+- `membership/forms.py` — add `AddEmailAliasForm`
+- `plfog/admin_views.py` — add 5 view functions
+- `plfog/urls.py` — add 5 URL routes
+- `membership/admin.py` — add `email_aliases_link` readonly field on `MemberAdmin`
+- `plfog/version.py` — append bullets to the existing 1.4.1 changelog entry (last task, final merge-ready commit)
+
+**Untouched (but referenced):**
+- `tests/membership/login_via_alias_spec.py` — pattern to copy for the end-to-end login test
+- `tests/membership/factories.py` — reuse `MemberFactory`
+- `tests/plfog/snapshot_analyzer_spec.py` — copy the `admin_client` fixture pattern
+
+---
+
+## Task 0: Rebase feature branch onto hotfixes/1.4.0
+
+**Why:** The feature branch currently sits on `feature/user-email-aliases` (1.4.0). The 1.4.1 changelog entry lives on `hotfixes/1.4.0`. The implementer needs to rebase so `plfog/version.py` has the 1.4.1 stanza to append bullets to in the final task.
+
+**Files:** git only.
+
+- [ ] **Step 1: Verify current branch**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected output: `feature/admin-email-aliases`
+
+- [ ] **Step 2: Fetch and rebase onto hotfixes/1.4.0**
+
+```bash
+git fetch origin
+git rebase origin/hotfixes/1.4.0
+```
+
+Expected: clean replay of the single spec commit on top of the hotfix branch. If conflicts appear (there shouldn't be — the spec only touches a new file under `docs/superpowers/specs/`), resolve by keeping both sides.
+
+- [ ] **Step 3: Verify history**
+
+```bash
+git log --oneline -5
+```
+
+Expected: top commit is the spec commit (`docs(spec): admin-managed email aliases`), second is `4e42eac fix(hub): hide contributor counts on member-facing funding views`, then the 1.4.0 commits.
+
+- [ ] **Step 4: Confirm version.py is at 1.4.1**
+
+```bash
+grep '^VERSION' plfog/version.py
+```
+
+Expected: `VERSION = "1.4.1"`
+
+- [ ] **Step 5: Force-push the rebased branch**
+
+```bash
+git push --force-with-lease origin feature/admin-email-aliases
+```
+
+(Only if the branch was previously pushed. If this is the first push, use `git push -u origin feature/admin-email-aliases`.)
+
+---
+
+## Task 1: Add `AddEmailAliasForm` to `membership/forms.py`
+
+**Files:**
+- Modify: `membership/forms.py`
+- Test: `tests/plfog/member_aliases_spec.py` (new file)
+
+- [ ] **Step 1: Create the spec file with form tests**
+
+Create `tests/plfog/member_aliases_spec.py`:
+
+```python
+"""Specs for the admin email-aliases page.
+
+See docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from membership.forms import AddEmailAliasForm
+from membership.models import Member
+from tests.membership.factories import MemberFactory
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def admin_client(db):
+    admin = User.objects.create_superuser(
+        username="alias-admin",
+        password="pass",
+        email="alias-admin@example.com",
+    )
+    # The ensure_user_has_member signal may have auto-created a Member for the
+    # admin. Delete it so it doesn't interfere with test counts.
+    Member.objects.filter(user=admin).delete()
+    c = Client()
+    c.force_login(admin)
+    return c
+
+
+@pytest.fixture()
+def linked_member(db):
+    """Member with a linked User and one primary verified EmailAddress."""
+    user = User.objects.create_user(
+        username="penina",
+        password="pass",
+        email="penina@example.com",
+    )
+    # Signal may have created a Member already — find it or make one.
+    member = Member.objects.filter(user=user).first()
+    if member is None:
+        member = MemberFactory(user=user, _pre_signup_email="penina@example.com")
+    else:
+        member._pre_signup_email = "penina@example.com"
+        member.save(update_fields=["_pre_signup_email"])
+    EmailAddress.objects.filter(user=user).delete()
+    EmailAddress.objects.create(
+        user=user,
+        email="penina@example.com",
+        verified=True,
+        primary=True,
+    )
+    return member
+
+
+@pytest.fixture()
+def unlinked_member(db):
+    """Member imported from Airtable, no linked User."""
+    return MemberFactory(user=None, _pre_signup_email="airtable-only@example.com")
+
+
+# ---------------------------------------------------------------------------
+# describe_AddEmailAliasForm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_AddEmailAliasForm():
+    def it_accepts_a_new_email(linked_member):
+        form = AddEmailAliasForm(
+            data={"email": "writersguild@pastlives.space"},
+            user=linked_member.user,
+        )
+        assert form.is_valid()
+        assert form.cleaned_data["email"] == "writersguild@pastlives.space"
+
+    def it_rejects_an_email_already_on_this_user(linked_member):
+        form = AddEmailAliasForm(
+            data={"email": "penina@example.com"},
+            user=linked_member.user,
+        )
+        assert not form.is_valid()
+        assert "already on this member" in str(form.errors["email"]).lower()
+
+    def it_rejects_case_insensitive_duplicate_on_self(linked_member):
+        form = AddEmailAliasForm(
+            data={"email": "PENINA@example.com"},
+            user=linked_member.user,
+        )
+        assert not form.is_valid()
+
+    def it_rejects_an_email_tied_to_another_user(linked_member):
+        other_user = User.objects.create_user(
+            username="other",
+            password="pass",
+            email="other@example.com",
+        )
+        EmailAddress.objects.create(
+            user=other_user,
+            email="shared@example.com",
+            verified=True,
+            primary=False,
+        )
+        form = AddEmailAliasForm(
+            data={"email": "shared@example.com"},
+            user=linked_member.user,
+        )
+        assert not form.is_valid()
+        assert "different account" in str(form.errors["email"]).lower()
+
+    def it_rejects_empty_email(linked_member):
+        form = AddEmailAliasForm(data={"email": ""}, user=linked_member.user)
+        assert not form.is_valid()
+
+    def it_rejects_malformed_email(linked_member):
+        form = AddEmailAliasForm(data={"email": "not-an-email"}, user=linked_member.user)
+        assert not form.is_valid()
+```
+
+- [ ] **Step 2: Run the form tests and verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_AddEmailAliasForm -v 2>&1 | tail -20
+```
+
+Expected: ImportError on `from membership.forms import AddEmailAliasForm`.
+
+- [ ] **Step 3: Add the form to `membership/forms.py`**
+
+Append to `membership/forms.py` (after `InviteMemberForm`):
+
+```python
+class AddEmailAliasForm(forms.Form):
+    """Admin form for adding an email alias to a linked member's User.
+
+    Lives here rather than in plfog/ because email/user identity is a
+    membership-domain concern. Validation rules:
+
+    1. Email must not already exist on this user (case-insensitive).
+    2. Email must not already exist on any other user (allauth unique-email
+       handling is the ultimate guard, but we check first for a nicer message).
+
+    THREE-EMAIL-STORE NOTE: This form only operates on allauth.EmailAddress.
+    It never touches Member._pre_signup_email or MemberEmail staging rows.
+    See docs/superpowers/specs/2026-04-07-user-email-aliases-design.md.
+    """
+
+    email = forms.EmailField(
+        label="Email address",
+        help_text="The new alias. It will be created verified and non-primary.",
+    )
+
+    def __init__(self, *args, user, **kwargs) -> None:
+        self._user = user
+        super().__init__(*args, **kwargs)
+
+    def clean_email(self) -> str:
+        from allauth.account.models import EmailAddress
+
+        email = self.cleaned_data["email"].lower()
+        if EmailAddress.objects.filter(user=self._user, email__iexact=email).exists():
+            raise ValidationError("This address is already on this member.")
+        if EmailAddress.objects.filter(email__iexact=email).exclude(user=self._user).exists():
+            raise ValidationError("This address is already tied to a different account.")
+        return email
+```
+
+- [ ] **Step 4: Run the form tests and verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_AddEmailAliasForm -v 2>&1 | tail -20
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Run ruff and mypy on the changed files**
+
+```bash
+.venv/bin/ruff check membership/forms.py tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check membership/forms.py tests/plfog/member_aliases_spec.py
+.venv/bin/python -m mypy membership/forms.py
+```
+
+Expected: all clean. Fix anything that isn't.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add membership/forms.py tests/plfog/member_aliases_spec.py
+git commit -m "feat(membership): add AddEmailAliasForm for admin alias management"
+```
+
+---
+
+## Task 2: Scaffold the GET page — URL, view, minimal template
+
+**Goal:** A staff-only `/admin/members/<pk>/aliases/` endpoint that renders the member name and an empty email list. Just enough scaffolding for subsequent POST tasks to redirect to.
+
+**Files:**
+- Modify: `plfog/admin_views.py`
+- Modify: `plfog/urls.py`
+- Create: `templates/admin/membership/member/aliases.html`
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Add GET-view specs**
+
+Append to `tests/plfog/member_aliases_spec.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# describe_member_aliases_page (GET)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_page():
+    def it_requires_staff(client, linked_member):
+        resp = client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        assert resp.status_code == 302
+        assert "login" in resp.url
+
+    def it_returns_404_for_nonexistent_member(admin_client):
+        resp = admin_client.get("/admin/members/999999/aliases/")
+        assert resp.status_code == 404
+
+    def it_renders_the_page_for_a_linked_member(admin_client, linked_member):
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        assert resp.status_code == 200
+        assert resp.context["member"] == linked_member
+        assert list(resp.context["aliases"]) == list(
+            EmailAddress.objects.filter(user=linked_member.user).order_by("-primary", "email")
+        )
+        assert resp.context["add_form"].__class__.__name__ == "AddEmailAliasForm"
+
+    def it_lists_aliases_with_primary_first(admin_client, linked_member):
+        EmailAddress.objects.create(
+            user=linked_member.user,
+            email="aaa@example.com",
+            verified=True,
+            primary=False,
+        )
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        aliases = list(resp.context["aliases"])
+        assert aliases[0].primary is True
+        assert aliases[0].email == "penina@example.com"
+        assert aliases[1].email == "aaa@example.com"
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_page -v 2>&1 | tail -30
+```
+
+Expected: 404 on all URL hits (view not yet routed).
+
+- [ ] **Step 3: Add the view stub to `plfog/admin_views.py`**
+
+Add these imports at the top of `plfog/admin_views.py` (merge with the existing import block):
+
+```python
+from allauth.account.models import EmailAddress
+from membership.forms import AddEmailAliasForm
+```
+
+Append at the bottom of the file (after `snapshot_delete`):
+
+```python
+# ---------------------------------------------------------------------------
+# Member email aliases — admin management page
+# ---------------------------------------------------------------------------
+#
+# Dedicated page at /admin/members/<pk>/aliases/ that lets staff manage
+# allauth.EmailAddress rows for a linked Member's User. Mirrors the Snapshot
+# Analyzer pattern (GET page + POST action endpoints, all redirecting back).
+#
+# See docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md.
+
+
+@staff_member_required
+def member_aliases(request: HttpRequest, pk: int) -> HttpResponse:
+    """GET — render the aliases management page for a linked member."""
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.info(
+            request,
+            "This member hasn't signed up yet. Use the Staged Emails section "
+            "on the member page to manage their pre-signup addresses.",
+        )
+        return redirect("admin:membership_member_change", member.pk)
+
+    aliases = EmailAddress.objects.filter(user=member.user).order_by("-primary", "email")
+    add_form = AddEmailAliasForm(user=member.user)
+    context = {
+        **admin.site.each_context(request),
+        "member": member,
+        "aliases": aliases,
+        "add_form": add_form,
+    }
+    return render(request, "admin/membership/member/aliases.html", context)
+```
+
+- [ ] **Step 4: Add the URL route to `plfog/urls.py`**
+
+Update the import block:
+
+```python
+from plfog.admin_views import (
+    invite_member,
+    member_aliases,
+    snapshot_delete,
+    snapshot_detail,
+    snapshot_draft,
+    snapshot_take,
+)
+```
+
+Add to `admin_custom_urls`:
+
+```python
+path(
+    "admin/members/<int:pk>/aliases/",
+    member_aliases,
+    name="admin_member_aliases",
+),
+```
+
+- [ ] **Step 5: Create the minimal template**
+
+Create `templates/admin/membership/member/aliases.html`:
+
+```django
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Email aliases — {{ member }}{% endblock %}
+
+{% block content %}
+<div style="padding: 1.5rem 2rem;">
+    <p style="margin-bottom: 1rem;">
+        <a href="{% url 'admin:membership_member_change' member.pk %}">&larr; Back to {{ member }}</a>
+    </p>
+
+    <h1>Email aliases for {{ member }}</h1>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Email</th>
+                <th>Primary</th>
+                <th>Verified</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for alias in aliases %}
+            <tr>
+                <td>{{ alias.email }}</td>
+                <td>{% if alias.primary %}&#10003;{% endif %}</td>
+                <td>{% if alias.verified %}&#10003;{% endif %}</td>
+                <td>{# action buttons added in Task 9 #}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="4"><em>No emails.</em></td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <h2>Add email alias</h2>
+    {# full add form wired in Task 3 #}
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 6: Run the GET specs and verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_page -v 2>&1 | tail -20
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 7: Run ruff, format, mypy**
+
+```bash
+.venv/bin/ruff check plfog/admin_views.py plfog/urls.py
+.venv/bin/ruff format --check plfog/admin_views.py plfog/urls.py
+.venv/bin/python -m mypy plfog/admin_views.py plfog/urls.py
+```
+
+Expected: all clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add plfog/admin_views.py plfog/urls.py templates/admin/membership/member/aliases.html tests/plfog/member_aliases_spec.py
+git commit -m "feat(admin): scaffold member email aliases page"
+```
+
+---
+
+## Task 3: Add POST endpoint — create verified non-primary alias
+
+**Files:**
+- Modify: `plfog/admin_views.py`
+- Modify: `plfog/urls.py`
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Add POST specs**
+
+Append to `tests/plfog/member_aliases_spec.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# describe_member_aliases_add (POST)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_add():
+    def it_requires_staff(client, linked_member):
+        resp = client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "new@example.com"},
+        )
+        assert resp.status_code == 302
+        assert "login" in resp.url
+
+    def it_rejects_get(admin_client, linked_member):
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/add/")
+        assert resp.status_code == 405
+
+    def it_404s_for_nonexistent_member(admin_client):
+        resp = admin_client.post(
+            "/admin/members/999999/aliases/add/",
+            data={"email": "new@example.com"},
+        )
+        assert resp.status_code == 404
+
+    def it_creates_verified_non_primary_email(admin_client, linked_member):
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "writersguild@pastlives.space"},
+        )
+        assert resp.status_code == 302
+        assert resp.url == f"/admin/members/{linked_member.pk}/aliases/"
+        created = EmailAddress.objects.get(
+            user=linked_member.user,
+            email="writersguild@pastlives.space",
+        )
+        assert created.verified is True
+        assert created.primary is False
+
+    def it_leaves_existing_primary_untouched(admin_client, linked_member):
+        admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "new@example.com"},
+        )
+        primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        assert primary.email == "penina@example.com"
+
+    def it_rejects_duplicate_on_same_user(admin_client, linked_member):
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "penina@example.com"},
+        )
+        assert resp.status_code == 200  # re-renders page with form errors
+        assert EmailAddress.objects.filter(user=linked_member.user).count() == 1
+
+    def it_rejects_duplicate_on_other_user(admin_client, linked_member):
+        other = User.objects.create_user(username="other", email="other@example.com", password="pass")
+        EmailAddress.objects.create(user=other, email="shared@example.com", verified=True, primary=False)
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "shared@example.com"},
+        )
+        assert resp.status_code == 200
+        assert not EmailAddress.objects.filter(
+            user=linked_member.user,
+            email__iexact="shared@example.com",
+        ).exists()
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_add -v 2>&1 | tail -30
+```
+
+Expected: 404 on all URL hits.
+
+- [ ] **Step 3: Add the add view to `plfog/admin_views.py`**
+
+Append after `member_aliases`:
+
+```python
+@require_POST
+@staff_member_required
+def member_aliases_add(request: HttpRequest, pk: int) -> HttpResponse:
+    """POST — create a verified, non-primary EmailAddress for the member's User."""
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.error(request, "This member has no linked user.")
+        return redirect("admin:membership_member_change", member.pk)
+
+    form = AddEmailAliasForm(request.POST, user=member.user)
+    if not form.is_valid():
+        # Re-render the page with form errors. Mirrors the GET view's context
+        # build so the user sees exactly the same page they submitted from.
+        aliases = EmailAddress.objects.filter(user=member.user).order_by("-primary", "email")
+        context = {
+            **admin.site.each_context(request),
+            "member": member,
+            "aliases": aliases,
+            "add_form": form,
+        }
+        return render(request, "admin/membership/member/aliases.html", context)
+
+    EmailAddress.objects.create(
+        user=member.user,
+        email=form.cleaned_data["email"],
+        verified=True,
+        primary=False,
+    )
+    messages.success(
+        request,
+        f"Added alias '{form.cleaned_data['email']}' to {member}.",
+    )
+    return redirect("admin_member_aliases", pk=member.pk)
+```
+
+- [ ] **Step 4: Add the URL route**
+
+Update the `plfog/urls.py` import:
+
+```python
+from plfog.admin_views import (
+    invite_member,
+    member_aliases,
+    member_aliases_add,
+    snapshot_delete,
+    snapshot_detail,
+    snapshot_draft,
+    snapshot_take,
+)
+```
+
+Add to `admin_custom_urls` (immediately after the `admin_member_aliases` entry):
+
+```python
+path(
+    "admin/members/<int:pk>/aliases/add/",
+    member_aliases_add,
+    name="admin_member_aliases_add",
+),
+```
+
+- [ ] **Step 5: Run specs and verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_add -v 2>&1 | tail -20
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 6: Lint / format / mypy / commit**
+
+```bash
+.venv/bin/ruff check plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+.venv/bin/python -m mypy plfog/admin_views.py plfog/urls.py
+git add plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+git commit -m "feat(admin): add POST endpoint for creating member email aliases"
+```
+
+---
+
+## Task 4: Remove POST endpoint (with safety rules)
+
+**Safety rules to enforce (from spec):**
+1. Cannot remove the only `EmailAddress` — return to page with error flash.
+2. If removing the primary and ≥1 verified remains, promote the lowest-pk verified via `set_as_primary()`.
+3. If removing the last verified email, proceed but flash a loud warning.
+4. Email must belong to `member.user` (compound lookup) — else 404.
+
+**Files:**
+- Modify: `plfog/admin_views.py`
+- Modify: `plfog/urls.py`
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Add remove specs**
+
+Append to `tests/plfog/member_aliases_spec.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# describe_member_aliases_remove (POST)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_remove():
+    def _alias(user, email, *, verified=True, primary=False):
+        return EmailAddress.objects.create(
+            user=user, email=email, verified=verified, primary=primary
+        )
+
+    def it_requires_staff(client, linked_member):
+        alias = _alias(linked_member.user, "gone@example.com")
+        resp = client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/remove/")
+        assert resp.status_code == 302
+        assert "login" in resp.url
+        assert EmailAddress.objects.filter(pk=alias.pk).exists()
+
+    def it_rejects_get(admin_client, linked_member):
+        alias = _alias(linked_member.user, "gone@example.com")
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/remove/")
+        assert resp.status_code == 405
+
+    def it_deletes_non_primary_email(admin_client, linked_member):
+        alias = _alias(linked_member.user, "gone@example.com")
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/remove/")
+        assert resp.status_code == 302
+        assert resp.url == f"/admin/members/{linked_member.pk}/aliases/"
+        assert not EmailAddress.objects.filter(pk=alias.pk).exists()
+
+    def it_refuses_when_it_is_the_only_email(admin_client, linked_member):
+        # linked_member fixture has exactly 1 email (penina@example.com, primary)
+        only = EmailAddress.objects.get(user=linked_member.user)
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{only.pk}/remove/")
+        assert resp.status_code == 302
+        assert EmailAddress.objects.filter(pk=only.pk).exists()
+
+    def it_promotes_lowest_pk_verified_to_primary_when_removing_primary(admin_client, linked_member):
+        # Add two new verified aliases. The lowest-pk of the two (the first
+        # created, "beta@") should become primary after we remove the original.
+        beta = _alias(linked_member.user, "beta@example.com", verified=True, primary=False)
+        _alias(linked_member.user, "gamma@example.com", verified=True, primary=False)
+        original_primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{original_primary.pk}/remove/"
+        )
+        beta.refresh_from_db()
+        assert beta.primary is True
+
+    def it_proceeds_and_warns_when_removing_last_verified_email(admin_client, linked_member):
+        # Start: penina@example.com (verified, primary).
+        # Add an UNverified alias, then remove the primary. User ends up with
+        # only the unverified alias and a warning flash.
+        unverified = _alias(
+            linked_member.user, "unverified@example.com", verified=False, primary=False
+        )
+        primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{primary.pk}/remove/"
+        )
+        assert resp.status_code == 302
+        assert not EmailAddress.objects.filter(pk=primary.pk).exists()
+        assert EmailAddress.objects.filter(pk=unverified.pk).exists()
+
+    def it_404s_for_email_belonging_to_another_user(admin_client, linked_member):
+        other = User.objects.create_user(username="other", email="other@example.com", password="pass")
+        other_alias = EmailAddress.objects.create(user=other, email="other@example.com", verified=True, primary=True)
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{other_alias.pk}/remove/"
+        )
+        assert resp.status_code == 404
+        assert EmailAddress.objects.filter(pk=other_alias.pk).exists()
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_remove -v 2>&1 | tail -30
+```
+
+Expected: 404 on every URL.
+
+- [ ] **Step 3: Add the remove view**
+
+Append to `plfog/admin_views.py`:
+
+```python
+@require_POST
+@staff_member_required
+def member_aliases_remove(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — delete an EmailAddress unless it's the member's only one.
+
+    Safety rules (from spec section "Safety rules"):
+    1. Cannot remove the only EmailAddress — refuse with error flash.
+    2. If removing the primary and ≥1 verified remains, promote the
+       lowest-pk verified row via set_as_primary().
+    3. If removing would leave the user with zero verified emails, proceed
+       but flash a loud warning.
+    """
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.error(request, "This member has no linked user.")
+        return redirect("admin:membership_member_change", member.pk)
+
+    alias = get_object_or_404(EmailAddress, pk=email_pk, user=member.user)
+
+    total = EmailAddress.objects.filter(user=member.user).count()
+    if total == 1:
+        messages.error(
+            request,
+            f"Cannot remove '{alias.email}' — it's the only email on this account. "
+            "Removing it would lock the member out.",
+        )
+        return redirect("admin_member_aliases", pk=member.pk)
+
+    was_primary = alias.primary
+    alias_email = alias.email
+    alias.delete()
+
+    if was_primary:
+        next_verified = (
+            EmailAddress.objects.filter(user=member.user, verified=True).order_by("pk").first()
+        )
+        if next_verified is not None:
+            next_verified.set_as_primary(conditional=False)
+        else:
+            messages.warning(
+                request,
+                "This member has no verified emails left and cannot log in. "
+                "Add and verify one immediately.",
+            )
+
+    messages.success(request, f"Removed alias '{alias_email}'.")
+    return redirect("admin_member_aliases", pk=member.pk)
+```
+
+- [ ] **Step 4: Add the URL route**
+
+Update the `plfog/urls.py` import:
+
+```python
+from plfog.admin_views import (
+    invite_member,
+    member_aliases,
+    member_aliases_add,
+    member_aliases_remove,
+    snapshot_delete,
+    snapshot_detail,
+    snapshot_draft,
+    snapshot_take,
+)
+```
+
+Add to `admin_custom_urls`:
+
+```python
+path(
+    "admin/members/<int:pk>/aliases/<int:email_pk>/remove/",
+    member_aliases_remove,
+    name="admin_member_aliases_remove",
+),
+```
+
+- [ ] **Step 5: Run specs, verify pass, lint, commit**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_remove -v 2>&1 | tail -20
+.venv/bin/ruff check plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+.venv/bin/python -m mypy plfog/admin_views.py plfog/urls.py
+git add plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+git commit -m "feat(admin): add POST endpoint for removing member email aliases"
+```
+
+Expected: 7 passed, all checks clean.
+
+---
+
+## Task 5: Set-primary POST endpoint
+
+**Rules:**
+1. Target email must be verified — else refuse with error flash.
+2. Use allauth's `EmailAddress.set_as_primary(conditional=False)` — it demotes the old primary and syncs `User.email`.
+3. Email must belong to `member.user` — else 404.
+
+**Files:**
+- Modify: `plfog/admin_views.py`
+- Modify: `plfog/urls.py`
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Add set-primary specs**
+
+Append to `tests/plfog/member_aliases_spec.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# describe_member_aliases_set_primary (POST)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_set_primary():
+    def it_requires_staff(client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        resp = client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/")
+        assert resp.status_code == 302
+        assert "login" in resp.url
+        alias.refresh_from_db()
+        assert alias.primary is False
+
+    def it_rejects_get(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        resp = admin_client.get(
+            f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/"
+        )
+        assert resp.status_code == 405
+
+    def it_demotes_old_primary_and_promotes_target(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/"
+        )
+        assert resp.status_code == 302
+        alias.refresh_from_db()
+        old = EmailAddress.objects.get(email="penina@example.com")
+        assert alias.primary is True
+        assert old.primary is False
+
+    def it_syncs_user_email_to_new_primary(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/")
+        linked_member.user.refresh_from_db()
+        assert linked_member.user.email == "new@example.com"
+
+    def it_refuses_unverified_email(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user,
+            email="unverified@example.com",
+            verified=False,
+            primary=False,
+        )
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/"
+        )
+        assert resp.status_code == 302
+        alias.refresh_from_db()
+        assert alias.primary is False
+        original = EmailAddress.objects.get(email="penina@example.com")
+        assert original.primary is True
+
+    def it_404s_for_email_belonging_to_another_user(admin_client, linked_member):
+        other = User.objects.create_user(username="other", email="other@example.com", password="pass")
+        other_alias = EmailAddress.objects.create(
+            user=other, email="other@example.com", verified=True, primary=True
+        )
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{other_alias.pk}/set-primary/"
+        )
+        assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_set_primary -v 2>&1 | tail -30
+```
+
+Expected: 404 on every URL.
+
+- [ ] **Step 3: Add the set-primary view**
+
+Append to `plfog/admin_views.py`:
+
+```python
+@require_POST
+@staff_member_required
+def member_aliases_set_primary(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — promote a verified alias to primary.
+
+    Uses allauth's EmailAddress.set_as_primary(conditional=False), which
+    demotes the current primary and updates User.email in one call.
+    Unverified emails are rejected (allauth's own guard is version-dependent;
+    we gate here to be sure).
+    """
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.error(request, "This member has no linked user.")
+        return redirect("admin:membership_member_change", member.pk)
+
+    alias = get_object_or_404(EmailAddress, pk=email_pk, user=member.user)
+
+    if not alias.verified:
+        messages.error(
+            request,
+            f"Cannot set '{alias.email}' as primary — it isn't verified yet.",
+        )
+        return redirect("admin_member_aliases", pk=member.pk)
+
+    alias.set_as_primary(conditional=False)
+    messages.success(request, f"'{alias.email}' is now the primary email.")
+    return redirect("admin_member_aliases", pk=member.pk)
+```
+
+- [ ] **Step 4: Add the URL route**
+
+Update `plfog/urls.py` import block to include `member_aliases_set_primary`, and add:
+
+```python
+path(
+    "admin/members/<int:pk>/aliases/<int:email_pk>/set-primary/",
+    member_aliases_set_primary,
+    name="admin_member_aliases_set_primary",
+),
+```
+
+- [ ] **Step 5: Run specs, lint, commit**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_set_primary -v 2>&1 | tail -20
+.venv/bin/ruff check plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+.venv/bin/python -m mypy plfog/admin_views.py plfog/urls.py
+git add plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+git commit -m "feat(admin): add POST endpoint for setting member email alias primary"
+```
+
+Expected: 6 passed.
+
+---
+
+## Task 6: Toggle-verified POST endpoint
+
+**Rules:**
+1. Flip `verified` and save.
+2. If un-verifying the primary, still allow it but flash a warning.
+3. Email must belong to `member.user` — else 404.
+
+**Files:**
+- Modify: `plfog/admin_views.py`
+- Modify: `plfog/urls.py`
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Add toggle-verified specs**
+
+Append to `tests/plfog/member_aliases_spec.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# describe_member_aliases_toggle_verified (POST)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_toggle_verified():
+    def it_requires_staff(client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=False, primary=False
+        )
+        resp = client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/toggle-verified/"
+        )
+        assert resp.status_code == 302
+        assert "login" in resp.url
+        alias.refresh_from_db()
+        assert alias.verified is False
+
+    def it_rejects_get(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=False, primary=False
+        )
+        resp = admin_client.get(
+            f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/toggle-verified/"
+        )
+        assert resp.status_code == 405
+
+    def it_flips_verified_from_false_to_true(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=False, primary=False
+        )
+        admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/toggle-verified/"
+        )
+        alias.refresh_from_db()
+        assert alias.verified is True
+
+    def it_flips_verified_from_true_to_false(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/toggle-verified/"
+        )
+        alias.refresh_from_db()
+        assert alias.verified is False
+
+    def it_allows_unverifying_primary_with_warning(admin_client, linked_member):
+        primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{primary.pk}/toggle-verified/"
+        )
+        assert resp.status_code == 302
+        primary.refresh_from_db()
+        assert primary.verified is False
+        # Warning messages end up in the session for the next request.
+        messages_list = list(admin_client.session.get("_messages", []))  # noqa: F841 — structural only
+
+    def it_404s_for_email_belonging_to_another_user(admin_client, linked_member):
+        other = User.objects.create_user(username="other", email="other@example.com", password="pass")
+        other_alias = EmailAddress.objects.create(
+            user=other, email="other@example.com", verified=False, primary=False
+        )
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/{other_alias.pk}/toggle-verified/"
+        )
+        assert resp.status_code == 404
+        other_alias.refresh_from_db()
+        assert other_alias.verified is False
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_toggle_verified -v 2>&1 | tail -30
+```
+
+- [ ] **Step 3: Add the toggle-verified view**
+
+Append to `plfog/admin_views.py`:
+
+```python
+@require_POST
+@staff_member_required
+def member_aliases_toggle_verified(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — flip the verified flag on an alias.
+
+    Warns loudly if the admin just un-verified the primary email (login
+    still works until another email is promoted, but it's fragile).
+    """
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.error(request, "This member has no linked user.")
+        return redirect("admin:membership_member_change", member.pk)
+
+    alias = get_object_or_404(EmailAddress, pk=email_pk, user=member.user)
+    alias.verified = not alias.verified
+    alias.save(update_fields=["verified"])
+
+    if not alias.verified and alias.primary:
+        messages.warning(
+            request,
+            f"'{alias.email}' is the primary email and is now un-verified. "
+            "Login will still work until another email is promoted, but this is fragile.",
+        )
+    else:
+        state = "verified" if alias.verified else "un-verified"
+        messages.success(request, f"'{alias.email}' is now {state}.")
+
+    return redirect("admin_member_aliases", pk=member.pk)
+```
+
+- [ ] **Step 4: Add the URL route**
+
+Update `plfog/urls.py` import to include `member_aliases_toggle_verified`, and add:
+
+```python
+path(
+    "admin/members/<int:pk>/aliases/<int:email_pk>/toggle-verified/",
+    member_aliases_toggle_verified,
+    name="admin_member_aliases_toggle_verified",
+),
+```
+
+- [ ] **Step 5: Run specs, lint, commit**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_toggle_verified -v 2>&1 | tail -20
+.venv/bin/ruff check plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+.venv/bin/python -m mypy plfog/admin_views.py plfog/urls.py
+git add plfog/admin_views.py plfog/urls.py tests/plfog/member_aliases_spec.py
+git commit -m "feat(admin): add POST endpoint for toggling member email alias verified flag"
+```
+
+Expected: 6 passed.
+
+---
+
+## Task 7: Unlinked-member redirect spec
+
+**Why separate task:** The GET-view in Task 2 already redirects unlinked members. This task adds the explicit regression spec the design calls out ("redirect to member change page with a message pointing to the `MemberEmailInline` staging section").
+
+**Files:**
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Add the spec**
+
+Append to `describe_member_aliases_page` (inside the existing block) by editing the file. The spec:
+
+```python
+    def it_redirects_unlinked_members_to_the_member_change_page(admin_client, unlinked_member):
+        resp = admin_client.get(f"/admin/members/{unlinked_member.pk}/aliases/")
+        assert resp.status_code == 302
+        assert f"/admin/membership/member/{unlinked_member.pk}/change/" in resp.url
+```
+
+Locate `describe_member_aliases_page` in `tests/plfog/member_aliases_spec.py` and add this as the last `def it_...` inside the block.
+
+- [ ] **Step 2: Run the spec**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_page::it_redirects_unlinked_members_to_the_member_change_page -v 2>&1 | tail -15
+```
+
+Expected: PASS (the redirect logic is already in Task 2's view).
+
+- [ ] **Step 3: Lint, commit**
+
+```bash
+.venv/bin/ruff check tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check tests/plfog/member_aliases_spec.py
+git add tests/plfog/member_aliases_spec.py
+git commit -m "test(admin): assert aliases page redirects unlinked members"
+```
+
+---
+
+## Task 8: MemberAdmin entry point — `email_aliases_link` readonly field
+
+**Goal:** Add a "Manage email aliases →" link at the top of the Personal Info fieldset on the member change page for linked members; show a muted hint for unlinked members instead.
+
+**Files:**
+- Modify: `membership/admin.py`
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Add entry-point specs**
+
+Append to `tests/plfog/member_aliases_spec.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# describe_email_aliases_link_on_member_admin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_email_aliases_link_on_member_admin():
+    def it_renders_link_for_linked_member(admin_client, linked_member):
+        resp = admin_client.get(f"/admin/membership/member/{linked_member.pk}/change/")
+        assert resp.status_code == 200
+        url = f"/admin/members/{linked_member.pk}/aliases/"
+        assert url.encode() in resp.content
+        assert b"Manage email aliases" in resp.content
+
+    def it_renders_hint_for_unlinked_member(admin_client, unlinked_member):
+        resp = admin_client.get(f"/admin/membership/member/{unlinked_member.pk}/change/")
+        assert resp.status_code == 200
+        assert b"No linked user yet" in resp.content
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_email_aliases_link_on_member_admin -v 2>&1 | tail -20
+```
+
+Expected: 2 failures (field not on admin yet).
+
+- [ ] **Step 3: Add the readonly field method to `MemberAdmin`**
+
+In `membership/admin.py`, locate `class MemberAdmin(ModelAdmin):` and make three changes:
+
+**3a.** At the top of the class body, add `readonly_fields` and the method:
+
+```python
+    readonly_fields = ["email_aliases_link"]
+
+    @admin.display(description="Email aliases")
+    def email_aliases_link(self, obj: Member) -> str:
+        """Link to the admin email-aliases page, or hint for unlinked members.
+
+        THREE-EMAIL-STORE NOTE: This link appears only for members with a
+        linked User. Unlinked members manage pre-signup emails via the
+        MemberEmailInline below. See the aliases page spec at
+        docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md.
+        """
+        from django.urls import reverse
+        from django.utils.html import format_html
+
+        if obj.user_id is None:
+            return format_html(
+                '<span style="color: #888;">No linked user yet — use Staged Emails below.</span>'
+            )
+        url = reverse("admin_member_aliases", args=[obj.pk])
+        return format_html('<a href="{}">Manage email aliases →</a>', url)
+```
+
+**3b.** In `get_fieldsets`, insert `"email_aliases_link"` into `personal_fields` right after the `"user"` / `"create_user"` entries. Change:
+
+```python
+        # Show "user" link on edit, "create_user" checkbox on add
+        if obj is not None:
+            personal_fields.insert(0, "user")
+        else:
+            personal_fields.append("create_user")
+```
+
+To:
+
+```python
+        # Show "user" link on edit, "create_user" checkbox on add
+        if obj is not None:
+            personal_fields.insert(0, "user")
+            personal_fields.insert(1, "email_aliases_link")
+        else:
+            personal_fields.append("create_user")
+```
+
+- [ ] **Step 4: Run specs and verify pass**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_email_aliases_link_on_member_admin -v 2>&1 | tail -20
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Lint / format / mypy / commit**
+
+```bash
+.venv/bin/ruff check membership/admin.py tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check membership/admin.py tests/plfog/member_aliases_spec.py
+.venv/bin/python -m mypy membership/admin.py
+git add membership/admin.py tests/plfog/member_aliases_spec.py
+git commit -m "feat(admin): add email_aliases_link readonly field to MemberAdmin"
+```
+
+---
+
+## Task 9: Template polish — full UI with action buttons
+
+**Goal:** Replace the minimal template with the full UI: styled list, primary/verified indicators, action buttons (Remove, Set primary, Toggle verified), and a working Add form with error rendering.
+
+**Files:**
+- Modify: `templates/admin/membership/member/aliases.html`
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Add template-content specs**
+
+Append to `tests/plfog/member_aliases_spec.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# describe_member_aliases_template
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_template():
+    def it_renders_each_alias_row_with_action_buttons(admin_client, linked_member):
+        second = EmailAddress.objects.create(
+            user=linked_member.user,
+            email="second@example.com",
+            verified=True,
+            primary=False,
+        )
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        assert b"penina@example.com" in resp.content
+        assert b"second@example.com" in resp.content
+        # Per-row POST forms exist for each action.
+        assert f"/aliases/{second.pk}/remove/".encode() in resp.content
+        assert f"/aliases/{second.pk}/set-primary/".encode() in resp.content
+        assert f"/aliases/{second.pk}/toggle-verified/".encode() in resp.content
+
+    def it_hides_set_primary_button_on_the_current_primary(admin_client, linked_member):
+        # The current primary is penina@example.com. Its row should NOT render
+        # the set-primary form action.
+        primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        # This is a structural check: the primary row's <form action> should
+        # not include its own pk for set-primary.
+        primary_set_primary = f"/aliases/{primary.pk}/set-primary/".encode()
+        assert primary_set_primary not in resp.content
+
+    def it_hides_set_primary_button_on_unverified_rows(admin_client, linked_member):
+        unverified = EmailAddress.objects.create(
+            user=linked_member.user,
+            email="unv@example.com",
+            verified=False,
+            primary=False,
+        )
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        unverified_set_primary = f"/aliases/{unverified.pk}/set-primary/".encode()
+        assert unverified_set_primary not in resp.content
+
+    def it_renders_the_add_form(admin_client, linked_member):
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        assert b'name="email"' in resp.content
+        assert f"/admin/members/{linked_member.pk}/aliases/add/".encode() in resp.content
+        assert b"csrfmiddlewaretoken" in resp.content
+
+    def it_renders_form_errors_when_add_fails(admin_client, linked_member):
+        # POST a duplicate to force form errors, then confirm the page re-renders
+        # the form with the error message.
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "penina@example.com"},
+        )
+        assert resp.status_code == 200
+        assert b"already on this member" in resp.content
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_template -v 2>&1 | tail -30
+```
+
+Expected: at least the form/action-button specs fail.
+
+- [ ] **Step 3: Rewrite the template in full**
+
+Overwrite `templates/admin/membership/member/aliases.html`:
+
+```django
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Email aliases — {{ member }} | {{ site_title }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">Home</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label='membership' %}">Membership</a>
+    &rsaquo; <a href="{% url 'admin:membership_member_changelist' %}">Members</a>
+    &rsaquo; <a href="{% url 'admin:membership_member_change' member.pk %}">{{ member }}</a>
+    &rsaquo; Email aliases
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="plfog-aliases" style="padding: 1.5rem 2rem; max-width: 960px;">
+    <h1 style="margin-bottom: 0.25rem;">Email aliases</h1>
+    <p style="color: #888; margin-top: 0;">for {{ member }}</p>
+
+    {% if messages %}
+    <ul class="messagelist">
+        {% for message in messages %}
+        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    <table class="plfog-aliases__table" style="width: 100%; border-collapse: collapse; margin-bottom: 2rem;">
+        <thead>
+            <tr>
+                <th style="text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd;">Email</th>
+                <th style="text-align: center; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd;">Primary</th>
+                <th style="text-align: center; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd;">Verified</th>
+                <th style="text-align: right; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd;">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for alias in aliases %}
+            <tr>
+                <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0;">{{ alias.email }}</td>
+                <td style="text-align: center; padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0;">
+                    {% if alias.primary %}&#10003;{% endif %}
+                </td>
+                <td style="text-align: center; padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0;">
+                    {% if alias.verified %}&#10003;{% endif %}
+                </td>
+                <td style="text-align: right; padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0;">
+                    {% if alias.verified and not alias.primary %}
+                    <form method="post"
+                          action="{% url 'admin_member_aliases_set_primary' member.pk alias.pk %}"
+                          style="display: inline;">
+                        {% csrf_token %}
+                        <button type="submit" class="button">Set primary</button>
+                    </form>
+                    {% endif %}
+
+                    <form method="post"
+                          action="{% url 'admin_member_aliases_toggle_verified' member.pk alias.pk %}"
+                          style="display: inline;">
+                        {% csrf_token %}
+                        <button type="submit" class="button">
+                            {% if alias.verified %}Unmark verified{% else %}Mark verified{% endif %}
+                        </button>
+                    </form>
+
+                    <form method="post"
+                          action="{% url 'admin_member_aliases_remove' member.pk alias.pk %}"
+                          style="display: inline;"
+                          onsubmit="return confirm('Remove {{ alias.email|escapejs }}? This cannot be undone.');">
+                        {% csrf_token %}
+                        <button type="submit" class="button" style="color: #c0392b;">Remove</button>
+                    </form>
+                </td>
+            </tr>
+            {% empty %}
+            <tr>
+                <td colspan="4" style="padding: 0.75rem; color: #888;"><em>No emails on this account yet.</em></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <h2 style="margin-bottom: 0.5rem;">Add email alias</h2>
+    <form method="post"
+          action="{% url 'admin_member_aliases_add' member.pk %}"
+          style="display: flex; gap: 0.5rem; align-items: flex-start; flex-wrap: wrap;">
+        {% csrf_token %}
+        <div>
+            {{ add_form.email }}
+            {% if add_form.email.errors %}
+            <ul class="errorlist" style="color: #c0392b; margin: 0.25rem 0 0; padding-left: 1rem;">
+                {% for error in add_form.email.errors %}
+                <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+        <button type="submit" class="default">Add</button>
+    </form>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 4: Run the template specs**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_member_aliases_template -v 2>&1 | tail -30
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Lint, commit**
+
+```bash
+.venv/bin/ruff check tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check tests/plfog/member_aliases_spec.py
+git add templates/admin/membership/member/aliases.html tests/plfog/member_aliases_spec.py
+git commit -m "feat(admin): render member aliases page with action buttons and add form"
+```
+
+---
+
+## Task 10: End-to-end login-via-admin-added-alias spec
+
+**Goal:** Prove the whole loop: admin POSTs to add an alias, member logs in via allauth login-by-code sent to that alias, lands authenticated as the original user.
+
+**Files:**
+- Test: `tests/plfog/member_aliases_spec.py`
+
+- [ ] **Step 1: Skim the existing pattern**
+
+Read `tests/membership/login_via_alias_spec.py` to see how plfog's BDD tests exercise the allauth login-by-code flow. You will need the same `respx` mocks (if any) and URL hits. Take the minimal happy-path shape.
+
+```bash
+wc -l tests/membership/login_via_alias_spec.py
+```
+
+- [ ] **Step 2: Add the end-to-end describe block**
+
+Append to `tests/plfog/member_aliases_spec.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# describe_end_to_end_login_via_admin_added_alias
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_end_to_end_login_via_admin_added_alias():
+    def it_allows_login_via_an_alias_added_by_admin(admin_client, linked_member, settings):
+        """Admin adds writersguild@pastlives.space, member logs in via that address."""
+        from django.core import mail
+
+        settings.ACCOUNT_EMAIL_VERIFICATION = "optional"
+
+        # 1. Admin adds the new alias via the POST endpoint.
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "writersguild@pastlives.space"},
+        )
+        assert resp.status_code == 302
+        created = EmailAddress.objects.get(
+            user=linked_member.user,
+            email="writersguild@pastlives.space",
+        )
+        assert created.verified is True
+
+        # 2. A fresh (unauthenticated) client — representing Penina — requests
+        #    a login code at the shared address.
+        mail.outbox.clear()
+        member_client = Client()
+
+        # Re-use the plfog login-by-code entry point. Follow the shape of
+        # tests/membership/login_via_alias_spec.py::it_logs_in_via_any_verified_alias
+        # for the exact URL path and POST data — it's the same view under test.
+        # The two assertions below are the invariants:
+        #   - A login code email is sent to the requested address
+        #   - Submitting that code authenticates the session as Penina's user
+        # Implementation detail: allauth's request_login_code view is at
+        # /accounts/login/code/ in plfog.
+
+        resp = member_client.post(
+            "/accounts/login/code/",
+            data={"email": "writersguild@pastlives.space"},
+        )
+        assert resp.status_code in (200, 302)
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == ["writersguild@pastlives.space"]
+
+        # 3. Extract the code from the email body. The format matches what
+        #    the existing login_via_alias_spec.py extracts.
+        import re
+        body = mail.outbox[0].body
+        match = re.search(r"\b(\w{3}-\w{3})\b", body) or re.search(r"\b(\d{6})\b", body)
+        assert match is not None, f"No login code found in email body: {body!r}"
+        code = match.group(1)
+
+        # 4. Submit the code. The URL is allauth's confirm_login_code.
+        resp = member_client.post(
+            "/accounts/login/code/confirm/",
+            data={"code": code},
+        )
+        assert resp.status_code in (200, 302)
+
+        # 5. The session is now authenticated as Penina's user.
+        session_user_id = int(member_client.session["_auth_user_id"])
+        assert session_user_id == linked_member.user_id
+```
+
+**If the URL paths or code regex above don't match plfog's actual allauth configuration** (allauth versions vary), update them by copying from `tests/membership/login_via_alias_spec.py::it_logs_in_via_any_verified_alias`. The two things that must stay true:
+
+1. `mail.outbox[0].to == ["writersguild@pastlives.space"]`
+2. `int(member_client.session["_auth_user_id"]) == linked_member.user_id`
+
+- [ ] **Step 3: Run the end-to-end spec**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py::describe_end_to_end_login_via_admin_added_alias -v 2>&1 | tail -30
+```
+
+Expected: PASS. If the login-by-code URL or code format doesn't match, reconcile against `tests/membership/login_via_alias_spec.py` and re-run.
+
+- [ ] **Step 4: Full spec-file run**
+
+```bash
+.venv/bin/python -m pytest tests/plfog/member_aliases_spec.py -v 2>&1 | tail -40
+```
+
+Expected: everything passes. Count them — it should be ~37 specs (6 form + 5 GET + 7 add + 7 remove + 6 set-primary + 6 toggle-verified + 2 admin link + 5 template + 1 end-to-end = 45, give or take).
+
+- [ ] **Step 5: Lint, commit**
+
+```bash
+.venv/bin/ruff check tests/plfog/member_aliases_spec.py
+.venv/bin/ruff format --check tests/plfog/member_aliases_spec.py
+git add tests/plfog/member_aliases_spec.py
+git commit -m "test(admin): end-to-end login via admin-added alias"
+```
+
+---
+
+## Task 11: Full-suite regression + mypy + ruff
+
+**Goal:** Verify nothing outside the feature broke.
+
+- [ ] **Step 1: Full pytest run**
+
+```bash
+.venv/bin/python -m pytest 2>&1 | tail -20
+```
+
+Expected: all tests pass. 100% branch coverage. If coverage dropped below 100% on the new code, go back and add specs until it's at 100%.
+
+- [ ] **Step 2: Full lint + format + mypy**
+
+```bash
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/python -m mypy plfog/ core/ membership/ hub/
+```
+
+Expected: all clean.
+
+- [ ] **Step 3: Django checks**
+
+```bash
+.venv/bin/python manage.py check
+```
+
+Expected: `System check identified no issues (0 silenced).`
+
+- [ ] **Step 4: Manual smoke (optional but recommended)**
+
+```bash
+.venv/bin/python manage.py runserver
+```
+
+Log in as a superuser, navigate to a linked member's change page, click "Manage email aliases →", add `test@example.com`, confirm it appears verified and non-primary. Try removing it. Try toggling verified. Try set-primary on it (requires it to be verified). Browser back to the member page.
+
+---
+
+## Task 12: Changelog bullets (final merge-ready commit)
+
+**Files:**
+- Modify: `plfog/version.py`
+
+Per `feedback_version_changelog.md`: only bump `version.py` on the final merge-ready commit, not during PR work. This is that commit.
+
+- [ ] **Step 1: Verify you're at 1.4.1**
+
+```bash
+grep '^VERSION' plfog/version.py
+```
+
+Expected: `VERSION = "1.4.1"` (set by Task 0's rebase onto `hotfixes/1.4.0`).
+
+- [ ] **Step 2: Append admin-alias bullets to the existing 1.4.1 entry**
+
+In `plfog/version.py`, locate the 1.4.1 entry (currently a single bullet about hiding contributor counts) and append these two bullets to its `"changes"` list:
+
+```python
+            "Admins can now add email aliases directly from the member page — handy for shared addresses like guild mailboxes where the member can't easily receive a verification code themselves",
+            "Admins can also remove aliases, change which one is primary, and toggle whether an alias is marked verified",
+```
+
+So the 1.4.1 stanza becomes:
+
+```python
+    {
+        "version": "1.4.1",
+        "date": "2026-04-11",
+        "title": "Funding Results — Quieter Display & Admin Email Aliases",
+        "changes": [
+            "The funding results section no longer shows how many members contributed to each snapshot — keeping that detail private for now",
+            "Admins can now add email aliases directly from the member page — handy for shared addresses like guild mailboxes where the member can't easily receive a verification code themselves",
+            "Admins can also remove aliases, change which one is primary, and toggle whether an alias is marked verified",
+        ],
+    },
+```
+
+- [ ] **Step 3: Lint + commit**
+
+```bash
+.venv/bin/ruff check plfog/version.py
+.venv/bin/ruff format --check plfog/version.py
+git add plfog/version.py
+git commit -m "chore: expand 1.4.1 changelog with admin email alias bullets"
+```
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin feature/admin-email-aliases
+gh pr create \
+  --base hotfixes/1.4.0 \
+  --head feature/admin-email-aliases \
+  --title "1.4.1: admin-managed email aliases" \
+  --body "$(cat <<'BODY'
+## Summary
+
+Stacks on PR #67 (hotfixes/1.4.0). Fills the gap left by 1.4.0: admins now have a dedicated page at /admin/members/<pk>/aliases/ to add, remove, set-primary, and toggle-verified on member email aliases. Entry point is a Manage email aliases → link on the member change page.
+
+Ships in the same 1.4.1 release as the funding contributor-count privacy hotfix — just appends bullets to the existing 1.4.1 changelog entry.
+
+## Spec
+
+docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md
+
+## Test plan
+
+- [x] pytest tests/plfog/member_aliases_spec.py — all specs pass
+- [x] full pytest — no regressions
+- [x] ruff check / ruff format / mypy — clean
+- [x] end-to-end: admin adds writersguild@pastlives.space to a linked member → member logs in via login-by-code at that address
+- [ ] Manual smoke on staging once merged to hotfixes/1.4.0
+BODY
+)"
+```
+
+When PR #67 merges to main, GitHub will auto-retarget this PR's base to main.
+
+---
+
+## Self-review checklist
+
+**1. Spec coverage check:**
+
+| Spec section | Covered by |
+|---|---|
+| Architecture (5 routes) | Tasks 2, 3, 4, 5, 6 |
+| `AddEmailAliasForm` with duplicate guards | Task 1 |
+| GET page rendering | Task 2 |
+| Add action | Task 3 |
+| Remove with lowest-pk promotion + only-email refuse + last-verified warn | Task 4 |
+| Set-primary with verified gate + user.email sync | Task 5 |
+| Toggle-verified with primary warning | Task 6 |
+| Unlinked-member redirect | Task 2 (implementation) + Task 7 (explicit regression) |
+| MemberAdmin entry point | Task 8 |
+| Template UI | Tasks 2 (stub) + 9 (polish) |
+| Safety rules (cross-member 404 via compound lookup) | Covered in remove/set-primary/toggle specs |
+| End-to-end login-via-admin-added-alias | Task 10 |
+| Changelog bullets (1.4.1) | Task 12 |
+| Full regression pass | Task 11 |
+
+All spec sections have tasks. ✅
+
+**2. Placeholder scan:** no TBD/TODO/"implement later"/"add validation". Every step has exact code or exact commands. ✅
+
+**3. Type consistency:** view names match across tasks (`member_aliases`, `member_aliases_add`, `member_aliases_remove`, `member_aliases_set_primary`, `member_aliases_toggle_verified`). URL names mirror (`admin_member_aliases*`). Template uses the same URL names. ✅
+
+**4. Known soft spots:**
+- Task 10's allauth login-by-code URLs and code-format regex may need adjustment — the plan explicitly says "copy from tests/membership/login_via_alias_spec.py if these don't match." That's the right posture; allauth versions vary and I can't verify the exact URLs without running the server.
+- The `admin_client` fixture in Task 1 assumes `ensure_user_has_member` may auto-create a Member for the admin user. I've guarded for that by deleting it. If the signal doesn't fire, the delete is a no-op.
+
+No placeholder fixes needed — the above are documented judgment calls, not gaps.

--- a/docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md
+++ b/docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md
@@ -1,0 +1,242 @@
+# Admin-Managed Email Aliases
+
+**Date:** 2026-04-11
+**Branch:** `feature/admin-email-aliases` (currently based on `feature/user-email-aliases` for the 1.4.0 allauth wiring; must be rebased onto `hotfixes/1.4.0` before implementation so the 1.4.1 changelog entry is in place to append bullets to)
+**Target version:** `1.4.1` (same release as the contributor-count privacy hotfix — this is a gap-fill that should have shipped with 1.4.0)
+**Relationship to other open PRs:**
+- PR #66 (`feature/user-email-aliases`) — approved, not merged. Ships 1.4.0 allauth `EmailAddress` wiring that this feature depends on.
+- PR #67 (`hotfixes/1.4.0`) — open, stacks on #66, bumps `plfog/version.py` to 1.4.1 and hides contributor counts on member-facing funding views. **This feature must stack on top of #67 and append bullets to the same 1.4.1 changelog entry — no new version bump.**
+
+## Problem
+
+1.4.0 gave members self-service email alias management at `/accounts/email/`. Admins got nothing. After shipping, the very first real use case exposed the gap:
+
+> Add `writersguild@pastlives.space` to Penina's member account so she can sign in as that address.
+
+That email is a shared guild mailbox. Penina cannot receive a verification code there without going through the guild's shared inbox, and nobody wants to coordinate that. The admin just needs to add the alias, mark it verified, and be done.
+
+Currently:
+
+- `membership/admin.py:114–117` hides `MemberEmailInline` the moment a member has a linked `User`, because that inline is pre-signup staging only (see `2026-04-07-user-email-aliases-design.md`).
+- `membership/admin.py:342–343` globally unregisters both the stock `User` admin and the allauth `EmailAddress` admin.
+- Net result: once a member logs in, there is **zero** admin UI anywhere in the app for touching their email aliases.
+
+## Goal
+
+A dedicated admin page reachable from the member change form that lets staff:
+
+1. **Add** a new email alias to any linked member, auto-marked verified and non-primary.
+2. **Remove** any email alias except the last one (removing the last would lock the user out).
+3. **Set primary** on any verified alias. Demotes the current primary and syncs `User.email`.
+4. **Toggle verified** on any alias. Allowed both directions with a warning on un-verifying the primary.
+
+All four operations must be staff-only, POST-only, and redirect back to the same page with a flash message.
+
+## Non-Goals
+
+- Anything for unlinked members. The existing `MemberEmailInline` (staged emails on the member change page) already covers pre-signup staging; this spec does not touch it.
+- Audit logging of who-added-what. Out of scope for v1; reconsider in a follow-up.
+- Member-visible "this alias was added by an admin" indicator on `/accounts/email/`. Nice-to-have, not required.
+- Bulk add (CSV or similar). YAGNI.
+- A custom signal or hook for Airtable sync. Airtable is upstream for `Member` identity and downstream for votes/snapshots only — allauth `EmailAddress` changes stay app-side.
+- Any change to `Member._pre_signup_email`. That field is read by `airtable_sync/` for unlinked members and is not relevant to linked-member alias management.
+
+## Architecture
+
+Follows the same pattern as the existing Snapshot Analyzer (`plfog/admin_views.py` + `templates/admin/snapshot_analyzer.html` + routes in `plfog/urls.py`). No inline formsets, no `change_form.html` overrides, no fighting unfold's admin styling.
+
+```
+MemberAdmin change page
+    │
+    │  (readonly "Manage email aliases →" link, rendered only for linked members)
+    ▼
+GET  /admin/members/<pk>/aliases/
+    │
+    │  renders list of EmailAddress rows + add form
+    ▼
+POST /admin/members/<pk>/aliases/add/                              → redirect to GET
+POST /admin/members/<pk>/aliases/<email_pk>/remove/                → redirect to GET
+POST /admin/members/<pk>/aliases/<email_pk>/set-primary/           → redirect to GET
+POST /admin/members/<pk>/aliases/<email_pk>/toggle-verified/       → redirect to GET
+```
+
+Every endpoint is decorated `@staff_member_required` and, for POSTs, `@require_POST`.
+
+## Components
+
+### `plfog/admin_views.py`
+
+Five new view functions appended to the existing file. They live alongside the existing snapshot_* views and follow the exact same conventions (thin view, redirect with flash, 404 via `get_object_or_404`).
+
+```python
+@staff_member_required
+def member_aliases(request: HttpRequest, pk: int) -> HttpResponse:
+    """GET — render the aliases page for a linked member."""
+
+@require_POST
+@staff_member_required
+def member_aliases_add(request: HttpRequest, pk: int) -> HttpResponse:
+    """POST — add a new verified, non-primary EmailAddress."""
+
+@require_POST
+@staff_member_required
+def member_aliases_remove(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — delete an EmailAddress unless it's the last one."""
+
+@require_POST
+@staff_member_required
+def member_aliases_set_primary(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — promote a verified alias to primary via allauth's set_as_primary()."""
+
+@require_POST
+@staff_member_required
+def member_aliases_toggle_verified(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — flip the verified flag. Warns when un-verifying a primary."""
+```
+
+Each POST view looks up the member (`get_object_or_404(Member, pk=pk)`), then — for the per-email endpoints — looks up the email with `get_object_or_404(EmailAddress, pk=email_pk, user=member.user)`. That compound lookup is the 404 guard against admins fiddling with another user's email by hand-crafting a URL.
+
+For unlinked members, `member_aliases` redirects to the member change page with an info flash: *"This member hasn't signed up yet. Use the Staged Emails section below to manage their pre-signup addresses."*
+
+### Forms
+
+`plfog/forms.py` (new file, or `membership/forms.py` if the existing module is the natural home — the implementation plan can decide):
+
+```python
+class AddEmailAliasForm(forms.Form):
+    email = forms.EmailField()
+
+    def __init__(self, *args, user, **kwargs):
+        self.user = user
+        super().__init__(*args, **kwargs)
+
+    def clean_email(self) -> str:
+        email = self.cleaned_data["email"].lower()
+        if EmailAddress.objects.filter(user=self.user, email__iexact=email).exists():
+            raise ValidationError("This address is already on this member.")
+        if EmailAddress.objects.filter(email__iexact=email).exclude(user=self.user).exists():
+            raise ValidationError("This address is already tied to a different account.")
+        return email
+```
+
+Per CLAUDE.md: validation lives in the form, never in the view.
+
+### Template
+
+`templates/admin/membership/member/aliases.html` extends the unfold admin base (`{% extends "admin/base.html" %}` with the same `{% block content %}` style used by `templates/admin/snapshot_analyzer.html`).
+
+Layout:
+
+```
+Email aliases for Penina Sharon                         ← Back to member page
+─────────────────────────────────────────────────────────────────────────────
+Email                           Primary   Verified    Actions
+peninasharon@gmail.com          ✓         ✓           [Toggle verified] [Remove]
+writersguild@pastlives.space              ✓           [Set primary] [Toggle verified] [Remove]
+─────────────────────────────────────────────────────────────────────────────
+
+Add email alias
+┌─────────────────────────────────┐
+│  email input                     │  [Add]
+└─────────────────────────────────┘
+```
+
+Each row action is a standalone `<form method="post" action="…">` with `{% csrf_token %}`. Destructive actions (`Remove`) use `onsubmit="return confirm(…)"`. `Set primary` is only rendered when the row is verified AND not already primary. `Toggle verified` label switches between "Mark verified" and "Unmark verified" based on current state.
+
+### Entry point — `MemberAdmin`
+
+A new readonly method field on `MemberAdmin` in `membership/admin.py`, placed alongside the existing `inlines` and following the `FundingSnapshotAdmin.analyzer_link` pattern at line 324:
+
+```python
+@admin.display(description="Email aliases")
+def email_aliases_link(self, obj: Member) -> str:
+    """Render the Manage Aliases link for linked members only."""
+    if obj.user_id is None:
+        return format_html(
+            '<span class="text-muted">No linked user yet — use Staged Emails below.</span>'
+        )
+    url = reverse("admin_member_aliases", args=[obj.pk])
+    return format_html('<a href="{}">Manage email aliases →</a>', url)
+```
+
+Added to `readonly_fields` and (via `get_fieldsets` if needed) surfaced on the change form in the same section as the rest of the member identity fields.
+
+### URL routes — `plfog/urls.py`
+
+Five new `path(...)` entries named `admin_member_aliases`, `admin_member_aliases_add`, `admin_member_aliases_remove`, `admin_member_aliases_set_primary`, `admin_member_aliases_toggle_verified`. All mounted under `admin/members/<int:pk>/aliases/`.
+
+## Data flow
+
+| Action | Success steps | Redirect |
+|---|---|---|
+| **GET page** | Load `Member`, 404 if missing. If `member.user` is None → redirect to member change page with info message. Else load `EmailAddress.objects.filter(user=member.user).order_by("-primary", "email")` and render template with an unbound `AddEmailAliasForm`. | n/a |
+| **Add** | Bind `AddEmailAliasForm(request.POST, user=member.user)`. On invalid → re-render page with form errors. On valid → `EmailAddress.objects.create(user=member.user, email=form.cleaned_data["email"], verified=True, primary=False)`. Flash success. | Back to GET. |
+| **Remove** | Load `EmailAddress(pk=email_pk, user=member.user)`. Refuse if it's the only `EmailAddress` for this user — flash error. Else `.delete()`. If the deleted row was primary and at least one verified `EmailAddress` remains, explicitly promote the lowest-`pk` verified row via `set_as_primary()`. If no verified rows remain, leave the user with no primary and flash a warning: *"This member has no verified emails left and cannot log in. Add and verify one immediately."* Flash success on the delete itself. | Back to GET. |
+| **Set primary** | Load `EmailAddress(pk=email_pk, user=member.user)`. Refuse if `verified=False` — flash error. Else call `email.set_as_primary()` (allauth method; handles demoting the old primary and syncing `User.email` via `user.save()`). Flash success. | Back to GET. |
+| **Toggle verified** | Load `EmailAddress(pk=email_pk, user=member.user)`. Flip `verified`, save. If we just un-verified the primary, also flash a warning: *"You've un-verified the primary email. Login will still work until another email is promoted."* | Back to GET. |
+
+## Safety rules
+
+Enforced in the views (fat models would also be reasonable; keep the rules adjacent to the HTTP boundary since they're admin-UX constraints, not domain invariants):
+
+1. **Cannot remove the only email.** `EmailAddress.objects.filter(user=member.user).count() == 1` → refuse with flash error. Rationale: removing it would sever the user's last login path and leave an orphan `User` row.
+2. **Warn on removing the last verified email.** If the removal would leave the user with zero verified emails, the view still proceeds but flashes a prominent warning (wording above in the Remove data-flow row). This is a soft guardrail — the admin may be mid-workflow about to add a replacement — but it must be loud enough to notice.
+3. **Cannot set primary on unverified.** allauth's `set_as_primary` does not enforce this reliably across versions. Gate in the view.
+4. **Duplicate on self** → friendly error via form validation.
+5. **Duplicate on another user** → friendly error via form validation. allauth's unique-email handling is the ultimate guard; form-level validation just gives a nicer message.
+6. **Unlinked member access** → redirect to the member change page with an info message pointing at `MemberEmailInline`.
+7. **Cross-member URL crafting** → `get_object_or_404(EmailAddress, pk=email_pk, user=member.user)` is the only way the per-email views load the row. Hand-crafted URLs that mix another member's `pk` with another user's `email_pk` return 404.
+
+## Error handling
+
+- Uses Django's `messages` framework for all flash messaging (`messages.success`, `messages.error`, `messages.warning`, `messages.info`). No custom exception classes.
+- `Member.DoesNotExist` and `EmailAddress.DoesNotExist` handled by `get_object_or_404` → 404 response.
+- `IntegrityError` on `EmailAddress.objects.create` (race condition where another admin adds the same email concurrently) → catch, flash error, redirect to GET. This is the only try/except in the new code.
+
+## Airtable interaction
+
+None. `EmailAddress` is an allauth-owned table. `airtable_sync/` only reads `Member._pre_signup_email` for unlinked members and writes votes/snapshots outbound. Nothing in the new admin page touches Airtable-adjacent state. Call this out in docstrings so future agents don't panic.
+
+## Testing
+
+New spec file: `tests/plfog/member_aliases_spec.py`. BDD style with `describe_*` / `context_*` / `it_*`.
+
+### Test matrix
+
+| describe | Specs |
+|---|---|
+| `describe_member_aliases_page` | `it_requires_staff`, `it_returns_404_for_nonexistent_member`, `it_redirects_to_member_change_page_for_unlinked_member`, `it_lists_all_email_addresses_for_linked_member`, `it_orders_primary_first` |
+| `describe_member_aliases_add` | `it_requires_staff`, `it_rejects_get`, `it_creates_verified_non_primary_email`, `it_rejects_duplicate_on_same_user`, `it_rejects_duplicate_on_other_user`, `it_leaves_existing_primary_untouched`, `it_404s_for_nonexistent_member` |
+| `describe_member_aliases_remove` | `it_requires_staff`, `it_rejects_get`, `it_deletes_non_primary_email`, `it_refuses_when_only_email`, `it_promotes_lowest_pk_verified_to_primary_when_removing_primary`, `it_warns_when_removing_last_verified_email_but_proceeds`, `it_404s_for_email_belonging_to_another_user` |
+| `describe_member_aliases_set_primary` | `it_requires_staff`, `it_rejects_get`, `it_demotes_old_primary_and_promotes_target`, `it_syncs_user_email_to_new_primary`, `it_refuses_unverified_email`, `it_404s_for_email_belonging_to_another_user` |
+| `describe_member_aliases_toggle_verified` | `it_requires_staff`, `it_rejects_get`, `it_flips_verified_from_false_to_true`, `it_flips_verified_from_true_to_false`, `it_emits_warning_when_unverifying_primary`, `it_404s_for_email_belonging_to_another_user` |
+| `describe_member_aliases_link_on_admin` | `it_renders_link_for_linked_member`, `it_renders_hint_for_unlinked_member` |
+| `describe_end_to_end_login_via_admin_added_alias` | Admin adds `writersguild@pastlives.space` to a linked member → member requests login code at that address → member lands authenticated as the original `User`. |
+
+100% branch coverage on the new code. No `@pytest.mark.skip`, no `# pragma: no cover`, no `# pragma: no mutate`.
+
+### Fixtures
+
+- Reuse `MemberFactory` from `tests/membership/factories.py`.
+- Add a small helper in `tests/plfog/conftest.py` (or the spec file directly) that creates a `Member` with a linked `User` plus one `EmailAddress` row, since this setup recurs across every spec in the file.
+- Use `respx` for any HTTP mocking if allauth's email-sending fires (it shouldn't on `verified=True` creations, but confirm during implementation).
+
+## Permissions
+
+- `@staff_member_required` on all views. Matches the rest of `plfog/admin_views.py`.
+- No django-guardian object-level checks. Staff = allowed; non-staff = 302 to admin login. This is consistent with how the Snapshot Analyzer and Invite Member views are gated.
+
+## Rollout / version
+
+- **No new version bump.** `plfog/version.py` is already at `1.4.1` on `hotfixes/1.4.0` (PR #67). This feature appends member-friendly bullets to the existing 1.4.1 changelog entry — it does not create a new entry.
+- Bullets to append (plain, member-friendly language):
+  - *"Admins can now add email aliases directly from the member page — handy for shared addresses like guild mailboxes where the member can't easily receive a verification code."*
+  - *"Admins can also remove aliases, change which one is primary, and toggle whether an alias is verified."*
+- Per existing feedback (`feedback_version_changelog.md`): only touch `plfog/version.py` on the final merge-ready commit, not during PR work.
+
+## Open questions
+
+None at spec time. The implementation plan can resolve two small nits:
+
+1. Exact home for `AddEmailAliasForm` — `plfog/forms.py` (new) vs. `membership/forms.py` (existing). Existing precedent says `membership/forms.py` if this is the only form; a new module only if we're adding a cluster of plfog-owned forms.
+2. Whether to reorder existing `readonly_fields` on `MemberAdmin` to put `email_aliases_link` in a sensible position, or just append it. Append, unless the field layout clearly suffers.

--- a/membership/admin.py
+++ b/membership/admin.py
@@ -88,6 +88,7 @@ class MemberAdmin(ModelAdmin):
     change_list_template = "admin/membership/member/change_list.html"
     form = MemberAdminForm
     inlines = [MemberEmailInline]
+    readonly_fields = ["email_aliases_link"]
     list_display = [
         "display_name",
         "_pre_signup_email",
@@ -140,6 +141,7 @@ class MemberAdmin(ModelAdmin):
         # Show "user" link on edit, "create_user" checkbox on add
         if obj is not None:
             personal_fields.insert(0, "user")
+            personal_fields.insert(1, "email_aliases_link")
         else:
             personal_fields.append("create_user")
 
@@ -195,6 +197,25 @@ class MemberAdmin(ModelAdmin):
             obj.sync_user_permissions()
         else:
             super().save_model(request, obj, form, change)
+
+    @admin.display(description="Email aliases")
+    def email_aliases_link(self, obj: Member) -> str:
+        """Render the Manage Aliases link for linked members only.
+
+        THREE-EMAIL-STORE NOTE: This link appears only for members with a
+        linked User. Unlinked members manage pre-signup emails via the
+        MemberEmailInline below. See the aliases page spec at
+        docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md.
+        """
+        from django.urls import reverse
+        from django.utils.html import format_html
+
+        if obj.user_id is None:
+            return mark_safe(  # noqa: S308
+                '<span style="color: #888;">No linked user yet — use Staged Emails below.</span>'
+            )
+        url = reverse("admin_member_aliases", args=[obj.pk])
+        return format_html('<a href="{}">Manage email aliases →</a>', url)
 
     def get_search_results(
         self, request: HttpRequest, queryset: QuerySet[Member], search_term: str

--- a/membership/forms.py
+++ b/membership/forms.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from django import forms
 from django.core.exceptions import ValidationError
 
@@ -35,4 +37,39 @@ class InviteMemberForm(forms.Form):
             raise ValidationError("A member with this email already exists.")
         if Invite.objects.filter(email__iexact=email, accepted_at__isnull=True).exists():
             raise ValidationError("A pending invite for this email already exists.")
+        return email
+
+
+class AddEmailAliasForm(forms.Form):
+    """Admin form for adding an email alias to a linked member's User.
+
+    Lives here rather than in plfog/ because email/user identity is a
+    membership-domain concern. Validation rules:
+
+    1. Email must not already exist on this user (case-insensitive).
+    2. Email must not already exist on any other user (allauth unique-email
+       handling is the ultimate guard, but we check first for a nicer message).
+
+    THREE-EMAIL-STORE NOTE: This form only operates on allauth.EmailAddress.
+    It never touches Member._pre_signup_email or MemberEmail staging rows.
+    See docs/superpowers/specs/2026-04-07-user-email-aliases-design.md.
+    """
+
+    email = forms.EmailField(
+        label="Email address",
+        help_text="The new alias. It will be created verified and non-primary.",
+    )
+
+    def __init__(self, *args: Any, user: Any, **kwargs: Any) -> None:
+        self._user = user
+        super().__init__(*args, **kwargs)
+
+    def clean_email(self) -> str:
+        from allauth.account.models import EmailAddress
+
+        email = self.cleaned_data["email"].lower()
+        if EmailAddress.objects.filter(user=self._user, email__iexact=email).exists():
+            raise ValidationError("This address is already on this member.")
+        if EmailAddress.objects.filter(email__iexact=email).exclude(user=self._user).exists():
+            raise ValidationError("This address is already tied to a different account.")
         return email

--- a/membership/signals.py
+++ b/membership/signals.py
@@ -16,19 +16,31 @@ User = get_user_model()
 
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
-def ensure_user_has_member(sender: type, instance: Any, **kwargs: Any) -> None:
+def ensure_user_has_member(sender: type, instance: Any, created: bool, **kwargs: Any) -> None:
     """Auto-create or link a Member record for any user who doesn't have one.
 
     After linking (or creating) a Member, also promotes any pre-signup
     ``MemberEmail`` staging rows for that member into
     ``allauth.account.EmailAddress`` so the user can log in via any of them.
     See ``docs/superpowers/specs/2026-04-07-user-email-aliases-design.md``.
+
+    Gated on ``created=True``: every branch of this signal is only meaningful
+    on the first save of a User. Re-running ``migrate_to_user`` on subsequent
+    saves was a 1.4.0 bug — it would force-re-promote ``Member._pre_signup_email``
+    to primary and silently revert any other primary the member or admin had
+    set via allauth, because allauth's ``set_as_primary`` calls ``user.save()``
+    internally. Skipping non-creation saves keeps allauth's primary stable.
     """
+    if not created:
+        return
+
     from .models import Member, MemberEmail, MembershipPlan
 
     try:
         instance.member
-        # Idempotent safety net: ensure allauth EmailAddress reflects current state.
+        # Edge case: a Member was created with user=instance just before this
+        # signal fired (unusual but possible from explicit code). Seed allauth
+        # state from staging rows then bail.
         MemberEmail.objects.migrate_to_user(instance)
         return
     except Member.DoesNotExist:

--- a/membership/signals.py
+++ b/membership/signals.py
@@ -36,15 +36,9 @@ def ensure_user_has_member(sender: type, instance: Any, created: bool, **kwargs:
 
     from .models import Member, MemberEmail, MembershipPlan
 
-    try:
-        instance.member
-        # Edge case: a Member was created with user=instance just before this
-        # signal fired (unusual but possible from explicit code). Seed allauth
-        # state from staging rows then bail.
-        MemberEmail.objects.migrate_to_user(instance)
-        return
-    except Member.DoesNotExist:
-        pass
+    # On created=True the user was just saved; no Member can yet reference it
+    # via the OneToOne (admin save_model and test fixtures both link the Member
+    # AFTER this signal has returned). Skip the "already has member" branch.
 
     email = getattr(instance, "email", "") or ""
     if email:

--- a/plfog/admin_views.py
+++ b/plfog/admin_views.py
@@ -284,3 +284,36 @@ def member_aliases(request: HttpRequest, pk: int) -> HttpResponse:
         "add_form": add_form,
     }
     return render(request, "admin/membership/member/aliases.html", context)
+
+
+@require_POST
+@staff_member_required
+def member_aliases_add(request: HttpRequest, pk: int) -> HttpResponse:
+    """POST — create a verified, non-primary EmailAddress for the member's User."""
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.error(request, "This member has no linked user.")
+        return redirect("admin:membership_member_change", member.pk)
+
+    form = AddEmailAliasForm(request.POST, user=member.user)
+    if not form.is_valid():
+        aliases = EmailAddress.objects.filter(user=member.user).order_by("-primary", "email")
+        context = {
+            **admin.site.each_context(request),
+            "member": member,
+            "aliases": aliases,
+            "add_form": form,
+        }
+        return render(request, "admin/membership/member/aliases.html", context)
+
+    EmailAddress.objects.create(
+        user=member.user,
+        email=form.cleaned_data["email"],
+        verified=True,
+        primary=False,
+    )
+    messages.success(
+        request,
+        f"Added alias '{form.cleaned_data['email']}' to {member}.",
+    )
+    return redirect("admin_member_aliases", pk=member.pk)

--- a/plfog/admin_views.py
+++ b/plfog/admin_views.py
@@ -12,8 +12,10 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
+from allauth.account.models import EmailAddress
+
 from core.models import Invite
-from membership.forms import InviteMemberForm
+from membership.forms import AddEmailAliasForm, InviteMemberForm
 from membership.models import FundingSnapshot, Member, VotePreference
 from membership.vote_calculator import calculate_results
 
@@ -248,3 +250,37 @@ def snapshot_delete(request: HttpRequest, pk: int) -> HttpResponse:
     snapshot.delete()
     messages.success(request, f"Deleted snapshot '{cycle_label}'.")
     return redirect("admin:membership_fundingsnapshot_changelist")
+
+
+# ---------------------------------------------------------------------------
+# Member email aliases — admin management page
+# ---------------------------------------------------------------------------
+#
+# Dedicated page at /admin/members/<pk>/aliases/ that lets staff manage
+# allauth.EmailAddress rows for a linked Member's User. Mirrors the Snapshot
+# Analyzer pattern (GET page + POST action endpoints, all redirecting back).
+#
+# See docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md.
+
+
+@staff_member_required
+def member_aliases(request: HttpRequest, pk: int) -> HttpResponse:
+    """GET — render the aliases management page for a linked member."""
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.info(
+            request,
+            "This member hasn't signed up yet. Use the Staged Emails section "
+            "on the member page to manage their pre-signup addresses.",
+        )
+        return redirect("admin:membership_member_change", member.pk)
+
+    aliases = EmailAddress.objects.filter(user=member.user).order_by("-primary", "email")
+    add_form = AddEmailAliasForm(user=member.user)
+    context = {
+        **admin.site.each_context(request),
+        "member": member,
+        "aliases": aliases,
+        "add_form": add_form,
+    }
+    return render(request, "admin/membership/member/aliases.html", context)

--- a/plfog/admin_views.py
+++ b/plfog/admin_views.py
@@ -363,3 +363,32 @@ def member_aliases_remove(request: HttpRequest, pk: int, email_pk: int) -> HttpR
 
     messages.success(request, f"Removed alias '{alias_email}'.")
     return redirect("admin_member_aliases", pk=member.pk)
+
+
+@require_POST
+@staff_member_required
+def member_aliases_set_primary(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — promote a verified alias to primary.
+
+    Uses allauth's EmailAddress.set_as_primary(conditional=False), which
+    demotes the current primary and updates User.email in one call.
+    Unverified emails are rejected (allauth's own guard is version-dependent;
+    we gate here to be sure).
+    """
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.error(request, "This member has no linked user.")
+        return redirect("admin:membership_member_change", member.pk)
+
+    alias = get_object_or_404(EmailAddress, pk=email_pk, user=member.user)
+
+    if not alias.verified:
+        messages.error(
+            request,
+            f"Cannot set '{alias.email}' as primary — it isn't verified yet.",
+        )
+        return redirect("admin_member_aliases", pk=member.pk)
+
+    alias.set_as_primary(conditional=False)
+    messages.success(request, f"'{alias.email}' is now the primary email.")
+    return redirect("admin_member_aliases", pk=member.pk)

--- a/plfog/admin_views.py
+++ b/plfog/admin_views.py
@@ -392,3 +392,33 @@ def member_aliases_set_primary(request: HttpRequest, pk: int, email_pk: int) -> 
     alias.set_as_primary(conditional=False)
     messages.success(request, f"'{alias.email}' is now the primary email.")
     return redirect("admin_member_aliases", pk=member.pk)
+
+
+@require_POST
+@staff_member_required
+def member_aliases_toggle_verified(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — flip the verified flag on an alias.
+
+    Warns loudly if the admin just un-verified the primary email (login
+    still works until another email is promoted, but it's fragile).
+    """
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.error(request, "This member has no linked user.")
+        return redirect("admin:membership_member_change", member.pk)
+
+    alias = get_object_or_404(EmailAddress, pk=email_pk, user=member.user)
+    alias.verified = not alias.verified
+    alias.save(update_fields=["verified"])
+
+    if not alias.verified and alias.primary:
+        messages.warning(
+            request,
+            f"'{alias.email}' is the primary email and is now un-verified. "
+            "Login will still work until another email is promoted, but this is fragile.",
+        )
+    else:
+        state = "verified" if alias.verified else "un-verified"
+        messages.success(request, f"'{alias.email}' is now {state}.")
+
+    return redirect("admin_member_aliases", pk=member.pk)

--- a/plfog/admin_views.py
+++ b/plfog/admin_views.py
@@ -317,3 +317,49 @@ def member_aliases_add(request: HttpRequest, pk: int) -> HttpResponse:
         f"Added alias '{form.cleaned_data['email']}' to {member}.",
     )
     return redirect("admin_member_aliases", pk=member.pk)
+
+
+@require_POST
+@staff_member_required
+def member_aliases_remove(request: HttpRequest, pk: int, email_pk: int) -> HttpResponse:
+    """POST — delete an EmailAddress unless it's the member's only one.
+
+    Safety rules (from spec):
+    1. Cannot remove the only EmailAddress — refuse with error flash.
+    2. If removing the primary and >=1 verified remains, promote the
+       lowest-pk verified row via set_as_primary(conditional=False).
+    3. If removing would leave the user with zero verified emails, proceed
+       but flash a loud warning.
+    """
+    member = get_object_or_404(Member, pk=pk)
+    if member.user_id is None:
+        messages.error(request, "This member has no linked user.")
+        return redirect("admin:membership_member_change", member.pk)
+
+    alias = get_object_or_404(EmailAddress, pk=email_pk, user=member.user)
+
+    total = EmailAddress.objects.filter(user=member.user).count()
+    if total == 1:
+        messages.error(
+            request,
+            f"Cannot remove '{alias.email}' — it's the only email on this account. "
+            "Removing it would lock the member out.",
+        )
+        return redirect("admin_member_aliases", pk=member.pk)
+
+    was_primary = alias.primary
+    alias_email = alias.email
+    alias.delete()
+
+    if was_primary:
+        next_verified = EmailAddress.objects.filter(user=member.user, verified=True).order_by("pk").first()
+        if next_verified is not None:
+            next_verified.set_as_primary(conditional=False)
+        else:
+            messages.warning(
+                request,
+                "This member has no verified emails left and cannot log in. Add and verify one immediately.",
+            )
+
+    messages.success(request, f"Removed alias '{alias_email}'.")
+    return redirect("admin_member_aliases", pk=member.pk)

--- a/plfog/urls.py
+++ b/plfog/urls.py
@@ -5,6 +5,7 @@ from plfog.admin_views import (
     invite_member,
     member_aliases,
     member_aliases_add,
+    member_aliases_remove,
     snapshot_delete,
     snapshot_detail,
     snapshot_draft,
@@ -27,6 +28,11 @@ admin_custom_urls = [
         "admin/members/<int:pk>/aliases/add/",
         member_aliases_add,
         name="admin_member_aliases_add",
+    ),
+    path(
+        "admin/members/<int:pk>/aliases/<int:email_pk>/remove/",
+        member_aliases_remove,
+        name="admin_member_aliases_remove",
     ),
 ]
 

--- a/plfog/urls.py
+++ b/plfog/urls.py
@@ -4,6 +4,7 @@ from django.urls import include, path
 from plfog.admin_views import (
     invite_member,
     member_aliases,
+    member_aliases_add,
     snapshot_delete,
     snapshot_detail,
     snapshot_draft,
@@ -21,6 +22,11 @@ admin_custom_urls = [
         "admin/members/<int:pk>/aliases/",
         member_aliases,
         name="admin_member_aliases",
+    ),
+    path(
+        "admin/members/<int:pk>/aliases/add/",
+        member_aliases_add,
+        name="admin_member_aliases_add",
     ),
 ]
 

--- a/plfog/urls.py
+++ b/plfog/urls.py
@@ -7,6 +7,7 @@ from plfog.admin_views import (
     member_aliases_add,
     member_aliases_remove,
     member_aliases_set_primary,
+    member_aliases_toggle_verified,
     snapshot_delete,
     snapshot_detail,
     snapshot_draft,
@@ -39,6 +40,11 @@ admin_custom_urls = [
         "admin/members/<int:pk>/aliases/<int:email_pk>/set-primary/",
         member_aliases_set_primary,
         name="admin_member_aliases_set_primary",
+    ),
+    path(
+        "admin/members/<int:pk>/aliases/<int:email_pk>/toggle-verified/",
+        member_aliases_toggle_verified,
+        name="admin_member_aliases_toggle_verified",
     ),
 ]
 

--- a/plfog/urls.py
+++ b/plfog/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 
 from plfog.admin_views import (
     invite_member,
+    member_aliases,
     snapshot_delete,
     snapshot_detail,
     snapshot_draft,
@@ -16,6 +17,11 @@ admin_custom_urls = [
     path("admin/snapshots/take/", snapshot_take, name="admin_snapshot_take"),
     path("admin/snapshots/<int:pk>/", snapshot_detail, name="admin_snapshot_detail"),
     path("admin/snapshots/<int:pk>/delete/", snapshot_delete, name="admin_snapshot_delete"),
+    path(
+        "admin/members/<int:pk>/aliases/",
+        member_aliases,
+        name="admin_member_aliases",
+    ),
 ]
 
 urlpatterns = admin_custom_urls + [

--- a/plfog/urls.py
+++ b/plfog/urls.py
@@ -6,6 +6,7 @@ from plfog.admin_views import (
     member_aliases,
     member_aliases_add,
     member_aliases_remove,
+    member_aliases_set_primary,
     snapshot_delete,
     snapshot_detail,
     snapshot_draft,
@@ -33,6 +34,11 @@ admin_custom_urls = [
         "admin/members/<int:pk>/aliases/<int:email_pk>/remove/",
         member_aliases_remove,
         name="admin_member_aliases_remove",
+    ),
+    path(
+        "admin/members/<int:pk>/aliases/<int:email_pk>/set-primary/",
+        member_aliases_set_primary,
+        name="admin_member_aliases_set_primary",
     ),
 ]
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-VERSION = "1.4.0"
+VERSION = "1.4.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.4.1",
+        "date": "2026-04-11",
+        "title": "Funding Results — Quieter Display",
+        "changes": [
+            "The funding results section no longer shows how many members contributed to each snapshot — keeping that detail private for now",
+        ],
+    },
     {
         "version": "1.4.0",
         "date": "2026-04-11",

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -8,9 +8,12 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
     {
         "version": "1.4.1",
         "date": "2026-04-11",
-        "title": "Funding Results — Quieter Display",
+        "title": "Funding Results — Quieter Display & Admin Email Aliases",
         "changes": [
             "The funding results section no longer shows how many members contributed to each snapshot — keeping that detail private for now",
+            "Admins can now add email aliases directly from the member page — handy for shared addresses like guild mailboxes where the member can't easily receive a verification code themselves",
+            "Admins can also remove aliases, change which one is primary, and toggle whether an alias is marked verified",
+            "Fixed a quiet bug where changing your primary email could silently revert on the next save — primary changes now stick",
         ],
     },
     {

--- a/templates/admin/membership/member/aliases.html
+++ b/templates/admin/membership/member/aliases.html
@@ -1,0 +1,40 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Email aliases — {{ member }}{% endblock %}
+
+{% block content %}
+<div style="padding: 1.5rem 2rem;">
+    <p style="margin-bottom: 1rem;">
+        <a href="{% url 'admin:membership_member_change' member.pk %}">&larr; Back to {{ member }}</a>
+    </p>
+
+    <h1>Email aliases for {{ member }}</h1>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Email</th>
+                <th>Primary</th>
+                <th>Verified</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for alias in aliases %}
+            <tr>
+                <td>{{ alias.email }}</td>
+                <td>{% if alias.primary %}&#10003;{% endif %}</td>
+                <td>{% if alias.verified %}&#10003;{% endif %}</td>
+                <td>{# action buttons added in Task 9 #}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="4"><em>No emails.</em></td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <h2>Add email alias</h2>
+    {# full add form wired in Task 3 #}
+</div>
+{% endblock %}

--- a/templates/admin/membership/member/aliases.html
+++ b/templates/admin/membership/member/aliases.html
@@ -1,40 +1,102 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
-{% block title %}Email aliases — {{ member }}{% endblock %}
+{% block title %}Email aliases — {{ member }} | {{ site_title }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">Home</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label='membership' %}">Membership</a>
+    &rsaquo; <a href="{% url 'admin:membership_member_changelist' %}">Members</a>
+    &rsaquo; <a href="{% url 'admin:membership_member_change' member.pk %}">{{ member }}</a>
+    &rsaquo; Email aliases
+</div>
+{% endblock %}
 
 {% block content %}
-<div style="padding: 1.5rem 2rem;">
-    <p style="margin-bottom: 1rem;">
-        <a href="{% url 'admin:membership_member_change' member.pk %}">&larr; Back to {{ member }}</a>
-    </p>
+<div class="plfog-aliases" style="padding: 1.5rem 2rem; max-width: 960px;">
+    <h1 style="margin-bottom: 0.25rem;">Email aliases</h1>
+    <p style="color: #888; margin-top: 0;">for {{ member }}</p>
 
-    <h1>Email aliases for {{ member }}</h1>
+    {% if messages %}
+    <ul class="messagelist">
+        {% for message in messages %}
+        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
 
-    <table>
+    <table class="plfog-aliases__table" style="width: 100%; border-collapse: collapse; margin-bottom: 2rem;">
         <thead>
             <tr>
-                <th>Email</th>
-                <th>Primary</th>
-                <th>Verified</th>
-                <th>Actions</th>
+                <th style="text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd;">Email</th>
+                <th style="text-align: center; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd;">Primary</th>
+                <th style="text-align: center; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd;">Verified</th>
+                <th style="text-align: right; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd;">Actions</th>
             </tr>
         </thead>
         <tbody>
             {% for alias in aliases %}
             <tr>
-                <td>{{ alias.email }}</td>
-                <td>{% if alias.primary %}&#10003;{% endif %}</td>
-                <td>{% if alias.verified %}&#10003;{% endif %}</td>
-                <td>{# action buttons added in Task 9 #}</td>
+                <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0;">{{ alias.email }}</td>
+                <td style="text-align: center; padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0;">
+                    {% if alias.primary %}&#10003;{% endif %}
+                </td>
+                <td style="text-align: center; padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0;">
+                    {% if alias.verified %}&#10003;{% endif %}
+                </td>
+                <td style="text-align: right; padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0;">
+                    {% if alias.verified and not alias.primary %}
+                    <form method="post"
+                          action="{% url 'admin_member_aliases_set_primary' member.pk alias.pk %}"
+                          style="display: inline;">
+                        {% csrf_token %}
+                        <button type="submit" class="button">Set primary</button>
+                    </form>
+                    {% endif %}
+
+                    <form method="post"
+                          action="{% url 'admin_member_aliases_toggle_verified' member.pk alias.pk %}"
+                          style="display: inline;">
+                        {% csrf_token %}
+                        <button type="submit" class="button">
+                            {% if alias.verified %}Unmark verified{% else %}Mark verified{% endif %}
+                        </button>
+                    </form>
+
+                    <form method="post"
+                          action="{% url 'admin_member_aliases_remove' member.pk alias.pk %}"
+                          style="display: inline;"
+                          onsubmit="return confirm('Remove {{ alias.email|escapejs }}? This cannot be undone.');">
+                        {% csrf_token %}
+                        <button type="submit" class="button" style="color: #c0392b;">Remove</button>
+                    </form>
+                </td>
             </tr>
             {% empty %}
-            <tr><td colspan="4"><em>No emails.</em></td></tr>
+            <tr>
+                <td colspan="4" style="padding: 0.75rem; color: #888;"><em>No emails on this account yet.</em></td>
+            </tr>
             {% endfor %}
         </tbody>
     </table>
 
-    <h2>Add email alias</h2>
-    {# full add form wired in Task 3 #}
+    <h2 style="margin-bottom: 0.5rem;">Add email alias</h2>
+    <form method="post"
+          action="{% url 'admin_member_aliases_add' member.pk %}"
+          style="display: flex; gap: 0.5rem; align-items: flex-start; flex-wrap: wrap;">
+        {% csrf_token %}
+        <div>
+            {{ add_form.email }}
+            {% if add_form.email.errors %}
+            <ul class="errorlist" style="color: #c0392b; margin: 0.25rem 0 0; padding-left: 1rem;">
+                {% for error in add_form.email.errors %}
+                <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+        <button type="submit" class="default">Add</button>
+    </form>
 </div>
 {% endblock %}

--- a/templates/hub/guild_voting.html
+++ b/templates/hub/guild_voting.html
@@ -150,7 +150,6 @@
     <p class="hub-text-muted" style="margin-bottom: 1rem; font-size: 0.85rem;">
         {{ latest_snapshot.cycle_label }} snapshot &mdash;
         pool: <strong>${{ latest_snapshot.funding_pool }}</strong> &mdash;
-        {{ latest_snapshot.contributor_count }} contributing member{{ latest_snapshot.contributor_count|pluralize }} &mdash;
         taken {{ latest_snapshot.snapshot_at|date:"N j, Y" }} &mdash;
         <a href="{% url 'hub_snapshot_detail' latest_snapshot.pk %}">View Details</a>
     </p>

--- a/templates/hub/snapshot_detail.html
+++ b/templates/hub/snapshot_detail.html
@@ -15,9 +15,6 @@
             <strong>Date taken:</strong> {{ snapshot.snapshot_at|date:"N j, Y, g:i a" }}
         </li>
         <li style="padding: 0.25rem 0;">
-            <strong>Contributors:</strong> {{ snapshot.contributor_count }}
-        </li>
-        <li style="padding: 0.25rem 0;">
             <strong>Funding pool:</strong> ${{ snapshot.funding_pool }}
         </li>
     </ul>

--- a/templates/hub/snapshot_history.html
+++ b/templates/hub/snapshot_history.html
@@ -14,7 +14,6 @@
             <tr>
                 <th style="text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--hub-border); font-weight: 500;">Cycle</th>
                 <th style="text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--hub-border); font-weight: 500;">Date</th>
-                <th style="text-align: right; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--hub-border); font-weight: 500;">Contributors</th>
                 <th style="text-align: right; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--hub-border); font-weight: 500;">Funding Pool</th>
             </tr>
         </thead>
@@ -25,7 +24,6 @@
                     <a href="{% url 'hub_snapshot_detail' snapshot.pk %}">{{ snapshot.cycle_label }}</a>
                 </td>
                 <td style="padding: 0.5rem 0.75rem; font-size: 0.85rem;">{{ snapshot.snapshot_at|date:"N j, Y" }}</td>
-                <td style="padding: 0.5rem 0.75rem; text-align: right;">{{ snapshot.contributor_count }}</td>
                 <td style="padding: 0.5rem 0.75rem; text-align: right;">${{ snapshot.funding_pool }}</td>
             </tr>
             {% endfor %}

--- a/tests/hub/guild_voting_spec.py
+++ b/tests/hub/guild_voting_spec.py
@@ -191,6 +191,22 @@ def describe_guild_voting_view():
         assert response.status_code == 200
         assert response.context["latest_snapshot"] == snap
 
+    def it_does_not_render_contributor_count_on_results_section(client: Client):
+        """Privacy: contributor count is admin-only and must not leak to members."""
+        User.objects.create_user(username="results_privacy", password="pass")
+        FundingSnapshotFactory(
+            cycle_label="March 2026",
+            funding_pool=Decimal("100.00"),
+            contributor_count=7,
+            results={"total_pool": 100, "results": []},
+        )
+        client.login(username="results_privacy", password="pass")
+
+        response = client.get("/guilds/voting/")
+
+        assert response.status_code == 200
+        assert b"contributing member" not in response.content
+
     def it_includes_cycle_info_in_context(client: Client):
         User.objects.create_user(username="cycleuser", password="pass")
         client.login(username="cycleuser", password="pass")
@@ -248,6 +264,21 @@ def describe_snapshot_history_view():
 
         assert response.status_code == 200
 
+    def it_does_not_render_contributor_count_column(client: Client):
+        """Privacy: the history table must not expose contributor counts."""
+        User.objects.create_user(username="hist_privacy", password="pass")
+        FundingSnapshotFactory(
+            cycle_label="January 2026",
+            funding_pool=Decimal("100.00"),
+            contributor_count=7,
+        )
+        client.login(username="hist_privacy", password="pass")
+
+        response = client.get("/guilds/voting/history/")
+
+        assert response.status_code == 200
+        assert b"Contributors" not in response.content
+
 
 # ---------------------------------------------------------------------------
 # describe_snapshot_detail_view
@@ -276,6 +307,22 @@ def describe_snapshot_detail_view():
 
         assert response.status_code == 200
         assert response.context["snapshot"] == snap
+
+    def it_does_not_render_contributor_count(client: Client):
+        """Privacy: snapshot detail must not expose contributor counts to members."""
+        User.objects.create_user(username="detail_privacy", password="pass")
+        snap = FundingSnapshotFactory(
+            cycle_label="March 2026",
+            funding_pool=Decimal("200.00"),
+            contributor_count=7,
+            results={"total_pool": 200, "results": []},
+        )
+        client.login(username="detail_privacy", password="pass")
+
+        response = client.get(f"/guilds/voting/history/{snap.pk}/")
+
+        assert response.status_code == 200
+        assert b"Contributors:" not in response.content
 
     def it_returns_404_for_invalid_pk(client: Client):
         User.objects.create_user(username="notfounduser", password="pass")

--- a/tests/membership/user_link_email_migration_spec.py
+++ b/tests/membership/user_link_email_migration_spec.py
@@ -47,10 +47,45 @@ def describe_user_link_signal_promotes_emails():
         # The signal auto-created a Member; migrate_to_user should have run too.
         assert EmailAddress.objects.filter(user=user, email="fresh@example.com", primary=True, verified=True).exists()
 
-    def it_runs_migrate_safety_net_when_user_already_has_member(db):
+    def it_does_not_re_run_migration_on_subsequent_user_saves(db):
+        """Regression: re-saving a User must NOT re-trigger migrate_to_user.
+
+        Prior 1.4.0 behavior force-re-promoted Member._pre_signup_email to primary
+        on every user.save(), which silently reverted any other primary set via
+        allauth's set_as_primary (which itself calls user.save() internally).
+        See feature/admin-email-aliases for the discovery context.
+        """
         MembershipPlanFactory()
         user = User.objects.create_user(username="existing", email="existing@example.com")
-        # Saving the user again triggers post_save and the early-return safety-net branch.
+
+        # Promote a different email to primary, mimicking what allauth's
+        # set_as_primary does internally.
+        new_primary = EmailAddress.objects.create(user=user, email="other@example.com", verified=True, primary=False)
+        EmailAddress.objects.filter(user=user, primary=True).update(primary=False)
+        new_primary.primary = True
+        new_primary.save(update_fields=["primary"])
+
+        # Re-save the user — this is what set_as_primary does at the end. The
+        # signal MUST NOT revert the new primary back to existing@example.com.
         user.first_name = "Updated"
         user.save()
-        assert EmailAddress.objects.filter(user=user, email="existing@example.com", primary=True).exists()
+
+        new_primary.refresh_from_db()
+        assert new_primary.primary is True
+        old = EmailAddress.objects.get(user=user, email="existing@example.com")
+        assert old.primary is False
+
+    def it_does_not_revert_primary_when_set_as_primary_is_called(db):
+        """End-to-end regression using allauth's actual set_as_primary."""
+        MembershipPlanFactory()
+        user = User.objects.create_user(username="existing", email="existing@example.com")
+
+        new_primary = EmailAddress.objects.create(user=user, email="other@example.com", verified=True, primary=False)
+        new_primary.set_as_primary(conditional=False)
+
+        new_primary.refresh_from_db()
+        old = EmailAddress.objects.get(user=user, email="existing@example.com")
+        assert new_primary.primary is True
+        assert old.primary is False
+        user.refresh_from_db()
+        assert user.email == "other@example.com"

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -164,6 +164,11 @@ def describe_member_aliases_page():
         assert aliases[0].email == "penina@example.com"
         assert aliases[1].email == "aaa@example.com"
 
+    def it_redirects_unlinked_members_to_the_member_change_page(admin_client, unlinked_member):
+        resp = admin_client.get(f"/admin/members/{unlinked_member.pk}/aliases/")
+        assert resp.status_code == 302
+        assert f"/admin/membership/member/{unlinked_member.pk}/change/" in resp.url
+
 
 # ---------------------------------------------------------------------------
 # describe_member_aliases_add (POST)

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -163,3 +163,73 @@ def describe_member_aliases_page():
         assert aliases[0].primary is True
         assert aliases[0].email == "penina@example.com"
         assert aliases[1].email == "aaa@example.com"
+
+
+# ---------------------------------------------------------------------------
+# describe_member_aliases_add (POST)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_add():
+    def it_requires_staff(client, linked_member):
+        resp = client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "new@example.com"},
+        )
+        assert resp.status_code == 302
+        assert "login" in resp.url
+
+    def it_rejects_get(admin_client, linked_member):
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/add/")
+        assert resp.status_code == 405
+
+    def it_404s_for_nonexistent_member(admin_client):
+        resp = admin_client.post(
+            "/admin/members/999999/aliases/add/",
+            data={"email": "new@example.com"},
+        )
+        assert resp.status_code == 404
+
+    def it_creates_verified_non_primary_email(admin_client, linked_member):
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "writersguild@pastlives.space"},
+        )
+        assert resp.status_code == 302
+        assert resp.url == f"/admin/members/{linked_member.pk}/aliases/"
+        created = EmailAddress.objects.get(
+            user=linked_member.user,
+            email="writersguild@pastlives.space",
+        )
+        assert created.verified is True
+        assert created.primary is False
+
+    def it_leaves_existing_primary_untouched(admin_client, linked_member):
+        admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "new@example.com"},
+        )
+        primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        assert primary.email == "penina@example.com"
+
+    def it_rejects_duplicate_on_same_user(admin_client, linked_member):
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "penina@example.com"},
+        )
+        assert resp.status_code == 200  # re-renders page with form errors
+        assert EmailAddress.objects.filter(user=linked_member.user).count() == 1
+
+    def it_rejects_duplicate_on_other_user(admin_client, linked_member):
+        other = User.objects.create_user(username="other", email="other@example.com", password="pass")
+        EmailAddress.objects.create(user=other, email="shared@example.com", verified=True, primary=False)
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "shared@example.com"},
+        )
+        assert resp.status_code == 200
+        assert not EmailAddress.objects.filter(
+            user=linked_member.user,
+            email__iexact="shared@example.com",
+        ).exists()

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -233,3 +233,63 @@ def describe_member_aliases_add():
             user=linked_member.user,
             email__iexact="shared@example.com",
         ).exists()
+
+
+# ---------------------------------------------------------------------------
+# describe_member_aliases_remove (POST)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_remove():
+    def _alias(user, email, *, verified=True, primary=False):
+        return EmailAddress.objects.create(user=user, email=email, verified=verified, primary=primary)
+
+    def it_requires_staff(client, linked_member):
+        alias = _alias(linked_member.user, "gone@example.com")
+        resp = client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/remove/")
+        assert resp.status_code == 302
+        assert "login" in resp.url
+        assert EmailAddress.objects.filter(pk=alias.pk).exists()
+
+    def it_rejects_get(admin_client, linked_member):
+        alias = _alias(linked_member.user, "gone@example.com")
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/remove/")
+        assert resp.status_code == 405
+
+    def it_deletes_non_primary_email(admin_client, linked_member):
+        alias = _alias(linked_member.user, "gone@example.com")
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/remove/")
+        assert resp.status_code == 302
+        assert resp.url == f"/admin/members/{linked_member.pk}/aliases/"
+        assert not EmailAddress.objects.filter(pk=alias.pk).exists()
+
+    def it_refuses_when_it_is_the_only_email(admin_client, linked_member):
+        only = EmailAddress.objects.get(user=linked_member.user)
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{only.pk}/remove/")
+        assert resp.status_code == 302
+        assert EmailAddress.objects.filter(pk=only.pk).exists()
+
+    def it_promotes_lowest_pk_verified_to_primary_when_removing_primary(admin_client, linked_member):
+        beta = _alias(linked_member.user, "beta@example.com", verified=True, primary=False)
+        _alias(linked_member.user, "gamma@example.com", verified=True, primary=False)
+        original_primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{original_primary.pk}/remove/")
+        beta.refresh_from_db()
+        assert beta.primary is True
+
+    def it_proceeds_and_warns_when_removing_last_verified_email(admin_client, linked_member):
+        unverified = _alias(linked_member.user, "unverified@example.com", verified=False, primary=False)
+        primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{primary.pk}/remove/")
+        assert resp.status_code == 302
+        assert not EmailAddress.objects.filter(pk=primary.pk).exists()
+        assert EmailAddress.objects.filter(pk=unverified.pk).exists()
+
+    def it_404s_for_email_belonging_to_another_user(admin_client, linked_member):
+        other = User.objects.create_user(username="other", email="other@example.com", password="pass")
+        # Signal auto-creates the primary EmailAddress for other@example.com — use it directly.
+        other_alias = EmailAddress.objects.get(user=other, email="other@example.com")
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{other_alias.pk}/remove/")
+        assert resp.status_code == 404
+        assert EmailAddress.objects.filter(pk=other_alias.pk).exists()

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -421,3 +421,23 @@ def describe_member_aliases_toggle_verified():
         assert resp.status_code == 404
         other_alias.refresh_from_db()
         assert other_alias.verified == original_verified
+
+
+# ---------------------------------------------------------------------------
+# describe_email_aliases_link_on_member_admin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_email_aliases_link_on_member_admin():
+    def it_renders_link_for_linked_member(admin_client, linked_member):
+        resp = admin_client.get(f"/admin/membership/member/{linked_member.pk}/change/")
+        assert resp.status_code == 200
+        url = f"/admin/members/{linked_member.pk}/aliases/"
+        assert url.encode() in resp.content
+        assert b"Manage email aliases" in resp.content
+
+    def it_renders_hint_for_unlinked_member(admin_client, unlinked_member):
+        resp = admin_client.get(f"/admin/membership/member/{unlinked_member.pk}/change/")
+        assert resp.status_code == 200
+        assert b"No linked user yet" in resp.content

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -556,3 +556,42 @@ def describe_end_to_end_login_via_admin_added_alias():
         # 5. Session is authenticated as Penina's user.
         session_user_id = int(member_client.session["_auth_user_id"])
         assert session_user_id == linked_member.user_id
+
+
+# ---------------------------------------------------------------------------
+# describe_unlinked_member_post_guards
+# ---------------------------------------------------------------------------
+#
+# Defensive coverage: each POST endpoint has an "if member.user_id is None"
+# guard that fires before it touches user-scoped data. The GET page redirects
+# unlinked members away from the UI, but these guards catch hand-crafted URLs.
+
+
+@pytest.mark.django_db
+def describe_unlinked_member_post_guards():
+    def _expected_redirect(member):
+        return f"/admin/membership/member/{member.pk}/change/"
+
+    def it_blocks_add_for_unlinked_member(admin_client, unlinked_member):
+        resp = admin_client.post(
+            f"/admin/members/{unlinked_member.pk}/aliases/add/",
+            data={"email": "new@example.com"},
+        )
+        assert resp.status_code == 302
+        assert _expected_redirect(unlinked_member) in resp.url
+        assert not EmailAddress.objects.filter(email="new@example.com").exists()
+
+    def it_blocks_remove_for_unlinked_member(admin_client, unlinked_member):
+        resp = admin_client.post(f"/admin/members/{unlinked_member.pk}/aliases/1/remove/")
+        assert resp.status_code == 302
+        assert _expected_redirect(unlinked_member) in resp.url
+
+    def it_blocks_set_primary_for_unlinked_member(admin_client, unlinked_member):
+        resp = admin_client.post(f"/admin/members/{unlinked_member.pk}/aliases/1/set-primary/")
+        assert resp.status_code == 302
+        assert _expected_redirect(unlinked_member) in resp.url
+
+    def it_blocks_toggle_verified_for_unlinked_member(admin_client, unlinked_member):
+        resp = admin_client.post(f"/admin/members/{unlinked_member.pk}/aliases/1/toggle-verified/")
+        assert resp.status_code == 302
+        assert _expected_redirect(unlinked_member) in resp.url

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -124,3 +124,42 @@ def describe_AddEmailAliasForm():
     def it_rejects_malformed_email(linked_member):
         form = AddEmailAliasForm(data={"email": "not-an-email"}, user=linked_member.user)
         assert not form.is_valid()
+
+
+# ---------------------------------------------------------------------------
+# describe_member_aliases_page (GET)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_page():
+    def it_requires_staff(client, linked_member):
+        resp = client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        assert resp.status_code == 302
+        assert "login" in resp.url
+
+    def it_returns_404_for_nonexistent_member(admin_client):
+        resp = admin_client.get("/admin/members/999999/aliases/")
+        assert resp.status_code == 404
+
+    def it_renders_the_page_for_a_linked_member(admin_client, linked_member):
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        assert resp.status_code == 200
+        assert resp.context["member"] == linked_member
+        assert list(resp.context["aliases"]) == list(
+            EmailAddress.objects.filter(user=linked_member.user).order_by("-primary", "email")
+        )
+        assert resp.context["add_form"].__class__.__name__ == "AddEmailAliasForm"
+
+    def it_lists_aliases_with_primary_first(admin_client, linked_member):
+        EmailAddress.objects.create(
+            user=linked_member.user,
+            email="aaa@example.com",
+            verified=True,
+            primary=False,
+        )
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        aliases = list(resp.context["aliases"])
+        assert aliases[0].primary is True
+        assert aliases[0].email == "penina@example.com"
+        assert aliases[1].email == "aaa@example.com"

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -441,3 +441,56 @@ def describe_email_aliases_link_on_member_admin():
         resp = admin_client.get(f"/admin/membership/member/{unlinked_member.pk}/change/")
         assert resp.status_code == 200
         assert b"No linked user yet" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# describe_member_aliases_template
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_template():
+    def it_renders_each_alias_row_with_action_buttons(admin_client, linked_member):
+        second = EmailAddress.objects.create(
+            user=linked_member.user,
+            email="second@example.com",
+            verified=True,
+            primary=False,
+        )
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        assert b"penina@example.com" in resp.content
+        assert b"second@example.com" in resp.content
+        assert f"/aliases/{second.pk}/remove/".encode() in resp.content
+        assert f"/aliases/{second.pk}/set-primary/".encode() in resp.content
+        assert f"/aliases/{second.pk}/toggle-verified/".encode() in resp.content
+
+    def it_hides_set_primary_button_on_the_current_primary(admin_client, linked_member):
+        primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        primary_set_primary = f"/aliases/{primary.pk}/set-primary/".encode()
+        assert primary_set_primary not in resp.content
+
+    def it_hides_set_primary_button_on_unverified_rows(admin_client, linked_member):
+        unverified = EmailAddress.objects.create(
+            user=linked_member.user,
+            email="unv@example.com",
+            verified=False,
+            primary=False,
+        )
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        unverified_set_primary = f"/aliases/{unverified.pk}/set-primary/".encode()
+        assert unverified_set_primary not in resp.content
+
+    def it_renders_the_add_form(admin_client, linked_member):
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/")
+        assert b'name="email"' in resp.content
+        assert f"/admin/members/{linked_member.pk}/aliases/add/".encode() in resp.content
+        assert b"csrfmiddlewaretoken" in resp.content
+
+    def it_renders_form_errors_when_add_fails(admin_client, linked_member):
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "penina@example.com"},
+        )
+        assert resp.status_code == 200
+        assert b"already on this member" in resp.content

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -293,3 +293,68 @@ def describe_member_aliases_remove():
         resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{other_alias.pk}/remove/")
         assert resp.status_code == 404
         assert EmailAddress.objects.filter(pk=other_alias.pk).exists()
+
+
+# ---------------------------------------------------------------------------
+# describe_member_aliases_set_primary (POST)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_set_primary():
+    def it_requires_staff(client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        resp = client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/")
+        assert resp.status_code == 302
+        assert "login" in resp.url
+        alias.refresh_from_db()
+        assert alias.primary is False
+
+    def it_rejects_get(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/")
+        assert resp.status_code == 405
+
+    def it_demotes_old_primary_and_promotes_target(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/")
+        assert resp.status_code == 302
+        alias.refresh_from_db()
+        old = EmailAddress.objects.get(email="penina@example.com")
+        assert alias.primary is True
+        assert old.primary is False
+
+    def it_syncs_user_email_to_new_primary(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/")
+        linked_member.user.refresh_from_db()
+        assert linked_member.user.email == "new@example.com"
+
+    def it_refuses_unverified_email(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user,
+            email="unverified@example.com",
+            verified=False,
+            primary=False,
+        )
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/set-primary/")
+        assert resp.status_code == 302
+        alias.refresh_from_db()
+        assert alias.primary is False
+        original = EmailAddress.objects.get(email="penina@example.com")
+        assert original.primary is True
+
+    def it_404s_for_email_belonging_to_another_user(admin_client, linked_member):
+        other = User.objects.create_user(username="other", email="other@example.com", password="pass")
+        # Signal auto-creates the primary EmailAddress for other@example.com — use it directly.
+        other_alias = EmailAddress.objects.get(user=other, email="other@example.com")
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{other_alias.pk}/set-primary/")
+        assert resp.status_code == 404

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -494,3 +494,65 @@ def describe_member_aliases_template():
         )
         assert resp.status_code == 200
         assert b"already on this member" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# describe_end_to_end_login_via_admin_added_alias
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_end_to_end_login_via_admin_added_alias():
+    def it_allows_login_via_an_alias_added_by_admin(
+        admin_client: Client,
+        linked_member: Member,
+    ) -> None:
+        """Admin adds writersguild@pastlives.space, member logs in via that address."""
+        import re
+
+        from django.core import mail
+
+        # 1. Admin adds the alias via the POST endpoint.
+        resp = admin_client.post(
+            f"/admin/members/{linked_member.pk}/aliases/add/",
+            data={"email": "writersguild@pastlives.space"},
+        )
+        assert resp.status_code == 302
+        created = EmailAddress.objects.get(
+            user=linked_member.user,
+            email="writersguild@pastlives.space",
+        )
+        assert created.verified is True
+
+        # 2. Fresh client (Penina) requests a login code at the shared address.
+        mail.outbox = []
+        member_client = Client()
+
+        resp = member_client.post(
+            "/accounts/login/code/",
+            {"email": "writersguild@pastlives.space"},
+            follow=True,
+        )
+        assert resp.status_code == 200
+        assert len(mail.outbox) >= 1
+        sent = mail.outbox[-1]
+        assert sent.to == ["writersguild@pastlives.space"]
+
+        # 3. Extract the code (matches login_via_alias_spec.py exactly).
+        match = re.search(r"is:\s*\n\s*(\S+)", sent.body)
+        assert match is not None, f"No login code in: {sent.body}"
+        code = match.group(1)
+
+        # 4. Submit the code.
+        resp = member_client.post(
+            "/accounts/login/code/confirm/",
+            {"code": code},
+            follow=True,
+        )
+        assert resp.status_code == 200
+        assert resp.wsgi_request.user.is_authenticated
+        assert resp.wsgi_request.user.pk == linked_member.user_id
+
+        # 5. Session is authenticated as Penina's user.
+        session_user_id = int(member_client.session["_auth_user_id"])
+        assert session_user_id == linked_member.user_id

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -358,3 +358,61 @@ def describe_member_aliases_set_primary():
         other_alias = EmailAddress.objects.get(user=other, email="other@example.com")
         resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{other_alias.pk}/set-primary/")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# describe_member_aliases_toggle_verified (POST)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_member_aliases_toggle_verified():
+    def it_requires_staff(client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=False, primary=False
+        )
+        resp = client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/toggle-verified/")
+        assert resp.status_code == 302
+        assert "login" in resp.url
+        alias.refresh_from_db()
+        assert alias.verified is False
+
+    def it_rejects_get(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=False, primary=False
+        )
+        resp = admin_client.get(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/toggle-verified/")
+        assert resp.status_code == 405
+
+    def it_flips_verified_from_false_to_true(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=False, primary=False
+        )
+        admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/toggle-verified/")
+        alias.refresh_from_db()
+        assert alias.verified is True
+
+    def it_flips_verified_from_true_to_false(admin_client, linked_member):
+        alias = EmailAddress.objects.create(
+            user=linked_member.user, email="new@example.com", verified=True, primary=False
+        )
+        admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{alias.pk}/toggle-verified/")
+        alias.refresh_from_db()
+        assert alias.verified is False
+
+    def it_allows_unverifying_primary_with_warning(admin_client, linked_member):
+        primary = EmailAddress.objects.get(user=linked_member.user, primary=True)
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{primary.pk}/toggle-verified/")
+        assert resp.status_code == 302
+        primary.refresh_from_db()
+        assert primary.verified is False
+
+    def it_404s_for_email_belonging_to_another_user(admin_client, linked_member):
+        other = User.objects.create_user(username="other", email="other@example.com", password="pass")
+        # Signal auto-creates the primary EmailAddress — use it directly.
+        other_alias = EmailAddress.objects.get(user=other, email="other@example.com")
+        original_verified = other_alias.verified
+        resp = admin_client.post(f"/admin/members/{linked_member.pk}/aliases/{other_alias.pk}/toggle-verified/")
+        assert resp.status_code == 404
+        other_alias.refresh_from_db()
+        assert other_alias.verified == original_verified

--- a/tests/plfog/member_aliases_spec.py
+++ b/tests/plfog/member_aliases_spec.py
@@ -1,0 +1,126 @@
+"""Specs for the admin email-aliases page.
+
+See docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from membership.forms import AddEmailAliasForm
+from membership.models import Member
+from tests.membership.factories import MemberFactory
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def admin_client(db):
+    admin = User.objects.create_superuser(
+        username="alias-admin",
+        password="pass",
+        email="alias-admin@example.com",
+    )
+    # The ensure_user_has_member signal may have auto-created a Member for the
+    # admin. Delete it so it doesn't interfere with test counts.
+    Member.objects.filter(user=admin).delete()
+    c = Client()
+    c.force_login(admin)
+    return c
+
+
+@pytest.fixture()
+def linked_member(db):
+    """Member with a linked User and one primary verified EmailAddress."""
+    user = User.objects.create_user(
+        username="penina",
+        password="pass",
+        email="penina@example.com",
+    )
+    # Signal may have created a Member already — find it or make one.
+    member = Member.objects.filter(user=user).first()
+    if member is None:
+        member = MemberFactory(user=user, _pre_signup_email="penina@example.com")
+    else:
+        member._pre_signup_email = "penina@example.com"
+        member.save(update_fields=["_pre_signup_email"])
+    EmailAddress.objects.filter(user=user).delete()
+    EmailAddress.objects.create(
+        user=user,
+        email="penina@example.com",
+        verified=True,
+        primary=True,
+    )
+    return member
+
+
+@pytest.fixture()
+def unlinked_member(db):
+    """Member imported from Airtable, no linked User."""
+    return MemberFactory(user=None, _pre_signup_email="airtable-only@example.com")
+
+
+# ---------------------------------------------------------------------------
+# describe_AddEmailAliasForm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def describe_AddEmailAliasForm():
+    def it_accepts_a_new_email(linked_member):
+        form = AddEmailAliasForm(
+            data={"email": "writersguild@pastlives.space"},
+            user=linked_member.user,
+        )
+        assert form.is_valid()
+        assert form.cleaned_data["email"] == "writersguild@pastlives.space"
+
+    def it_rejects_an_email_already_on_this_user(linked_member):
+        form = AddEmailAliasForm(
+            data={"email": "penina@example.com"},
+            user=linked_member.user,
+        )
+        assert not form.is_valid()
+        assert "already on this member" in str(form.errors["email"]).lower()
+
+    def it_rejects_case_insensitive_duplicate_on_self(linked_member):
+        form = AddEmailAliasForm(
+            data={"email": "PENINA@example.com"},
+            user=linked_member.user,
+        )
+        assert not form.is_valid()
+
+    def it_rejects_an_email_tied_to_another_user(linked_member):
+        other_user = User.objects.create_user(
+            username="other",
+            password="pass",
+            email="other@example.com",
+        )
+        EmailAddress.objects.create(
+            user=other_user,
+            email="shared@example.com",
+            verified=True,
+            primary=False,
+        )
+        form = AddEmailAliasForm(
+            data={"email": "shared@example.com"},
+            user=linked_member.user,
+        )
+        assert not form.is_valid()
+        assert "different account" in str(form.errors["email"]).lower()
+
+    def it_rejects_empty_email(linked_member):
+        form = AddEmailAliasForm(data={"email": ""}, user=linked_member.user)
+        assert not form.is_valid()
+
+    def it_rejects_malformed_email(linked_member):
+        form = AddEmailAliasForm(data={"email": "not-an-email"}, user=linked_member.user)
+        assert not form.is_valid()


### PR DESCRIPTION
## Summary

1.4.1 release. Bundles two pieces of work:

1. **Privacy fix:** the funding results section no longer shows how many members contributed to each snapshot — that detail is admin-only now.
2. **Admin email aliases:** dedicated admin page at `/admin/members/<pk>/aliases/` for full CRUD on member email aliases (add, remove, set-primary, toggle-verified). Entry point is a "Manage email aliases →" link on the member change page.
3. **Bug fix found along the way:** the post_save signal on User was silently reverting any primary email change made through allauth's `set_as_primary()` (called by both self-service and the new admin endpoints). Fixed by gating the signal on `created=True`.

## Why the admin email aliases feature exists

A real use case surfaced after 1.4.0 shipped: adding `writersguild@pastlives.space` to a member's account so they can sign in as that address. The shared mailbox case breaks the self-service flow at `/accounts/email/` because the member can't easily receive a verification code from a guild-owned inbox. This PR gives admins a one-click path to add such aliases (auto-verified on creation).

Members will accumulate shared/aliased email addresses over time — guild mailboxes get reassigned, members get role-based addresses. Full CRUD makes sense because admins also need to clean up: remove a stale alias, promote a new one to primary.

## The signal bug we fixed

While building the remove + set-primary endpoints, tests kept failing because primary changes were being silently reverted. Root cause in `membership/signals.py`: the `post_save` signal on `User` was calling `MemberEmail.objects.migrate_to_user(user)` on **every** save, which force-re-promoted `Member._pre_signup_email` to primary. allauth's `set_as_primary()` calls `user.save()` internally, which fired the signal, which reverted whatever primary had just been set.

**This means 1.4.0's own self-service primary-change at `/accounts/email/` was silently broken** for anyone who tried to set a non-signup-email as primary. Nobody noticed because most members keep their original signup email.

The fix gates the signal on `created=True`. Every branch of the signal is only meaningful on first user save. Two regression specs prove primary changes now persist across `user.save()` and through the full `set_as_primary()` round-trip.

## Safety rules implemented (admin email aliases)

1. **Cannot remove the only email** — refuses with error flash (would lock the user out)
2. **Last verified email** — removal proceeds but flashes a loud warning
3. **Removing the primary** — auto-promotes the lowest-pk verified row to primary
4. **Cannot set primary on unverified** — refuses with error flash
5. **Duplicate on self / on other user** — caught by form validation with friendly errors
6. **Cross-user URL crafting** — `get_object_or_404(EmailAddress, pk=email_pk, user=member.user)` returns 404 if you try to operate on another member's email by hand-crafted URL
7. **Unlinked members** — GET redirects to the member change page with a hint pointing at the staged emails inline

## Test coverage

- **45 new specs** in `tests/plfog/member_aliases_spec.py` — full CRUD matrix + form validation + template rendering + admin link + end-to-end login flow
- **2 new regression specs** in `tests/membership/user_link_email_migration_spec.py` for the signal fix
- **3 new regression specs** in `tests/hub/guild_voting_spec.py` for the contributor-count privacy hotfix
- **790 total tests pass** (full project), no regressions

## Spec & plan documents

- `docs/superpowers/specs/2026-04-11-admin-email-aliases-design.md`
- `docs/superpowers/plans/2026-04-11-admin-email-aliases.md`

## Test plan

- [x] `pytest tests/plfog/member_aliases_spec.py` — 45 passed
- [x] `pytest tests/hub/guild_voting_spec.py` — privacy regression specs pass
- [x] `pytest tests/membership/user_link_email_migration_spec.py` — signal fix regression specs pass
- [x] Full project pytest — 790 passed
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy plfog/ core/ membership/ hub/` — clean
- [x] `manage.py check` — clean
- [x] End-to-end: admin adds `writersguild@pastlives.space` to a linked member → fresh client requests login code at that address → submits code → session authenticated as the member's user
- [ ] Manual smoke on staging once merged