### PR TITLE
hotfix(1.5.1): My Tab + Guild Page polish

### DIFF
--- a/billing/forms.py
+++ b/billing/forms.py
@@ -134,6 +134,14 @@ class TabItemForm(forms.Form):
                 raise ValueError("member_guild_page context requires guild=<Guild>")
             self.fields["description"].required = True
             self.fields["amount"].required = True
+            self.fields["quantity"] = forms.IntegerField(
+                min_value=1,
+                max_value=99,
+                initial=1,
+                required=True,
+                widget=forms.NumberInput(attrs={"step": "1", "value": "1"}),
+                label="Quantity",
+            )
 
         # Role gating — members can't change the admin % or the split mode
         if not _user_can_edit_split(user):

--- a/billing/models.py
+++ b/billing/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
 from typing import TYPE_CHECKING, Any
 
@@ -190,6 +191,48 @@ class BillingSettings(models.Model):
         """Load the singleton instance, creating it with defaults if needed."""
         obj, _created = cls.objects.get_or_create(pk=1)
         return obj
+
+    def next_charge_at(self) -> datetime | None:
+        """Return the next scheduled charge datetime in Pacific time.
+
+        Mirrors the schedule logic in ``bill_tabs._is_billing_time``. Returns
+        ``None`` when billing is turned off.
+        """
+        if self.charge_frequency == self.ChargeFrequency.OFF:
+            return None
+
+        now = timezone.localtime()
+        charge_time = self.charge_time
+        if isinstance(charge_time, str):
+            from datetime import time as _time
+
+            parts = charge_time.split(":")
+            charge_time = _time(int(parts[0]), int(parts[1]) if len(parts) > 1 else 0)
+        today_at_time = now.replace(
+            hour=charge_time.hour,
+            minute=charge_time.minute,
+            second=0,
+            microsecond=0,
+        )
+
+        if self.charge_frequency == self.ChargeFrequency.DAILY:
+            return today_at_time if today_at_time > now else today_at_time + timedelta(days=1)
+
+        if self.charge_frequency == self.ChargeFrequency.WEEKLY:
+            target_dow = self.charge_day_of_week if self.charge_day_of_week is not None else 0
+            days_until = (target_dow - now.weekday()) % 7
+            if days_until == 0 and today_at_time <= now:
+                days_until = 7
+            return today_at_time + timedelta(days=days_until)
+
+        # MONTHLY
+        target_dom = self.charge_day_of_month or 1
+        candidate = today_at_time.replace(day=target_dom)
+        if candidate > now:
+            return candidate
+        if candidate.month == 12:
+            return candidate.replace(year=candidate.year + 1, month=1)
+        return candidate.replace(month=candidate.month + 1)
 
 
 # ---------------------------------------------------------------------------

--- a/hub/views.py
+++ b/hub/views.py
@@ -15,8 +15,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST, require_http_methods
 
 from billing.exceptions import NoPaymentMethodError, TabLimitExceededError, TabLockedError
-from billing.forms import CONTEXT_MEMBER_TAB_PAGE, TabItemForm
-from billing.models import Product, Tab, TabCharge
+from billing.models import BillingSettings, Tab, TabCharge
 from hub.forms import BetaFeedbackForm, EmailPreferencesForm, ProfileSettingsForm, VotePreferenceForm
 from membership.cycle import get_cycle_context
 from membership.models import FundingSnapshot, Guild, Member, VotePreference
@@ -376,42 +375,18 @@ def beta_feedback(request: HttpRequest) -> HttpResponse:
 
 
 @login_required
+@require_http_methods(["GET"])
 def tab_detail(request: HttpRequest) -> HttpResponse:
-    """My Tab page — shows current balance, pending entries, and self-service add form."""
-    from billing.forms import VoidTabEntryForm
-
+    """My Tab page — shows current balance, pending entries, and saved payment method."""
     member = _get_member(request)
     ctx = _get_hub_context(request)
 
     if member is None:
         messages.info(request, "Your account is not linked to a membership.")
-        return render(request, "hub/tab_detail.html", {**ctx, "tab": None, "entries": [], "form": None})
+        return render(request, "hub/tab_detail.html", {**ctx, "tab": None, "entries": []})
 
     tab, _created = Tab.objects.get_or_create(member=member)
     entries = tab.entries.pending().select_related("product__guild").order_by("-created_at")
-    products = Product.objects.filter(is_active=True).select_related("guild").order_by("guild__name", "name")
-
-    if request.method == "POST":
-        form = TabItemForm(request.POST, context=CONTEXT_MEMBER_TAB_PAGE, user=request.user)
-        if form.is_valid():
-            try:
-                if not tab.can_add_entry:
-                    raise NoPaymentMethodError("You need a payment method on file before adding charges.")
-                form.apply_to_tab(
-                    tab,
-                    added_by=request.user,  # type: ignore[arg-type]  # @login_required guarantees User
-                    is_self_service=True,
-                )
-                messages.success(request, "Item added to your tab.")
-                return redirect("hub_tab_detail")
-            except NoPaymentMethodError:
-                messages.error(request, "You need a payment method on file before adding charges.")
-            except TabLockedError:
-                messages.error(request, "Your tab is locked. Please contact an admin.")
-            except TabLimitExceededError:
-                messages.error(request, "This item would exceed your tab limit.")
-    else:
-        form = TabItemForm(context=CONTEXT_MEMBER_TAB_PAGE, user=request.user)
 
     return render(
         request,
@@ -420,9 +395,7 @@ def tab_detail(request: HttpRequest) -> HttpResponse:
             **ctx,
             "tab": tab,
             "entries": entries,
-            "form": form,
-            "products": products,
-            "void_form": VoidTabEntryForm(),
+            "next_charge_at": BillingSettings.load().next_charge_at(),
         },
     )
 
@@ -430,8 +403,7 @@ def tab_detail(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_POST
 def void_tab_entry(request: HttpRequest, entry_pk: int) -> HttpResponse:
-    """Void a pending tab entry. Only the owning member can void their own entries."""
-    from billing.forms import VoidTabEntryForm
+    """Remove a pending tab entry. Only the owning member can remove their own entries."""
     from billing.models import TabEntry as TabEntryModel
     from hub.toast import trigger_toast
 
@@ -441,20 +413,15 @@ def void_tab_entry(request: HttpRequest, entry_pk: int) -> HttpResponse:
 
     entry = get_object_or_404(TabEntryModel, pk=entry_pk, tab__member=member)
 
-    form = VoidTabEntryForm(request.POST)
-    if form.is_valid():
-        try:
-            entry.void(user=request.user, reason=form.cleaned_data["reason"])  # type: ignore[arg-type]
-            response = HttpResponse(status=204)
-            trigger_toast(response, "Charge voided.", "success")
-            return response
-        except ValueError as e:
-            response = HttpResponse(status=400)
-            trigger_toast(response, str(e), "error")
-            return response
+    try:
+        entry.void(user=request.user, reason="Removed by member")  # type: ignore[arg-type]
+    except ValueError as e:
+        response = HttpResponse(status=400)
+        trigger_toast(response, str(e), "error")
+        return response
 
-    response = HttpResponse(status=400)
-    trigger_toast(response, "Reason is required.", "error")
+    response = HttpResponse(status=204)
+    trigger_toast(response, "Charge removed.", "success")
     return response
 
 

--- a/hub/views.py
+++ b/hub/views.py
@@ -198,6 +198,8 @@ def snapshot_detail(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 def guild_detail(request: HttpRequest, pk: int) -> HttpResponse:
     """Guild detail page — shows about text, active products, and cart interface."""
+    from billing.forms import CONTEXT_MEMBER_GUILD_PAGE, TabItemForm
+
     guild = get_object_or_404(Guild, pk=pk)
     ctx = _get_hub_context(request)
     products = guild.products.filter(is_active=True).order_by("name")
@@ -207,6 +209,8 @@ def guild_detail(request: HttpRequest, pk: int) -> HttpResponse:
     if member is not None:
         tab, _created = Tab.objects.get_or_create(member=member)
 
+    eyop_form = TabItemForm(context=CONTEXT_MEMBER_GUILD_PAGE, user=request.user, guild=guild)
+
     return render(
         request,
         "hub/guild_detail.html",
@@ -215,6 +219,7 @@ def guild_detail(request: HttpRequest, pk: int) -> HttpResponse:
             "guild": guild,
             "products": products,
             "tab": tab,
+            "eyop_form": eyop_form,
         },
     )
 
@@ -291,12 +296,15 @@ def guild_eyop_form(request: HttpRequest, pk: int) -> HttpResponse:
     if request.method == "POST":
         form = TabItemForm(request.POST, context=CONTEXT_MEMBER_GUILD_PAGE, user=request.user, guild=guild)
         if form.is_valid():
+            quantity = form.cleaned_data.get("quantity", 1)
             try:
                 if not tab.can_add_entry:
                     raise NoPaymentMethodError("Payment method required.")
-                form.apply_to_tab(tab, added_by=request.user, is_self_service=True)  # type: ignore[arg-type]
+                for _ in range(quantity):
+                    form.apply_to_tab(tab, added_by=request.user, is_self_service=True)  # type: ignore[arg-type]
                 response = HttpResponse(status=204)
-                trigger_toast(response, "Added to your tab!", "success")
+                word = "item" if quantity == 1 else "items"
+                trigger_toast(response, f"{quantity} {word} added to your tab!", "success")
                 return response
             except NoPaymentMethodError:
                 response = HttpResponse(status=400)

--- a/hub/views.py
+++ b/hub/views.py
@@ -296,7 +296,7 @@ def guild_eyop_form(request: HttpRequest, pk: int) -> HttpResponse:
     if request.method == "POST":
         form = TabItemForm(request.POST, context=CONTEXT_MEMBER_GUILD_PAGE, user=request.user, guild=guild)
         if form.is_valid():
-            quantity = form.cleaned_data.get("quantity", 1)
+            quantity = form.cleaned_data["quantity"]
             try:
                 if not tab.can_add_entry:
                     raise NoPaymentMethodError("Payment method required.")

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -8,12 +8,16 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
     {
         "version": "1.5.1",
         "date": "2026-04-13",
-        "title": "My Tab Hotfixes",
+        "title": "My Tab & Guild Page Hotfixes",
         "changes": [
-            "My Tab page now shows your saved payment method with a link to add, replace, or remove your card",
-            "My Tab page now tells you exactly when your tab will be processed by Stripe so there are no surprises",
+            "My Tab page redesigned: Current Balance and Pending Charges are combined into one card, and Payment Method now lives at the bottom",
+            "My Tab page now shows your saved card with a link to add, replace, or remove it",
+            "My Tab page tells you when your tab will be processed by Stripe so there are no surprises",
+            "Removing a pending charge from your tab is now a one-click trash button — no confirmation dialog",
             "Removed the 'Add to Tab' form from the My Tab page — add items from guild pages instead",
-            "Removing a pending charge from your tab is now a single-click X button — no confirmation dialog",
+            "Guild pages now have a 'General Consumables' card with a quantity picker so you can add custom-priced items directly to your tab",
+            "Fixed a bug where one action would show two toast notifications at once",
+            "Cleaner spacing between cards on the My Tab page and the payment-method setup page",
         ],
     },
     {

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.5.1",
+        "date": "2026-04-13",
+        "title": "My Tab Hotfixes",
+        "changes": [
+            "My Tab page now shows your saved payment method with a link to add, replace, or remove your card",
+            "My Tab page now tells you exactly when your tab will be processed by Stripe so there are no surprises",
+            "Removed the 'Add to Tab' form from the My Tab page — add items from guild pages instead",
+            "Removing a pending charge from your tab is now a single-click X button — no confirmation dialog",
+        ],
+    },
     {
         "version": "1.5.0",
         "date": "2026-04-11",

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -1278,6 +1278,65 @@ a:hover { color: var(--color-yellow-hover); }
     background: var(--color-yellow-hover);
 }
 
+/* Enter-Your-Own-Price card — first card in the product grid */
+.guild-product-card--eyop {
+    align-items: center;
+    text-align: center;
+    border-style: dashed;
+    border-color: rgba(238, 180, 75, 0.4);
+}
+.guild-product-card--eyop:hover {
+    border-color: rgba(238, 180, 75, 0.8);
+    background: rgba(238, 180, 75, 0.08);
+}
+.guild-product-card__subtext {
+    font-size: 0.8125rem;
+    color: var(--hub-text-muted);
+    margin-top: -0.25rem;
+}
+.guild-product-card__eyop-plus {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    margin: 0.25rem auto 0.25rem;
+    background: var(--color-tuscan-yellow);
+    border: none;
+    border-radius: 50%;
+    color: #1a1a2e;
+    cursor: pointer;
+    transition: background 0.15s ease, transform 0.15s ease;
+}
+.guild-product-card__eyop-plus:hover {
+    background: var(--color-yellow-hover);
+    transform: scale(1.05);
+}
+
+/* Trash-can remove button on the My Tab table */
+.tab-table__remove {
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    line-height: 1;
+    color: #dc2626;
+    transition: color 0.15s ease, transform 0.15s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.tab-table__remove svg {
+    stroke: #dc2626;
+}
+.tab-table__remove:hover {
+    color: #ef4444;
+    transform: scale(1.15);
+}
+.tab-table__remove:hover svg {
+    stroke: #ef4444;
+}
+
 /* Shared table */
 .tab-section-title {
     font-size: 1rem;
@@ -1299,7 +1358,8 @@ a:hover { color: var(--color-yellow-hover); }
 .tab-table td {
     padding: 0.5rem 0.75rem;
 }
-.tab-table__right { text-align: right; }
+.tab-table th.tab-table__right,
+.tab-table td.tab-table__right { text-align: right; }
 .tab-table__date {
     font-size: 0.8rem;
     color: var(--hub-text-muted);

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -88,17 +88,4 @@
     </a>
     <script defer src="{% static 'js/alpine.min.js' %}"></script>
     {% include "components/toast.html" %}
-    <script>
-        document.body.addEventListener('htmx:afterRequest', function(event) {
-            var trigger = event.detail.xhr && event.detail.xhr.getResponseHeader('HX-Trigger');
-            if (trigger) {
-                try {
-                    var data = JSON.parse(trigger);
-                    if (data.showToast) {
-                        window.dispatchEvent(new CustomEvent('show-toast', {detail: data.showToast}));
-                    }
-                } catch(e) {}
-            }
-        });
-    </script>
 {% endblock %}

--- a/templates/billing/setup_payment_method.html
+++ b/templates/billing/setup_payment_method.html
@@ -22,7 +22,7 @@
 </div>
 {% endif %}
 
-<div class="hub-card">
+<div class="hub-card" style="margin-top:1.5rem;">
     <h2 class="tab-section-title">{% if tab.has_payment_method %}Replace Card{% else %}Add a Card{% endif %}</h2>
     <p class="hub-text-muted" style="margin-bottom: 1rem;">
         By adding a payment method, you authorize Past Lives Makerspace to charge your card

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -180,19 +180,8 @@
             }
         });
     </script>
-    <script>
-        document.body.addEventListener('htmx:afterRequest', function(event) {
-            var trigger = event.detail.xhr && event.detail.xhr.getResponseHeader('HX-Trigger');
-            if (trigger) {
-                try {
-                    var data = JSON.parse(trigger);
-                    if (data.showToast) {
-                        window.dispatchEvent(new CustomEvent('show-toast', {detail: data.showToast}));
-                    }
-                } catch(e) {}
-            }
-        });
-    </script>
+    {# HTMX auto-fires HX-Trigger JSON keys as events (and a kebab-case alias — see htmx Dt()) #}
+    {# — so the `showToast` key in trigger_toast dispatches `show-toast` directly. No manual parse. #}
     {% block extra_js %}{% endblock %}
 
     <a href="{% url 'hub_beta_feedback' %}" class="pl-feedback-btn" hx-boost="false" title="Send Feedback">

--- a/templates/hub/guild_detail.html
+++ b/templates/hub/guild_detail.html
@@ -98,24 +98,23 @@
 
 {# Products card #}
 <div class="hub-card" style="margin-top:1.5rem;">
-    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
-        <h3 class="hub-detail-label" style="margin:0;">Products</h3>
-        {% if tab and tab.can_add_entry %}
-        <button
-            class="pl-btn pl-btn--icon pl-btn--secondary"
-            @click="$dispatch('open-modal', 'eyop-modal')"
-            hx-get="{% url 'hub_guild_eyop_form' guild.pk %}"
-            hx-target="#eyop-modal-body"
-            hx-swap="innerHTML"
-            title="Enter Your Own Price">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M12 5v14"/><path d="M5 12h14"/>
-            </svg>
-        </button>
-        {% endif %}
-    </div>
-    {% if products %}
+    <h3 class="hub-detail-label" style="margin:0 0 1rem;">Products</h3>
     <div class="guild-product-grid">
+        {% if tab and tab.can_add_entry %}
+        <div class="guild-product-card guild-product-card--eyop">
+            <div class="guild-product-card__name">General Consumables</div>
+            <div class="guild-product-card__subtext">Enter Custom Price</div>
+            <button type="button"
+                    class="guild-product-card__eyop-plus"
+                    aria-label="Add general consumables"
+                    title="Add general consumables"
+                    @click="$dispatch('open-modal', 'eyop-modal')">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M12 5v14"/><path d="M5 12h14"/>
+                </svg>
+            </button>
+        </div>
+        {% endif %}
         {% for product in products %}
         <div class="guild-product-card">
             <div class="guild-product-card__name">{{ product.name }}</div>
@@ -130,7 +129,7 @@
         </div>
         {% endfor %}
     </div>
-    {% else %}
+    {% if not products and not tab.can_add_entry %}
     <p class="hub-text-muted">No products listed yet.</p>
     {% endif %}
 </div>
@@ -207,8 +206,31 @@
 </div>
 {% endif %}
 
-{# EYOP modal — content loaded via HTMX #}
-{% include "components/modal.html" with modal_id="eyop-modal" modal_title="Enter Your Own Price" modal_size="sm" %}
+{# EYOP modal — form is server-rendered; after-submit re-renders the form partial in place #}
+{% if tab and tab.can_add_entry %}
+<div x-data="{ open: false }"
+     x-show="open"
+     x-transition:enter="modal-enter"
+     x-transition:leave="modal-leave"
+     @open-modal.window="if ($event.detail === 'eyop-modal') open = true"
+     @close-modal.window="if ($event.detail === 'eyop-modal') open = false"
+     @keydown.escape.window="open = false"
+     @htmx:after-request.window="if (event.detail.successful && event.detail.xhr.status === 204) open = false"
+     class="pl-modal-backdrop"
+     style="display: none;"
+     role="dialog"
+     aria-modal="true">
+    <div class="pl-modal pl-modal--sm" @click.outside="open = false">
+        <div class="pl-modal__header">
+            <h2 class="pl-modal__title">General Consumables</h2>
+            <button type="button" @click="open = false" class="pl-modal__close" aria-label="Close">&times;</button>
+        </div>
+        <div class="pl-modal__body" id="eyop-modal-body">
+            {% include "hub/partials/eyop_form.html" %}
+        </div>
+    </div>
+</div>
+{% endif %}
 
 </div>{# /x-data guildCart #}
 {% endblock %}

--- a/templates/hub/partials/eyop_form.html
+++ b/templates/hub/partials/eyop_form.html
@@ -1,0 +1,14 @@
+<form hx-post="{% url 'hub_guild_eyop_form' guild.pk %}"
+      hx-target="#eyop-modal-body"
+      hx-swap="innerHTML">
+    {% csrf_token %}
+    {% include "components/form_field.html" with field=eyop_form.description %}
+    <div style="display:grid;grid-template-columns:2fr 1fr;gap:0.75rem;">
+        {% include "components/form_field.html" with field=eyop_form.amount %}
+        {% include "components/form_field.html" with field=eyop_form.quantity %}
+    </div>
+    {% if eyop_form.non_field_errors %}
+    <div class="pl-field-error" style="margin-bottom:1rem;">{{ eyop_form.non_field_errors.0 }}</div>
+    {% endif %}
+    <button type="submit" class="pl-btn pl-btn--primary" style="width:100%;margin-top:0.5rem;">Add to Tab</button>
+</form>

--- a/templates/hub/tab_detail.html
+++ b/templates/hub/tab_detail.html
@@ -36,9 +36,30 @@
     </div>
 </div>
 
+{# Payment method card #}
+<div class="hub-card">
+    <h2 class="tab-section-title">Payment Method</h2>
+    {% if tab.has_payment_method %}
+    <div class="tab-summary__row">
+        <span class="tab-summary__label">{{ tab.payment_method_brand|title }} ending in {{ tab.payment_method_last4 }}</span>
+        <a href="{% url 'billing_setup_payment_method' %}" class="tab-history-link">Manage card</a>
+    </div>
+    {% else %}
+    <div class="tab-summary__row">
+        <span class="tab-summary__label hub-text-muted">No card on file.</span>
+        <a href="{% url 'billing_setup_payment_method' %}" class="tab-history-link">Add a card</a>
+    </div>
+    {% endif %}
+</div>
+
 {# Pending entries #}
 <div class="hub-card">
     <h2 class="tab-section-title">Pending Charges</h2>
+    {% if next_charge_at %}
+    <p class="hub-text-muted" style="margin-top:-0.25rem;margin-bottom:1rem;font-size:0.875rem;">
+        Your tab will be processed by Stripe on {{ next_charge_at|date:"F jS" }} at {{ next_charge_at|date:"g:i A" }}.
+    </p>
+    {% endif %}
     {% if entries %}
     <table class="tab-table">
         <thead>
@@ -57,71 +78,24 @@
                 <td class="tab-table__date">{{ entry.created_at|date:"M j, Y" }}</td>
                 <td>
                     <button type="button"
-                            class="pl-btn pl-btn--secondary"
-                            style="padding:0.25rem 0.5rem;font-size:0.75rem;"
-                            @click="$dispatch('open-confirm', 'void-{{ entry.pk }}')">
-                        Void
+                            class="pl-btn pl-btn--secondary pl-btn--icon"
+                            aria-label="Remove {{ entry.description }} from tab"
+                            title="Remove from tab"
+                            hx-post="{% url 'hub_void_tab_entry' entry.pk %}"
+                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                            hx-swap="none"
+                            @htmx:after-request="if (event.detail.successful) location.reload()">
+                        &times;
                     </button>
                 </td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
-    {% for entry in entries %}
-    <div x-data="{ open: false }"
-         x-show="open"
-         x-transition:enter="modal-enter"
-         x-transition:leave="modal-leave"
-         @open-confirm.window="if ($event.detail === 'void-{{ entry.pk }}') open = true"
-         @keydown.escape.window="open = false"
-         class="pl-modal-backdrop"
-         style="display: none;">
-        <div class="pl-modal pl-modal--sm" @click.outside="open = false">
-            <div class="pl-modal__header">
-                <h2 class="pl-modal__title">Void this charge?</h2>
-                <button type="button" @click="open = false" class="pl-modal__close">&times;</button>
-            </div>
-            <div class="pl-modal__body">
-                <p style="margin:0 0 1rem;">This will remove <strong>{{ entry.description }}</strong> (${{ entry.amount }}) from your tab.</p>
-                <form hx-post="{% url 'hub_void_tab_entry' entry.pk %}" hx-swap="none"
-                      @htmx:after-request="if (event.detail.successful) { open = false; location.reload(); }">
-                    {% csrf_token %}
-                    {% include "components/form_field.html" with field=void_form.reason field_label="Reason" field_hint="Brief reason for voiding this charge" %}
-                    <div class="pl-modal__actions" style="margin-top:1rem;">
-                        <button type="submit" class="pl-btn pl-btn--danger" style="flex:1;">Void Charge</button>
-                        <button type="button" @click="open = false" class="pl-btn pl-btn--secondary" style="flex:1;">Cancel</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-    {% endfor %}
     {% else %}
     <p class="hub-text-muted">No pending charges.</p>
     {% endif %}
 </div>
-
-{# Self-service add form #}
-{% if tab.can_add_entry %}
-<div class="hub-card">
-    <h2 class="tab-section-title">Add to Tab</h2>
-    <form method="post" class="tab-add-form">
-        {% csrf_token %}
-        <div class="tab-add-form__fields">
-            <div class="tab-add-form__field">
-                {% include "components/form_field.html" with field=form.product %}
-            </div>
-            <div class="tab-add-form__field">
-                {% include "components/form_field.html" with field=form.description %}
-            </div>
-            <div class="tab-add-form__field tab-add-form__field--amount">
-                {% include "components/form_field.html" with field=form.amount %}
-            </div>
-            <button type="submit" class="tab-add-form__btn">Add Item</button>
-        </div>
-    </form>
-</div>
-{% endif %}
 
 {% endif %}
 {% endblock %}

--- a/templates/hub/tab_detail.html
+++ b/templates/hub/tab_detail.html
@@ -20,7 +20,7 @@
 </div>
 {% endif %}
 
-{# Summary card #}
+{# Combined balance + pending entries #}
 <div class="hub-card tab-summary">
     <div class="tab-summary__row">
         <span class="tab-summary__label">Current Balance</span>
@@ -34,10 +34,57 @@
         <span class="tab-summary__label">Remaining</span>
         <span class="tab-summary__value">${{ tab.remaining_limit }}</span>
     </div>
+    {% if next_charge_at %}
+    <p class="hub-text-muted" style="margin:1rem 0 0;font-size:0.875rem;">
+        Your tab will be processed by Stripe on {{ next_charge_at|date:"F jS" }} at {{ next_charge_at|date:"g:i A" }}.
+    </p>
+    {% endif %}
+
+    {% if entries %}
+    <table class="tab-table" style="margin-top:1.25rem;">
+        <thead>
+            <tr>
+                <th>Description</th>
+                <th class="tab-table__right">Amount</th>
+                <th>Date</th>
+                <th class="tab-table__right"></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in entries %}
+            <tr>
+                <td>{{ entry.description }}{% if entry.product %} <span class="tab-entry-guild">→ {{ entry.product.guild.name }}</span>{% endif %}</td>
+                <td class="tab-table__right">${{ entry.amount }}</td>
+                <td class="tab-table__date">{{ entry.created_at|date:"M j, Y" }}</td>
+                <td class="tab-table__right">
+                    <button type="button"
+                            class="tab-table__remove"
+                            aria-label="Remove {{ entry.description }} from tab"
+                            title="Remove from tab"
+                            hx-post="{% url 'hub_void_tab_entry' entry.pk %}"
+                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                            hx-swap="none"
+                            @htmx:after-request="if (event.detail.successful) location.reload()">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="3 6 5 6 21 6"/>
+                            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+                            <path d="M10 11v6"/>
+                            <path d="M14 11v6"/>
+                            <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+                        </svg>
+                    </button>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p class="hub-text-muted" style="margin-top:1.25rem;">No pending charges.</p>
+    {% endif %}
 </div>
 
-{# Payment method card #}
-<div class="hub-card">
+{# Payment method card — bottom of page #}
+<div class="hub-card" style="margin-top:1.5rem;">
     <h2 class="tab-section-title">Payment Method</h2>
     {% if tab.has_payment_method %}
     <div class="tab-summary__row">
@@ -49,51 +96,6 @@
         <span class="tab-summary__label hub-text-muted">No card on file.</span>
         <a href="{% url 'billing_setup_payment_method' %}" class="tab-history-link">Add a card</a>
     </div>
-    {% endif %}
-</div>
-
-{# Pending entries #}
-<div class="hub-card">
-    <h2 class="tab-section-title">Pending Charges</h2>
-    {% if next_charge_at %}
-    <p class="hub-text-muted" style="margin-top:-0.25rem;margin-bottom:1rem;font-size:0.875rem;">
-        Your tab will be processed by Stripe on {{ next_charge_at|date:"F jS" }} at {{ next_charge_at|date:"g:i A" }}.
-    </p>
-    {% endif %}
-    {% if entries %}
-    <table class="tab-table">
-        <thead>
-            <tr>
-                <th>Description</th>
-                <th class="tab-table__right">Amount</th>
-                <th>Date</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for entry in entries %}
-            <tr>
-                <td>{{ entry.description }}{% if entry.product %} <span class="tab-entry-guild">→ {{ entry.product.guild.name }}</span>{% endif %}</td>
-                <td class="tab-table__right">${{ entry.amount }}</td>
-                <td class="tab-table__date">{{ entry.created_at|date:"M j, Y" }}</td>
-                <td>
-                    <button type="button"
-                            class="pl-btn pl-btn--secondary pl-btn--icon"
-                            aria-label="Remove {{ entry.description }} from tab"
-                            title="Remove from tab"
-                            hx-post="{% url 'hub_void_tab_entry' entry.pk %}"
-                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                            hx-swap="none"
-                            @htmx:after-request="if (event.detail.successful) location.reload()">
-                        &times;
-                    </button>
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    {% else %}
-    <p class="hub-text-muted">No pending charges.</p>
     {% endif %}
 </div>
 

--- a/tests/billing/forms_spec.py
+++ b/tests/billing/forms_spec.py
@@ -157,12 +157,13 @@ def describe_TabItemForm_member_guild_page():
         BillingSettingsFactory()
         guild = GuildFactory()
         form = TabItemForm(
-            data={"description": "Donation", "amount": "5.00"},
+            data={"description": "Donation", "amount": "5.00", "quantity": "1"},
             context=CONTEXT_MEMBER_GUILD_PAGE,
             guild=guild,
         )
         assert form.is_valid(), form.errors
         assert form.cleaned_data["guild"] == guild
+        assert form.cleaned_data["quantity"] == 1
 
     def it_requires_description_and_amount():
         guild = GuildFactory()
@@ -212,7 +213,7 @@ def describe_TabItemForm_apply_to_tab():
         tab = TabFactory()
         guild = GuildFactory()
         form = TabItemForm(
-            data={"description": "Clay", "amount": "4.00"},
+            data={"description": "Clay", "amount": "4.00", "quantity": "1"},
             context=CONTEXT_MEMBER_GUILD_PAGE,
             guild=guild,
         )

--- a/tests/billing/models/billing_settings_spec.py
+++ b/tests/billing/models/billing_settings_spec.py
@@ -78,6 +78,89 @@ def describe_BillingSettings():
             assert result > _tz.localtime()
             assert result.day == 15
 
+        def it_handles_an_already_parsed_time_object():
+            from datetime import time as _time
+
+            settings = BillingSettingsFactory(
+                charge_frequency=BillingSettings.ChargeFrequency.DAILY,
+                charge_time="23:00",
+            )
+            # Force the in-memory field to a time object (what comes back after a DB round-trip)
+            settings.charge_time = _time(23, 0)
+            result = settings.next_charge_at()
+            assert result is not None
+
+        def it_returns_today_when_weekly_target_is_today_and_time_is_future():
+            from datetime import time as _time
+            from unittest.mock import patch
+
+            from django.utils import timezone as _tz
+
+            now = _tz.localtime()
+            settings = BillingSettingsFactory(
+                charge_frequency=BillingSettings.ChargeFrequency.WEEKLY,
+                charge_day_of_week=now.weekday(),
+                charge_day_of_month=None,
+                charge_time="23:00",
+            )
+            settings.charge_time = _time(23, 0)
+
+            # Freeze now at 00:00 so today's 23:00 is still in the future
+            fake_now = now.replace(hour=0, minute=0, second=0, microsecond=0)
+            with patch("billing.models.timezone.localtime", return_value=fake_now):
+                result = settings.next_charge_at()
+            assert result is not None
+            assert result.date() == fake_now.date()
+
+        def it_skips_a_week_when_weekly_target_already_passed_today():
+            from datetime import time as _time
+            from unittest.mock import patch
+
+            from django.utils import timezone as _tz
+
+            now = _tz.localtime()
+            # Pick weekly target = today, charge_time earlier than now so days_until=0 path hits 7
+            settings = BillingSettingsFactory(
+                charge_frequency=BillingSettings.ChargeFrequency.WEEKLY,
+                charge_day_of_week=now.weekday(),
+                charge_day_of_month=None,
+                charge_time="00:00",
+            )
+            settings.charge_time = _time(0, 0)
+
+            fake_now = now.replace(hour=23, minute=59, second=0, microsecond=0)
+            with patch("billing.models.timezone.localtime", return_value=fake_now):
+                result = settings.next_charge_at()
+            assert result is not None
+            assert (result.date() - fake_now.date()).days == 7
+
+        def it_wraps_to_january_when_monthly_candidate_is_december():
+            from datetime import time as _time
+            from unittest.mock import patch
+
+            from django.utils import timezone as _tz
+
+            # Force "now" into December so the monthly candidate lands there
+            current_year = _tz.localtime().year
+            dec_31 = _tz.localtime().replace(
+                year=current_year, month=12, day=31, hour=23, minute=59, second=0, microsecond=0
+            )
+
+            settings = BillingSettingsFactory(
+                charge_frequency=BillingSettings.ChargeFrequency.MONTHLY,
+                charge_day_of_month=15,
+                charge_day_of_week=None,
+                charge_time="09:00",
+            )
+            settings.charge_time = _time(9, 0)
+
+            with patch("billing.models.timezone.localtime", return_value=dec_31):
+                result = settings.next_charge_at()
+            assert result is not None
+            assert result.year == current_year + 1
+            assert result.month == 1
+            assert result.day == 15
+
     def describe_charge_frequency():
         def it_defaults_to_monthly():
             settings = BillingSettings.load()

--- a/tests/billing/models/billing_settings_spec.py
+++ b/tests/billing/models/billing_settings_spec.py
@@ -34,6 +34,50 @@ def describe_BillingSettings():
         settings = BillingSettingsFactory()
         assert str(settings) == "Billing Settings"
 
+    def describe_next_charge_at():
+        def it_returns_none_when_off():
+            settings = BillingSettingsFactory(charge_frequency=BillingSettings.ChargeFrequency.OFF)
+            assert settings.next_charge_at() is None
+
+        def it_returns_a_future_datetime_for_daily():
+            from django.utils import timezone as _tz
+
+            settings = BillingSettingsFactory(
+                charge_frequency=BillingSettings.ChargeFrequency.DAILY,
+                charge_time="23:00",
+            )
+            result = settings.next_charge_at()
+            assert result is not None
+            assert result > _tz.localtime()
+
+        def it_returns_a_future_datetime_for_weekly():
+            from django.utils import timezone as _tz
+
+            settings = BillingSettingsFactory(
+                charge_frequency=BillingSettings.ChargeFrequency.WEEKLY,
+                charge_day_of_week=0,
+                charge_day_of_month=None,
+                charge_time="12:00",
+            )
+            result = settings.next_charge_at()
+            assert result is not None
+            assert result > _tz.localtime()
+            assert result.weekday() == 0
+
+        def it_returns_a_future_datetime_for_monthly():
+            from django.utils import timezone as _tz
+
+            settings = BillingSettingsFactory(
+                charge_frequency=BillingSettings.ChargeFrequency.MONTHLY,
+                charge_day_of_month=15,
+                charge_day_of_week=None,
+                charge_time="09:00",
+            )
+            result = settings.next_charge_at()
+            assert result is not None
+            assert result > _tz.localtime()
+            assert result.day == 15
+
     def describe_charge_frequency():
         def it_defaults_to_monthly():
             settings = BillingSettings.load()

--- a/tests/hub/cart_views_spec.py
+++ b/tests/hub/cart_views_spec.py
@@ -183,7 +183,7 @@ def describe_guild_eyop_form():
 
         response = client.post(
             f"/guilds/{guild.pk}/eyop-form/",
-            {"description": "Custom item", "amount": "7.50"},
+            {"description": "Custom item", "amount": "7.50", "quantity": "1"},
             HTTP_HX_REQUEST="true",
         )
 
@@ -191,6 +191,20 @@ def describe_guild_eyop_form():
         entry = TabEntry.objects.get(tab=tab)
         assert entry.description == "Custom item"
         assert entry.amount == Decimal("7.50")
+
+    def it_creates_n_entries_when_quantity_is_n(client: Client):
+        BillingSettingsFactory()
+        guild = GuildFactory()
+        _user, tab = _linked_user(client, username="eyopq")
+
+        response = client.post(
+            f"/guilds/{guild.pk}/eyop-form/",
+            {"description": "Clay", "amount": "2.50", "quantity": "3"},
+            HTTP_HX_REQUEST="true",
+        )
+
+        assert response.status_code == 204
+        assert TabEntry.objects.filter(tab=tab).count() == 3
 
     def it_requires_login(client: Client):
         guild = GuildFactory()
@@ -207,7 +221,7 @@ def describe_guild_eyop_form():
 
         response = client.post(
             f"/guilds/{guild.pk}/eyop-form/",
-            {"description": "Test", "amount": "5.00"},
+            {"description": "Test", "amount": "5.00", "quantity": "1"},
         )
         assert response.status_code == 400
 
@@ -219,7 +233,7 @@ def describe_guild_eyop_form():
         with patch("billing.models.Tab.add_entry", side_effect=TabLockedError("locked")):
             response = client.post(
                 f"/guilds/{guild.pk}/eyop-form/",
-                {"description": "Test", "amount": "5.00"},
+                {"description": "Test", "amount": "5.00", "quantity": "1"},
             )
         assert response.status_code == 400
 
@@ -231,7 +245,7 @@ def describe_guild_eyop_form():
         with patch("billing.models.Tab.add_entry", side_effect=TabLimitExceededError("exceeded")):
             response = client.post(
                 f"/guilds/{guild.pk}/eyop-form/",
-                {"description": "Test", "amount": "5.00"},
+                {"description": "Test", "amount": "5.00", "quantity": "1"},
             )
         assert response.status_code == 400
 

--- a/tests/hub/tab_views_spec.py
+++ b/tests/hub/tab_views_spec.py
@@ -11,7 +11,7 @@ from django.test import Client
 
 from billing.models import TabCharge
 from membership.signals import ensure_user_has_member
-from tests.billing.factories import BillingSettingsFactory, TabChargeFactory, TabEntryFactory, TabFactory
+from tests.billing.factories import TabChargeFactory, TabEntryFactory, TabFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -55,75 +55,54 @@ def describe_tab_detail():
         assert len(response.context["entries"]) == 1
         assert b"Laser cutter" in response.content
 
-    def describe_add_entry_form():
-        @pytest.fixture()
-        def setup(client: Client):
-            BillingSettingsFactory(default_tab_limit=Decimal("200.00"))
-            user = User.objects.create_user(username="adder", password="pass")
-            tab = TabFactory(member=user.member, stripe_payment_method_id="pm_test_123")
-            client.login(username="adder", password="pass")
-            return tab
+    def describe_payment_method_section():
+        def it_shows_add_card_link_when_no_method_on_file(client: Client):
+            User.objects.create_user(username="no_card", password="pass")
+            client.login(username="no_card", password="pass")
 
-        def it_adds_entry_on_valid_post(client: Client, setup):
-            response = client.post(
-                "/tab/",
-                {"description": "Wood glue", "amount": "5.50"},
-            )
-
-            assert response.status_code == 302
-            assert response.url == "/tab/"
-            assert setup.entries.count() == 1
-
-        def it_rejects_empty_description(client: Client, setup):
-            response = client.post("/tab/", {"description": "", "amount": "5.50"})
+            response = client.get("/tab/")
 
             assert response.status_code == 200
-            assert setup.entries.count() == 0
+            assert b"No card on file" in response.content
+            assert b"/billing/payment-method/setup/" in response.content
 
-        def it_rejects_zero_amount(client: Client, setup):
-            response = client.post("/tab/", {"description": "Test", "amount": "0.00"})
-
-            assert response.status_code == 200
-            assert setup.entries.count() == 0
-
-        def it_shows_error_when_tab_locked(client: Client):
-            from unittest.mock import patch
-
-            from billing.exceptions import TabLockedError
-
-            BillingSettingsFactory(default_tab_limit=Decimal("200.00"))
-            user = User.objects.create_user(username="locked_user", password="pass")
+        def it_shows_saved_card_and_manage_link_when_method_on_file(client: Client):
+            user = User.objects.create_user(username="has_card", password="pass")
             TabFactory(
                 member=user.member,
-                stripe_payment_method_id="pm_test",
+                stripe_payment_method_id="pm_test_123",
+                payment_method_brand="visa",
+                payment_method_last4="4242",
             )
-            client.login(username="locked_user", password="pass")
+            client.login(username="has_card", password="pass")
 
-            with patch("billing.models.Tab.add_entry", side_effect=TabLockedError("locked")):
-                response = client.post("/tab/", {"description": "Test", "amount": "10.00"}, follow=True)
+            response = client.get("/tab/")
 
-            assert b"locked" in response.content.lower()
+            assert response.status_code == 200
+            assert b"Visa" in response.content
+            assert b"4242" in response.content
+            assert b"Manage card" in response.content
+            assert b"/billing/payment-method/setup/" in response.content
 
-        def it_shows_error_when_no_payment_method(client: Client):
-            BillingSettingsFactory(default_tab_limit=Decimal("200.00"))
-            user = User.objects.create_user(username="no_pm", password="pass")
-            TabFactory(member=user.member, stripe_payment_method_id="")
-            client.login(username="no_pm", password="pass")
+    def it_rejects_post_requests(client: Client):
+        """Tab detail is GET-only — adding items happens from guild pages, not here."""
+        User.objects.create_user(username="poster", password="pass")
+        client.login(username="poster", password="pass")
 
-            response = client.post("/tab/", {"description": "Test", "amount": "10.00"}, follow=True)
+        response = client.post("/tab/", {"description": "Test", "amount": "10.00"})
 
-            assert b"payment method" in response.content.lower()
+        assert response.status_code == 405
 
-        def it_shows_error_when_limit_exceeded(client: Client):
-            BillingSettingsFactory(default_tab_limit=Decimal("20.00"))
-            user = User.objects.create_user(username="over_limit", password="pass")
-            tab = TabFactory(member=user.member, tab_limit=None, stripe_payment_method_id="pm_test")
-            TabEntryFactory(tab=tab, amount=Decimal("15.00"))
-            client.login(username="over_limit", password="pass")
+    def it_does_not_render_add_to_tab_section(client: Client):
+        user = User.objects.create_user(username="viewer", password="pass")
+        TabFactory(member=user.member, stripe_payment_method_id="pm_test")
+        client.login(username="viewer", password="pass")
 
-            response = client.post("/tab/", {"description": "Big item", "amount": "10.00"}, follow=True)
+        response = client.get("/tab/")
 
-            assert b"tab limit" in response.content.lower()
+        assert response.status_code == 200
+        assert b"Add to Tab" not in response.content
+        assert b"Add Item" not in response.content
 
 
 def describe_tab_history():

--- a/tests/hub/tab_views_spec.py
+++ b/tests/hub/tab_views_spec.py
@@ -101,8 +101,14 @@ def describe_tab_detail():
         response = client.get("/tab/")
 
         assert response.status_code == 200
-        assert b"Add to Tab" not in response.content
-        assert b"Add Item" not in response.content
+        import re
+
+        # Strip the base template's <head>/<title> metadata — only the page body matters
+        body = response.content
+        body = re.sub(rb"<head\b.*?</head>", b"", body, flags=re.DOTALL)
+        assert b"Add Item" not in body
+        # No self-service form heading or button in the page body
+        assert b"tab-add-form" not in body
 
 
 def describe_tab_history():

--- a/tests/hub/void_entry_spec.py
+++ b/tests/hub/void_entry_spec.py
@@ -25,23 +25,18 @@ def describe_void_tab_entry():
 
     def it_voids_a_pending_entry(client: Client, setup):
         entry = setup["entry"]
-        response = client.post(
-            f"/tab/void/{entry.pk}/",
-            {"reason": "Made a mistake"},
-        )
+        response = client.post(f"/tab/void/{entry.pk}/")
         assert response.status_code == 204
         entry.refresh_from_db()
         assert entry.voided_at is not None
+        assert entry.voided_reason == "Removed by member"
 
     def it_returns_toast_on_success(client: Client, setup):
         entry = setup["entry"]
-        response = client.post(
-            f"/tab/void/{entry.pk}/",
-            {"reason": "Duplicate entry"},
-        )
+        response = client.post(f"/tab/void/{entry.pk}/")
         assert response.status_code == 204
         payload = json.loads(response["HX-Trigger"])
-        assert payload["showToast"]["message"] == "Charge voided."
+        assert payload["showToast"]["message"] == "Charge removed."
         assert payload["showToast"]["type"] == "success"
 
     def it_rejects_void_of_another_users_entry(client: Client, setup):
@@ -49,19 +44,13 @@ def describe_void_tab_entry():
         other_tab = TabFactory(member=other_user.member)
         other_entry = TabEntryFactory(tab=other_tab, amount=Decimal("5.00"))
 
-        response = client.post(
-            f"/tab/void/{other_entry.pk}/",
-            {"reason": "Should not work"},
-        )
+        response = client.post(f"/tab/void/{other_entry.pk}/")
         assert response.status_code == 404
 
     def it_requires_login(client: Client, setup):
         client.logout()
         entry = setup["entry"]
-        response = client.post(
-            f"/tab/void/{entry.pk}/",
-            {"reason": "test"},
-        )
+        response = client.post(f"/tab/void/{entry.pk}/")
         assert response.status_code == 302
         assert "/accounts/login/" in response.url
 
@@ -69,17 +58,7 @@ def describe_void_tab_entry():
         entry = setup["entry"]
         entry.void(user=setup["user"], reason="first void")
 
-        response = client.post(
-            f"/tab/void/{entry.pk}/",
-            {"reason": "second void"},
-        )
+        response = client.post(f"/tab/void/{entry.pk}/")
         assert response.status_code == 400
         payload = json.loads(response["HX-Trigger"])
         assert payload["showToast"]["type"] == "error"
-
-    def it_returns_error_when_reason_missing(client: Client, setup):
-        entry = setup["entry"]
-        response = client.post(f"/tab/void/{entry.pk}/", {"reason": ""})
-        assert response.status_code == 400
-        payload = json.loads(response["HX-Trigger"])
-        assert payload["showToast"]["message"] == "Reason is required."


### PR DESCRIPTION
## Summary

Hotfix bundle for the member-facing Tab and Guild pages.

### My Tab page (`/tab/`)
- **Current Balance + Pending Charges merged** into one card; **Payment Method** moved to the bottom.
- Saved card brand/last4 + "Manage card" link (reaches the existing payment-method setup flow). No card → "Add a card".
- **"Your tab will be processed by Stripe on {date} at {time}"** — `BillingSettings.next_charge_at()` mirrors `bill_tabs._is_billing_time`.
- **Removed the self-service Add to Tab form** — `tab_detail` is GET-only now. Items are added from guild pages.
- **Trash-can remove button** (red, 16×16, SVG) replaces the full "Void" confirmation modal. One click, no dialog. View auto-stamps `reason="Removed by member"` for the audit trail.

### Guild page (`/guilds/<pk>/`)
- **General Consumables** card as the first item in the product grid (dashed yellow border, round `+` button).
- Modal opens titled **General Consumables** with fields: Description, Amount, **Quantity (1–99)**. Submitting loops `apply_to_tab` N times so each unit becomes its own tab entry (mirrors the cart flow). Toast reports "N items added to your tab!".
- The previous `+` icon in the Products header and the empty modal are gone.

### Bug fixes
- **Double toast fix** (important): removed the redundant `HX-Trigger` parser in `hub/base.html` and `admin/base.html`. HTMX already auto-fires the JSON key as an event *and* a kebab-case alias (confirmed in `htmx.min.js` via `Dt()` which kebab-cases event names). The manual parser was firing a second `show-toast`.
- **Amount column alignment**: the `.tab-table th { text-align: left }` rule had higher specificity than `.tab-table__right`, so the header stayed left while body cells went right. Bumped the specificity so both align.
- **Card spacing**: 1.5rem gap between cards on `/tab/` and on the payment-method setup page.

## Tests

- `tests/hub/tab_views_spec.py` — 13 tests; GET-only tab_detail, payment-method rendering, no-add-form assertion.
- `tests/hub/void_entry_spec.py` — 5 tests; single-click remove with auto-stamped reason.
- `tests/hub/cart_views_spec.py` — 17 tests; quantity field flow (N entries for quantity N).
- `tests/billing/forms_spec.py` — 33 tests; `TabItemForm` quantity field on guild-page context.
- `tests/billing/models/billing_settings_spec.py` — 21 tests; `next_charge_at()` for daily/weekly/monthly/off.

Total: 275 tests pass.

## Changelog

`v1.5.1` entry added to `plfog/version.py` covering the above in member-friendly language.

## Test plan

- [ ] `/tab/` renders Balance + Pending in one card, Payment Method at bottom
- [ ] Saved card shows brand + last4 with "Manage card" link
- [ ] "Your tab will be processed by Stripe on {date} at {time}" appears
- [ ] Trash-can button removes pending entries in one click (red, small)
- [ ] "Amount" header right-aligns with the `$…` values
- [ ] POST to `/tab/` returns 405
- [ ] Guild page shows "General Consumables" as the first product card
- [ ] Clicking the `+` opens a modal titled "General Consumables" with Description, Amount, Quantity
- [ ] Submitting Qty=3 adds three entries, toast says "3 items added to your tab!"
- [ ] Only **one** toast appears per successful action