### PR TITLE
1.6.0: Local dev setup, prod DB pull & cart toast fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,61 @@
+# ===========================================
+# Database
+# ===========================================
+# Local Docker Compose default — no changes needed for standard setup
+DATABASE_URL=postgres://plfog:plfog@localhost:5432/plfog
+
+# Production DB — only needed for `make db-pull-prod`
+# Get this from Render dashboard > plfog database > External Connection String
+PROD_DATABASE_URL=
+
+# ===========================================
+# Django
+# ===========================================
+DJANGO_SECRET_KEY=django-insecure-dev-key-change-in-production
+DJANGO_DEBUG=True
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+
+# ===========================================
+# Stripe (optional for local dev)
+# ===========================================
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_FIELD_ENCRYPTION_KEY=
+
+# ===========================================
+# Email (optional — DEBUG mode prints to console)
+# ===========================================
+RESEND_API_KEY=
+DEFAULT_FROM_EMAIL=noreply@pastlives.space
+BETA_FEEDBACK_EMAILS=josh@plaza.codes
+
+# ===========================================
+# Airtable Sync (optional)
+# ===========================================
+AIRTABLE_API_TOKEN=
+AIRTABLE_BASE_ID=
+AIRTABLE_SYNC_ENABLED=false
+
+# ===========================================
+# Web Push (optional)
+# ===========================================
+WEBPUSH_VAPID_PUBLIC_KEY=
+WEBPUSH_VAPID_PRIVATE_KEY=
+WEBPUSH_VAPID_ADMIN_EMAIL=
+
+# ===========================================
+# Sentry (optional)
+# ===========================================
+SENTRY_DSN=
+
+# ===========================================
+# Allauth
+# ===========================================
+ALLAUTH_TRUSTED_PROXY_COUNT=0
+
+# ===========================================
+# Infrastructure (set automatically on Render — ignore locally)
+# ===========================================
+# RENDER_EXTERNAL_HOSTNAME=
+# CSRF_TRUSTED_ORIGINS=
+# ADMIN_DOMAINS=

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+.DEFAULT_GOAL := help
+
+# Load .env if it exists
+ifneq (,$(wildcard .env))
+    include .env
+    export
+endif
+
+.PHONY: help setup install db-up db-down db-pull-prod migrate server test lint format
+
+help: ## Show available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+setup: ## First-time setup: .env, venv, deps, migrate
+	@test -f .env || (cp .env.example .env && echo "Created .env from .env.example — edit it if needed")
+	python3 -m venv .venv
+	.venv/bin/pip install --upgrade pip
+	.venv/bin/pip install -r requirements.txt
+	@echo ""
+	@echo "Setup complete. Next steps:"
+	@echo "  1. make db-up        (start PostgreSQL)"
+	@echo "  2. make migrate      (create tables)"
+	@echo "  3. make server       (start dev server)"
+	@echo ""
+	@echo "Optional: set PROD_DATABASE_URL in .env, then run 'make db-pull-prod' to load production data."
+
+install: ## Install Python dependencies into venv
+	.venv/bin/pip install -r requirements.txt
+
+db-up: ## Start PostgreSQL via Docker Compose
+	docker compose up -d
+	@echo "PostgreSQL running on localhost:5432"
+
+db-down: ## Stop PostgreSQL
+	docker compose down
+
+db-pull-prod: ## Download production database into local Postgres
+	.venv/bin/python manage.py pull_prod_db
+
+migrate: ## Run Django migrations
+	.venv/bin/python manage.py migrate
+
+server: ## Start Django dev server
+	.venv/bin/python manage.py runserver
+
+test: ## Run tests
+	.venv/bin/pytest
+
+lint: ## Run ruff linter and formatter check
+	.venv/bin/ruff check . && .venv/bin/ruff format --check .
+
+format: ## Auto-format code with ruff
+	.venv/bin/ruff format . && .venv/bin/ruff check --fix .

--- a/core/management/commands/pull_prod_db.py
+++ b/core/management/commands/pull_prod_db.py
@@ -13,6 +13,7 @@ Requires:
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import tempfile
@@ -25,7 +26,7 @@ from django.core.management.base import BaseCommand, CommandError
 class Command(BaseCommand):
     help = "Download the production database into your local PostgreSQL."
 
-    def add_arguments(self, parser: object) -> None:
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--no-input", action="store_true", help="Skip confirmation prompt")
 
     def handle(self, *args: object, **options: object) -> None:

--- a/core/management/commands/pull_prod_db.py
+++ b/core/management/commands/pull_prod_db.py
@@ -1,0 +1,84 @@
+"""Download the production database into local PostgreSQL.
+
+Usage:
+    python manage.py pull_prod_db          # interactive confirmation
+    python manage.py pull_prod_db --no-input  # skip confirmation (CI/scripts)
+
+Requires:
+    - PROD_DATABASE_URL env var (Render external connection string)
+    - Local DATABASE_URL pointing to PostgreSQL (not SQLite)
+    - pg_dump and psql available on PATH
+    - DEBUG=True (refuses to run in production)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Download the production database into your local PostgreSQL."
+
+    def add_arguments(self, parser: object) -> None:
+        parser.add_argument("--no-input", action="store_true", help="Skip confirmation prompt")
+
+    def handle(self, *args: object, **options: object) -> None:
+        if not settings.DEBUG:
+            raise CommandError("Refusing to run: DEBUG is not True.")
+
+        prod_url = os.environ.get("PROD_DATABASE_URL", "")
+        if not prod_url:
+            raise CommandError("PROD_DATABASE_URL is not set. Add it to your .env file.")
+
+        db_engine = settings.DATABASES["default"].get("ENGINE", "")
+        if "sqlite" in db_engine:
+            raise CommandError(
+                "Your local database must be PostgreSQL, not SQLite. "
+                "Set DATABASE_URL in your .env and run 'make db-up'."
+            )
+
+        local_url = os.environ.get("DATABASE_URL", "")
+
+        if not options["no_input"]:
+            confirm = input("This will REPLACE your local database with production data. Continue? [y/N] ")
+            if confirm.lower() != "y":
+                self.stdout.write("Aborted.")
+                return
+
+        self.stdout.write(self.style.NOTICE("Dumping production database..."))
+
+        with tempfile.NamedTemporaryFile(suffix=".sql", delete=False) as dump_file:
+            dump_path = dump_file.name
+
+        try:
+            result = subprocess.run(
+                ["pg_dump", "--no-owner", "--no-acl", "--clean", "--if-exists", "-f", dump_path, prod_url],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise CommandError(f"pg_dump failed: {result.stderr}")
+
+            self.stdout.write(self.style.NOTICE("Loading into local database..."))
+
+            result = subprocess.run(
+                ["psql", "-f", dump_path, local_url],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise CommandError(f"psql failed: {result.stderr}")
+
+        finally:
+            os.unlink(dump_path)
+
+        self.stdout.write(self.style.NOTICE("Running migrations..."))
+        call_command("migrate", verbosity=1, stdout=self.stdout)
+
+        self.stdout.write(self.style.SUCCESS("Done — loaded production data into local database."))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16
+    image: postgres:18
     environment:
       POSTGRES_DB: plfog
       POSTGRES_USER: plfog
@@ -8,7 +8,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: plfog
+      POSTGRES_USER: plfog
+      POSTGRES_PASSWORD: plfog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/docs/superpowers/plans/2026-04-14-local-dev-setup.md
+++ b/docs/superpowers/plans/2026-04-14-local-dev-setup.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Docker Compose runs PostgreSQL locally. A management command pulls the production database via `pg_dump`/`psql`. The allauth adapter shows the login code in the Django messages banner when `DEBUG=True`. A Makefile and `.env.example` standardize the developer workflow.
 
-**Tech Stack:** Docker Compose, PostgreSQL 16, Django management commands, allauth adapter override, Make
+**Tech Stack:** Docker Compose, PostgreSQL 18, Django management commands, allauth adapter override, Make
 
 ---
 
@@ -20,7 +20,7 @@
 ```yaml
 services:
   db:
-    image: postgres:16
+    image: postgres:18
     environment:
       POSTGRES_DB: plfog
       POSTGRES_USER: plfog
@@ -28,7 +28,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
 volumes:
   pgdata:

--- a/docs/superpowers/plans/2026-04-14-local-dev-setup.md
+++ b/docs/superpowers/plans/2026-04-14-local-dev-setup.md
@@ -1,0 +1,680 @@
+# Local Dev Setup & Prod DB Pull — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Any developer can clone the repo, run a few commands, and have a fully working local environment with production data and frictionless login.
+
+**Architecture:** Docker Compose runs PostgreSQL locally. A management command pulls the production database via `pg_dump`/`psql`. The allauth adapter shows the login code in the Django messages banner when `DEBUG=True`. A Makefile and `.env.example` standardize the developer workflow.
+
+**Tech Stack:** Docker Compose, PostgreSQL 16, Django management commands, allauth adapter override, Make
+
+---
+
+### Task 1: Docker Compose for Local PostgreSQL
+
+**Files:**
+- Create: `docker-compose.yml`
+
+- [ ] **Step 1: Create `docker-compose.yml`**
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: plfog
+      POSTGRES_USER: plfog
+      POSTGRES_PASSWORD: plfog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+```
+
+- [ ] **Step 2: Verify it starts**
+
+Run: `docker compose up -d && docker compose ps`
+Expected: `db` service is running and healthy on port 5432.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "infra: add Docker Compose for local PostgreSQL"
+```
+
+---
+
+### Task 2: `.env.example`
+
+**Files:**
+- Create: `.env.example`
+
+- [ ] **Step 1: Create `.env.example`**
+
+This lists every `os.environ.get()` from `plfog/settings.py`, grouped by concern, with sensible local defaults and comments. The `DATABASE_URL` default points to the Docker Compose Postgres.
+
+```bash
+# ===========================================
+# Database
+# ===========================================
+# Local Docker Compose default — no changes needed for standard setup
+DATABASE_URL=postgres://plfog:plfog@localhost:5432/plfog
+
+# Production DB — only needed for `make db-pull-prod`
+# Get this from Render dashboard > plfog database > External Connection String
+PROD_DATABASE_URL=
+
+# ===========================================
+# Django
+# ===========================================
+DJANGO_SECRET_KEY=django-insecure-dev-key-change-in-production
+DJANGO_DEBUG=True
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+
+# ===========================================
+# Stripe (optional for local dev)
+# ===========================================
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_FIELD_ENCRYPTION_KEY=
+
+# ===========================================
+# Email (optional — DEBUG mode prints to console)
+# ===========================================
+RESEND_API_KEY=
+DEFAULT_FROM_EMAIL=noreply@pastlives.space
+BETA_FEEDBACK_EMAILS=josh@plaza.codes
+
+# ===========================================
+# Airtable Sync (optional)
+# ===========================================
+AIRTABLE_API_TOKEN=
+AIRTABLE_BASE_ID=
+AIRTABLE_SYNC_ENABLED=false
+
+# ===========================================
+# Web Push (optional)
+# ===========================================
+WEBPUSH_VAPID_PUBLIC_KEY=
+WEBPUSH_VAPID_PRIVATE_KEY=
+WEBPUSH_VAPID_ADMIN_EMAIL=
+
+# ===========================================
+# Sentry (optional)
+# ===========================================
+SENTRY_DSN=
+
+# ===========================================
+# Allauth
+# ===========================================
+ALLAUTH_TRUSTED_PROXY_COUNT=0
+
+# ===========================================
+# Infrastructure (set automatically on Render — ignore locally)
+# ===========================================
+# RENDER_EXTERNAL_HOSTNAME=
+# CSRF_TRUSTED_ORIGINS=
+# ADMIN_DOMAINS=
+```
+
+- [ ] **Step 2: Verify `.env.example` is tracked by git**
+
+`.gitignore` already has `!.env.example` so it will be tracked. Verify:
+
+Run: `git check-ignore .env.example`
+Expected: No output (not ignored).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .env.example
+git commit -m "docs: add .env.example with all local dev defaults"
+```
+
+---
+
+### Task 3: Makefile
+
+**Files:**
+- Create: `Makefile`
+
+- [ ] **Step 1: Create `Makefile`**
+
+```makefile
+.DEFAULT_GOAL := help
+
+# Load .env if it exists
+ifneq (,$(wildcard .env))
+    include .env
+    export
+endif
+
+.PHONY: help setup install db-up db-down db-pull-prod migrate server test lint format
+
+help: ## Show available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+setup: ## First-time setup: .env, venv, deps, migrate
+	@test -f .env || (cp .env.example .env && echo "Created .env from .env.example — edit it if needed")
+	python3 -m venv .venv
+	.venv/bin/pip install --upgrade pip
+	.venv/bin/pip install -r requirements.txt
+	@echo ""
+	@echo "Setup complete. Next steps:"
+	@echo "  1. make db-up        (start PostgreSQL)"
+	@echo "  2. make migrate      (create tables)"
+	@echo "  3. make server       (start dev server)"
+	@echo ""
+	@echo "Optional: set PROD_DATABASE_URL in .env, then run 'make db-pull-prod' to load production data."
+
+install: ## Install Python dependencies into venv
+	.venv/bin/pip install -r requirements.txt
+
+db-up: ## Start PostgreSQL via Docker Compose
+	docker compose up -d
+	@echo "PostgreSQL running on localhost:5432"
+
+db-down: ## Stop PostgreSQL
+	docker compose down
+
+db-pull-prod: ## Download production database into local Postgres
+	.venv/bin/python manage.py pull_prod_db
+
+migrate: ## Run Django migrations
+	.venv/bin/python manage.py migrate
+
+server: ## Start Django dev server
+	.venv/bin/python manage.py runserver
+
+test: ## Run tests
+	.venv/bin/pytest
+
+lint: ## Run ruff linter and formatter check
+	.venv/bin/ruff check . && .venv/bin/ruff format --check .
+
+format: ## Auto-format code with ruff
+	.venv/bin/ruff format . && .venv/bin/ruff check --fix .
+```
+
+**Important:** Makefile rules require literal tab characters for indentation, not spaces. Ensure your editor writes tabs.
+
+- [ ] **Step 2: Verify `make help` works**
+
+Run: `make help`
+Expected: Formatted list of all targets with descriptions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "infra: add Makefile with developer commands"
+```
+
+---
+
+### Task 4: `pull_prod_db` Management Command — Tests
+
+**Files:**
+- Create: `tests/core/pull_prod_db_spec.py`
+
+The management command shells out to `pg_dump` and `psql`. Tests should mock `subprocess.run` to avoid needing a real prod database. Test the guard rails: DEBUG check, missing env vars, user confirmation.
+
+- [ ] **Step 1: Create `tests/core/pull_prod_db_spec.py`**
+
+```python
+"""BDD-style tests for the pull_prod_db management command."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import call, patch
+
+import pytest
+from django.core.management import CommandError, call_command
+
+
+def describe_pull_prod_db():
+    def describe_guard_rails():
+        def it_refuses_to_run_when_debug_is_false(settings):
+            settings.DEBUG = False
+            with pytest.raises(CommandError, match="DEBUG is not True"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())
+
+        @patch.dict("os.environ", {"PROD_DATABASE_URL": ""}, clear=False)
+        def it_refuses_when_prod_database_url_is_empty(settings):
+            settings.DEBUG = True
+            with pytest.raises(CommandError, match="PROD_DATABASE_URL is not set"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())
+
+        @patch.dict("os.environ", {"PROD_DATABASE_URL": "postgres://prod:5432/db"}, clear=False)
+        def it_refuses_when_local_db_is_sqlite(settings):
+            settings.DEBUG = True
+            settings.DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite3"}}
+            with pytest.raises(CommandError, match="local database must be PostgreSQL"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())
+
+    def describe_interactive_confirmation():
+        @patch.dict("os.environ", {"PROD_DATABASE_URL": "postgres://prod:5432/db"}, clear=False)
+        @patch("builtins.input", return_value="n")
+        def it_aborts_when_user_declines(mock_input, settings):
+            settings.DEBUG = True
+            out = StringIO()
+            call_command("pull_prod_db", stdout=out)
+            assert "Aborted" in out.getvalue()
+
+    def describe_successful_pull():
+        @patch.dict(
+            "os.environ",
+            {"PROD_DATABASE_URL": "postgres://user:pass@host:5432/proddb"},
+            clear=False,
+        )
+        @patch("core.management.commands.pull_prod_db.call_command")
+        @patch("subprocess.run")
+        def it_dumps_and_loads_prod_data(mock_run, mock_call_command, settings, tmp_path):
+            settings.DEBUG = True
+            mock_run.return_value.returncode = 0
+
+            out = StringIO()
+            call_command("pull_prod_db", "--no-input", stdout=out)
+
+            # Should call pg_dump and psql
+            commands_run = [c.args[0][0] for c in mock_run.call_args_list]
+            assert "pg_dump" in commands_run
+            assert "psql" in commands_run
+
+            # Should run migrate after loading
+            mock_call_command.assert_called_once_with("migrate", verbosity=1, stdout=out)
+
+            output = out.getvalue()
+            assert "production data" in output.lower() or "Done" in output
+
+        @patch.dict(
+            "os.environ",
+            {"PROD_DATABASE_URL": "postgres://user:pass@host:5432/proddb"},
+            clear=False,
+        )
+        @patch("core.management.commands.pull_prod_db.call_command")
+        @patch("subprocess.run")
+        def it_fails_gracefully_on_pg_dump_error(mock_run, mock_call_command, settings):
+            settings.DEBUG = True
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stderr = "connection refused"
+
+            with pytest.raises(CommandError, match="pg_dump failed"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/core/pull_prod_db_spec.py -v`
+Expected: FAIL — `CommandError: Unknown command: 'pull_prod_db'`
+
+---
+
+### Task 5: `pull_prod_db` Management Command — Implementation
+
+**Files:**
+- Create: `core/management/commands/pull_prod_db.py`
+
+- [ ] **Step 1: Create `core/management/commands/pull_prod_db.py`**
+
+```python
+"""Download the production database into local PostgreSQL.
+
+Usage:
+    python manage.py pull_prod_db          # interactive confirmation
+    python manage.py pull_prod_db --no-input  # skip confirmation (CI/scripts)
+
+Requires:
+    - PROD_DATABASE_URL env var (Render external connection string)
+    - Local DATABASE_URL pointing to PostgreSQL (not SQLite)
+    - pg_dump and psql available on PATH
+    - DEBUG=True (refuses to run in production)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Download the production database into your local PostgreSQL."
+
+    def add_arguments(self, parser: object) -> None:
+        parser.add_argument("--no-input", action="store_true", help="Skip confirmation prompt")
+
+    def handle(self, *args: object, **options: object) -> None:
+        if not settings.DEBUG:
+            raise CommandError("Refusing to run: DEBUG is not True.")
+
+        prod_url = os.environ.get("PROD_DATABASE_URL", "")
+        if not prod_url:
+            raise CommandError("PROD_DATABASE_URL is not set. Add it to your .env file.")
+
+        db_engine = settings.DATABASES["default"].get("ENGINE", "")
+        if "sqlite" in db_engine:
+            raise CommandError(
+                "Your local database must be PostgreSQL, not SQLite. "
+                "Set DATABASE_URL in your .env and run 'make db-up'."
+            )
+
+        local_url = os.environ.get("DATABASE_URL", "")
+
+        if not options["no_input"]:
+            confirm = input("This will REPLACE your local database with production data. Continue? [y/N] ")
+            if confirm.lower() != "y":
+                self.stdout.write("Aborted.")
+                return
+
+        self.stdout.write(self.style.NOTICE("Dumping production database..."))
+
+        with tempfile.NamedTemporaryFile(suffix=".sql", delete=False) as dump_file:
+            dump_path = dump_file.name
+
+        try:
+            # pg_dump from production
+            result = subprocess.run(
+                ["pg_dump", "--no-owner", "--no-acl", "--clean", "--if-exists", "-f", dump_path, prod_url],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise CommandError(f"pg_dump failed: {result.stderr}")
+
+            self.stdout.write(self.style.NOTICE("Loading into local database..."))
+
+            # psql into local
+            result = subprocess.run(
+                ["psql", "-f", dump_path, local_url],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise CommandError(f"psql failed: {result.stderr}")
+
+        finally:
+            os.unlink(dump_path)
+
+        self.stdout.write(self.style.NOTICE("Running migrations..."))
+        call_command("migrate", verbosity=1, stdout=self.stdout)
+
+        self.stdout.write(self.style.SUCCESS("Done — loaded production data into local database."))
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pytest tests/core/pull_prod_db_spec.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Run linter**
+
+Run: `ruff check core/management/commands/pull_prod_db.py && ruff format --check core/management/commands/pull_prod_db.py`
+Expected: Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/management/commands/pull_prod_db.py tests/core/pull_prod_db_spec.py
+git commit -m "feat: add pull_prod_db management command"
+```
+
+---
+
+### Task 6: Dev-Mode Login Code Display — Tests
+
+**Files:**
+- Modify: `tests/plfog/adapters_spec.py`
+
+The adapter override works in two parts:
+1. `send_mail` stashes the code on the request when `DEBUG=True` and the template is `account/email/login_code`
+2. `add_message` reads the stashed code and appends a `[DEV]` Django message
+
+- [ ] **Step 1: Add tests to `tests/plfog/adapters_spec.py`**
+
+Add these test blocks inside `describe_AdminRedirectAccountAdapter()`:
+
+```python
+    def describe_send_mail():
+        def it_stashes_login_code_on_request_in_debug_mode(rf, settings):
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            context = {"request": request, "code": "123456"}
+
+            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "send_mail"):
+                adapter.send_mail("account/email/login_code", "user@example.com", context)
+
+            assert request._dev_login_code == "123456"
+
+        def it_does_not_stash_code_when_debug_is_false(rf, settings):
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = False
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            context = {"request": request, "code": "123456"}
+
+            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "send_mail"):
+                adapter.send_mail("account/email/login_code", "user@example.com", context)
+
+            assert not hasattr(request, "_dev_login_code")
+
+        def it_does_not_stash_code_for_other_templates(rf, settings):
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            context = {"request": request, "code": "123456"}
+
+            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "send_mail"):
+                adapter.send_mail("account/email/password_reset", "user@example.com", context)
+
+            assert not hasattr(request, "_dev_login_code")
+
+    def describe_add_message():
+        def it_appends_dev_code_message_when_code_is_stashed(rf, settings):
+            from django.contrib.messages import get_messages
+            from django.contrib.messages.storage.fallback import FallbackStorage
+
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            # Django messages middleware setup
+            setattr(request, "session", {})
+            setattr(request, "_messages", FallbackStorage(request))
+            request._dev_login_code = "654321"
+
+            adapter.add_message(
+                request,
+                messages.SUCCESS,
+                message_template="account/messages/login_code_sent.txt",
+                message_context={"recipient": "user@example.com", "email": "user@example.com"},
+            )
+
+            all_messages = [str(m) for m in get_messages(request)]
+            assert any("[DEV] Your login code is: 654321" in m for m in all_messages)
+
+        def it_does_not_append_code_when_none_stashed(rf, settings):
+            from django.contrib.messages import get_messages
+            from django.contrib.messages.storage.fallback import FallbackStorage
+
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            setattr(request, "session", {})
+            setattr(request, "_messages", FallbackStorage(request))
+
+            adapter.add_message(
+                request,
+                messages.SUCCESS,
+                message_template="account/messages/login_code_sent.txt",
+                message_context={"recipient": "user@example.com", "email": "user@example.com"},
+            )
+
+            all_messages = [str(m) for m in get_messages(request)]
+            assert not any("[DEV]" in m for m in all_messages)
+
+        def it_cleans_up_stashed_code_after_use(rf, settings):
+            from django.contrib.messages.storage.fallback import FallbackStorage
+
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            setattr(request, "session", {})
+            setattr(request, "_messages", FallbackStorage(request))
+            request._dev_login_code = "111222"
+
+            adapter.add_message(
+                request,
+                messages.SUCCESS,
+                message_template="account/messages/login_code_sent.txt",
+                message_context={"recipient": "user@example.com", "email": "user@example.com"},
+            )
+
+            assert not hasattr(request, "_dev_login_code")
+```
+
+Note: You'll need to add `from django.contrib import messages` to the imports at the top of the file.
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `pytest tests/plfog/adapters_spec.py -k "send_mail or add_message" -v`
+Expected: FAIL — `AdminRedirectAccountAdapter` has no `send_mail` or `add_message` override yet.
+
+---
+
+### Task 7: Dev-Mode Login Code Display — Implementation
+
+**Files:**
+- Modify: `plfog/adapters.py`
+
+- [ ] **Step 1: Add `send_mail` and `add_message` overrides to `AdminRedirectAccountAdapter`**
+
+Add these two methods to the `AdminRedirectAccountAdapter` class in `plfog/adapters.py`, after the existing `_sync_permissions` method:
+
+```python
+    def send_mail(self, template_prefix: str, email: str, context: dict) -> None:
+        """In DEBUG mode, stash the login code on the request for display in the UI."""
+        if settings.DEBUG and template_prefix == "account/email/login_code" and "code" in context:
+            request = context.get("request")
+            if request:
+                request._dev_login_code = context["code"]
+        super().send_mail(template_prefix, email, context)
+
+    def add_message(
+        self,
+        request: HttpRequest,
+        level: int,
+        message_template: str | None = None,
+        message_context: dict | None = None,
+        extra_tags: str = "",
+        message: str | None = None,
+    ) -> None:
+        """In DEBUG mode, append the login code to the 'code sent' message."""
+        super().add_message(request, level, message_template, message_context, extra_tags=extra_tags, message=message)
+        if settings.DEBUG and hasattr(request, "_dev_login_code"):
+            from django.contrib import messages
+
+            messages.success(request, f"[DEV] Your login code is: {request._dev_login_code}")
+            del request._dev_login_code
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `pytest tests/plfog/adapters_spec.py -k "send_mail or add_message" -v`
+Expected: All PASS.
+
+- [ ] **Step 3: Run the full adapter test suite**
+
+Run: `pytest tests/plfog/adapters_spec.py -v`
+Expected: All PASS (no regressions).
+
+- [ ] **Step 4: Run linter**
+
+Run: `ruff check plfog/adapters.py && ruff format --check plfog/adapters.py`
+Expected: Clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plfog/adapters.py tests/plfog/adapters_spec.py
+git commit -m "feat: show login code in banner during local dev (DEBUG=True)"
+```
+
+---
+
+### Task 8: Full Test Suite & Coverage Check
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `pytest -q`
+Expected: All tests pass, 100% coverage maintained.
+
+- [ ] **Step 2: Run linter on entire project**
+
+Run: `ruff check . && ruff format --check .`
+Expected: Clean.
+
+- [ ] **Step 3: Run type checker**
+
+Run: `mypy .`
+Expected: No new errors.
+
+---
+
+### Task 9: Version Bump & Changelog
+
+**Files:**
+- Modify: `plfog/version.py`
+
+Note: The hotfix branch already has version 1.5.2 for the center cart toast. This work should be included in the same release or bumped to 1.6.0 since it adds new features (management command, Makefile, Docker Compose). Decide based on whether the cart toast hotfix is being shipped separately.
+
+- [ ] **Step 1: Update version and changelog**
+
+If shipping together with the cart toast fix as a feature release, update the existing 1.5.2 entry or bump to 1.6.0. Add changelog entries:
+
+```python
+{
+    "version": "1.6.0",
+    "date": "2026-04-14",
+    "title": "Local Dev Setup & Cart Toast Fix",
+    "changes": [
+        "New developer setup: clone, make setup, make server — and you're running locally with PostgreSQL",
+        "New 'make db-pull-prod' command downloads a copy of the production database for local testing",
+        "Login codes now appear directly on screen during local development — no more checking the terminal",
+        "The 'added to cart' notification now appears in the center of the screen instead of covering the tab balance",
+    ],
+},
+```
+
+- [ ] **Step 2: Run tests to confirm version bump doesn't break anything**
+
+Run: `pytest tests/plfog/version_spec.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plfog/version.py
+git commit -m "chore: bump version to 1.6.0 with changelog"
+```

--- a/docs/superpowers/specs/2026-04-14-local-dev-setup-design.md
+++ b/docs/superpowers/specs/2026-04-14-local-dev-setup-design.md
@@ -1,0 +1,274 @@
+# Local Dev Setup & Prod DB Pull — Design Spec
+
+**Date:** 2026-04-14
+**Status:** Draft
+**Goal:** Any developer can clone the repo, run a few commands, and have a fully working local environment with production data.
+
+---
+
+## 1. Problem
+
+Local dev currently uses SQLite with no seed data. Developers can't test against real guilds, members, products, or tab entries. The passwordless login flow requires checking the terminal console for the 6-digit code, which is annoying. There are no setup instructions or standardized commands.
+
+## 2. Solution Overview
+
+| Component | What it does |
+|-----------|-------------|
+| `docker-compose.yml` | Runs PostgreSQL 16 locally (nothing else in Docker) |
+| `.env.example` | Documents every env var with sensible local defaults |
+| `Makefile` | Standardized commands: `make setup`, `make server`, `make db-pull-prod`, etc. |
+| `pull_prod_db` management command | Downloads the Render production database into local Postgres |
+| Dev-mode login code display | Shows the 6-digit code in the green banner instead of requiring email/console |
+
+## 3. Docker Compose — Local PostgreSQL
+
+A minimal `docker-compose.yml` at the project root. Only Postgres — the Django app runs natively in the venv.
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: plfog
+      POSTGRES_USER: plfog
+      POSTGRES_PASSWORD: plfog
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+```
+
+Default local `DATABASE_URL`: `postgres://plfog:plfog@localhost:5432/plfog`
+
+## 4. Environment Variables — `.env.example`
+
+Lists every `os.environ.get()` from `settings.py` with placeholder values and comments. Grouped by concern.
+
+```bash
+# ===========================================
+# Database
+# ===========================================
+# Local Docker Compose default — no changes needed for standard setup
+DATABASE_URL=postgres://plfog:plfog@localhost:5432/plfog
+
+# Production DB — only needed for `make db-pull-prod`
+# Get this from Render dashboard > plfog database > External Connection String
+PROD_DATABASE_URL=
+
+# ===========================================
+# Django
+# ===========================================
+DJANGO_SECRET_KEY=django-insecure-dev-key-change-in-production
+DJANGO_DEBUG=True
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+
+# ===========================================
+# Stripe (optional for local dev)
+# ===========================================
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_FIELD_ENCRYPTION_KEY=
+
+# ===========================================
+# Email (optional — DEBUG mode prints to console)
+# ===========================================
+RESEND_API_KEY=
+DEFAULT_FROM_EMAIL=noreply@pastlives.space
+BETA_FEEDBACK_EMAILS=josh@plaza.codes
+
+# ===========================================
+# Airtable Sync (optional)
+# ===========================================
+AIRTABLE_API_TOKEN=
+AIRTABLE_BASE_ID=
+AIRTABLE_SYNC_ENABLED=false
+
+# ===========================================
+# Web Push (optional)
+# ===========================================
+WEBPUSH_VAPID_PUBLIC_KEY=
+WEBPUSH_VAPID_PRIVATE_KEY=
+WEBPUSH_VAPID_ADMIN_EMAIL=
+
+# ===========================================
+# Sentry (optional)
+# ===========================================
+SENTRY_DSN=
+
+# ===========================================
+# Allauth
+# ===========================================
+ALLAUTH_TRUSTED_PROXY_COUNT=0
+
+# ===========================================
+# Infrastructure (set automatically on Render — ignore locally)
+# ===========================================
+# RENDER_EXTERNAL_HOSTNAME=
+# CSRF_TRUSTED_ORIGINS=
+# ADMIN_DOMAINS=
+```
+
+The `Makefile setup` target copies `.env.example` → `.env` if `.env` doesn't already exist.
+
+## 5. Makefile
+
+```makefile
+.DEFAULT_GOAL := help
+
+# Load .env if it exists
+ifneq (,$(wildcard .env))
+    include .env
+    export
+endif
+
+.PHONY: help setup install db-up db-down db-pull-prod migrate server test lint format
+
+help: ## Show available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+setup: ## First-time setup: .env, venv, deps, DB, migrate
+	@test -f .env || (cp .env.example .env && echo "Created .env from .env.example")
+	python3 -m venv .venv
+	.venv/bin/pip install -r requirements.txt
+	@echo ""
+	@echo "Run 'make db-up' to start PostgreSQL, then 'make migrate' to set up tables."
+
+install: ## Install Python dependencies into venv
+	.venv/bin/pip install -r requirements.txt
+
+db-up: ## Start PostgreSQL via Docker Compose
+	docker compose up -d
+
+db-down: ## Stop PostgreSQL
+	docker compose down
+
+db-pull-prod: ## Download production database into local Postgres
+	.venv/bin/python manage.py pull_prod_db
+
+migrate: ## Run Django migrations
+	.venv/bin/python manage.py migrate
+
+server: ## Start Django dev server
+	.venv/bin/python manage.py runserver
+
+test: ## Run tests
+	.venv/bin/pytest
+
+lint: ## Run ruff linter
+	.venv/bin/ruff check .
+
+format: ## Run ruff formatter
+	.venv/bin/ruff format .
+```
+
+## 6. Management Command — `pull_prod_db`
+
+**Location:** `core/management/commands/pull_prod_db.py`
+
+**Behavior:**
+1. Reads `PROD_DATABASE_URL` from environment
+2. Refuses to run if `DEBUG` is not `True` (safety check)
+3. Confirms with the user: "This will REPLACE your local database with production data. Continue? [y/N]"
+4. Runs `pg_dump` against the Render Postgres (external connection string)
+5. Drops and recreates the local `plfog` database
+6. Loads the dump via `psql`
+7. Runs `migrate` to apply any pending local migrations not yet in prod
+8. Prints summary: "Done — loaded production data into local database."
+
+**Requirements:**
+- `pg_dump` and `psql` must be available locally. These come with the `postgresql-client` package (Linux/WSL) or Homebrew `libpq` (Mac). Docker Desktop also includes them.
+- The Render database must allow external connections (it does — external connection string is in the Render dashboard).
+
+**Implementation sketch:**
+
+```python
+class Command(BaseCommand):
+    help = "Download the production database into your local PostgreSQL."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--no-input", action="store_true", help="Skip confirmation prompt")
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError("Refusing to run: DEBUG is not True.")
+
+        prod_url = os.environ.get("PROD_DATABASE_URL")
+        if not prod_url:
+            raise CommandError("PROD_DATABASE_URL is not set.")
+
+        local_url = os.environ.get("DATABASE_URL")
+        if not local_url or "sqlite" in local_url:
+            raise CommandError("DATABASE_URL must point to a PostgreSQL database.")
+
+        if not options["no_input"]:
+            confirm = input("This will REPLACE your local database with production data. Continue? [y/N] ")
+            if confirm.lower() != "y":
+                self.stdout.write("Aborted.")
+                return
+
+        # 1. pg_dump from prod
+        # 2. dropdb + createdb locally
+        # 3. psql load dump
+        # 4. migrate
+```
+
+**`--no-input` flag** for CI/scripting use without interactive prompt.
+
+## 7. Dev-Mode Login Code Display
+
+**Goal:** When `DEBUG=True`, show the 6-digit login code directly in the green Django messages banner on the "Check Your Email" page, so developers never need to check the console.
+
+**Approach:** Override allauth's message template. Allauth sends a Django message using the template `account/messages/login_code_sent.txt`. The default says:
+
+> "A sign-in code has been sent to {recipient}."
+
+We already have a `templates/` directory that takes priority over allauth's built-in templates (`DIRS` comes before `APP_DIRS` in settings). We'll create a custom template at:
+
+```
+templates/account/messages/login_code_sent.txt
+```
+
+However, the message template doesn't receive the code — it only gets `recipient` and `email`/`phone` context. The code is stored in the session state, not passed to the message.
+
+**Solution:** Override `add_message` in the existing `AdminRedirectAccountAdapter` to intercept the login-code-sent message and append the code from the session state when `DEBUG=True`.
+
+```python
+# In plfog/adapters.py — add to AdminRedirectAccountAdapter
+
+def add_message(self, request, level, message_template, message_context=None, *args, **kwargs):
+    super().add_message(request, level, message_template, message_context, *args, **kwargs)
+    if settings.DEBUG and message_template == "account/messages/login_code_sent.txt":
+        # The code is in the stashed login state in the session
+        from allauth.account.internal.stagekit import get_pending_stage
+        stage = get_pending_stage(request)
+        if stage and "code" in stage.state:
+            messages.success(request, f"[DEV] Your login code is: {stage.state['code']}")
+```
+
+This is minimal, safe (only fires in DEBUG), and doesn't modify any allauth internals. The dev sees two messages: the normal "code sent" message plus a `[DEV] Your login code is: 123456` message in the green banner.
+
+**Alternative considered:** Override the `confirm_login_code.html` template to read from the session. Rejected because the session state is in an allauth-internal format and accessing it from a template is fragile.
+
+## 8. Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docker-compose.yml` | Create | PostgreSQL 16 service |
+| `.env.example` | Create | All env vars with local defaults and comments |
+| `Makefile` | Create | Developer commands |
+| `core/management/commands/pull_prod_db.py` | Create | Prod DB download command |
+| `plfog/adapters.py` | Modify | Add `add_message` override for dev-mode login code display |
+| `tests/plfog/adapters_spec.py` | Modify | Test the dev-mode login code message |
+| `tests/core/pull_prod_db_spec.py` | Create | Tests for the management command |
+| `.gitignore` | Modify | Ensure `.env` is gitignored (`.env.example` is tracked) |
+
+## 9. Out of Scope
+
+- Containerizing the Django app itself (runs natively in venv)
+- Seed data / fixtures (prod DB pull replaces this need)
+- CI/CD changes (this is local dev tooling only)
+- `README.md` or `CONTRIBUTING.md` (the Makefile `help` target and `.env.example` comments serve as docs for now)

--- a/docs/superpowers/specs/2026-04-14-local-dev-setup-design.md
+++ b/docs/superpowers/specs/2026-04-14-local-dev-setup-design.md
@@ -14,7 +14,7 @@ Local dev currently uses SQLite with no seed data. Developers can't test against
 
 | Component | What it does |
 |-----------|-------------|
-| `docker-compose.yml` | Runs PostgreSQL 16 locally (nothing else in Docker) |
+| `docker-compose.yml` | Runs PostgreSQL 18 locally (nothing else in Docker) |
 | `.env.example` | Documents every env var with sensible local defaults |
 | `Makefile` | Standardized commands: `make setup`, `make server`, `make db-pull-prod`, etc. |
 | `pull_prod_db` management command | Downloads the Render production database into local Postgres |
@@ -27,7 +27,7 @@ A minimal `docker-compose.yml` at the project root. Only Postgres — the Django
 ```yaml
 services:
   db:
-    image: postgres:16
+    image: postgres:18
     environment:
       POSTGRES_DB: plfog
       POSTGRES_USER: plfog
@@ -35,7 +35,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
 volumes:
   pgdata:
@@ -257,7 +257,7 @@ This is minimal, safe (only fires in DEBUG), and doesn't modify any allauth inte
 
 | File | Action | Description |
 |------|--------|-------------|
-| `docker-compose.yml` | Create | PostgreSQL 16 service |
+| `docker-compose.yml` | Create | PostgreSQL 18 service |
 | `.env.example` | Create | All env vars with local defaults and comments |
 | `Makefile` | Create | Developer commands |
 | `core/management/commands/pull_prod_db.py` | Create | Prod DB download command |

--- a/plfog/adapters.py
+++ b/plfog/adapters.py
@@ -91,6 +91,31 @@ class AdminRedirectAccountAdapter(DefaultAccountAdapter):
             return reverse("admin:index")
         return reverse("hub_guild_voting")
 
+    def send_mail(self, template_prefix: str, email: str, context: dict) -> None:
+        """In DEBUG mode, stash the login code on the request for display in the UI."""
+        if settings.DEBUG and template_prefix == "account/email/login_code" and "code" in context:
+            request = context.get("request")
+            if request:
+                request._dev_login_code = context["code"]
+        super().send_mail(template_prefix, email, context)
+
+    def add_message(
+        self,
+        request: HttpRequest,
+        level: int,
+        message_template: str | None = None,
+        message_context: dict | None = None,
+        extra_tags: str = "",
+        message: str | None = None,
+    ) -> None:
+        """In DEBUG mode, append the login code to the 'code sent' message."""
+        super().add_message(request, level, message_template, message_context, extra_tags=extra_tags, message=message)
+        if settings.DEBUG and hasattr(request, "_dev_login_code"):
+            from django.contrib import messages
+
+            messages.success(request, f"[DEV] Your login code is: {request._dev_login_code}")
+            del request._dev_login_code
+
     def _sync_permissions(self, user: object) -> None:
         """Sync is_staff/is_superuser from the user's Member fog_role.
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
-VERSION = "1.5.1"
+VERSION = "1.6.0"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.6.0",
+        "date": "2026-04-14",
+        "title": "Local Dev Setup & Cart Toast Fix",
+        "changes": [
+            "New developer setup: clone the repo, run make setup, make db-up, make server — and you're running locally with PostgreSQL",
+            "New 'make db-pull-prod' command downloads a copy of the production database for local testing",
+            "Login codes now appear directly on screen during local development — no more checking the terminal",
+            "The 'added to cart' notification now appears in the center of the screen instead of covering the tab balance",
+        ],
+    },
     {
         "version": "1.5.1",
         "date": "2026-04-13",

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -140,6 +140,19 @@
     color: var(--hub-text, #F4EFDD);
 }
 
+.pl-toast-container--center {
+    top: 4rem;
+    right: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    align-items: center;
+}
+
+.pl-toast-container--center .pl-toast {
+    text-align: center;
+    justify-content: center;
+}
+
 /* Toast transitions */
 .toast-enter {
     transition: all 0.3s ease;

--- a/templates/components/toast.html
+++ b/templates/components/toast.html
@@ -5,16 +5,31 @@ Triggered by:
   1. Server-side: HX-Trigger header with showToast event (via hub.toast.trigger_toast)
   2. Client-side: $dispatch('show-toast', {message: '...', type: 'success'})
 {% endcomment %}
-<div x-data="plToastManager()" @show-toast.window="add($event.detail)" class="pl-toast-container" aria-live="polite">
-    <template x-for="toast in toasts" :key="toast.id">
-        <div class="pl-toast" :class="'pl-toast--' + toast.type"
-             x-show="toast.visible"
-             x-transition:enter="toast-enter"
-             x-transition:leave="toast-leave">
-            <span x-text="toast.message"></span>
-            <button @click="dismiss(toast.id)" class="pl-toast__close" aria-label="Dismiss">&times;</button>
-        </div>
-    </template>
+<div x-data="plToastManager()" @show-toast.window="add($event.detail)" aria-live="polite">
+    {% comment %} Top-right toasts (default) {% endcomment %}
+    <div class="pl-toast-container">
+        <template x-for="toast in toasts.filter(t => t.position !== 'center')" :key="toast.id">
+            <div class="pl-toast" :class="'pl-toast--' + toast.type"
+                 x-show="toast.visible"
+                 x-transition:enter="toast-enter"
+                 x-transition:leave="toast-leave">
+                <span x-text="toast.message"></span>
+                <button @click="dismiss(toast.id)" class="pl-toast__close" aria-label="Dismiss">&times;</button>
+            </div>
+        </template>
+    </div>
+    {% comment %} Center toasts {% endcomment %}
+    <div class="pl-toast-container pl-toast-container--center">
+        <template x-for="toast in toasts.filter(t => t.position === 'center')" :key="toast.id">
+            <div class="pl-toast" :class="'pl-toast--' + toast.type"
+                 x-show="toast.visible"
+                 x-transition:enter="toast-enter"
+                 x-transition:leave="toast-leave">
+                <span x-text="toast.message"></span>
+                <button @click="dismiss(toast.id)" class="pl-toast__close" aria-label="Dismiss">&times;</button>
+            </div>
+        </template>
+    </div>
 </div>
 
 <script>
@@ -24,7 +39,13 @@ function plToastManager() {
         toasts: [],
         add(detail) {
             var id = ++_nextId;
-            this.toasts.push({id: id, message: detail.message, type: detail.type || 'success', visible: true});
+            this.toasts.push({
+                id: id,
+                message: detail.message,
+                type: detail.type || 'success',
+                position: detail.position || 'top-right',
+                visible: true
+            });
             var self = this;
             setTimeout(function() { self.dismiss(id); }, 4000);
         },

--- a/templates/hub/guild_detail.html
+++ b/templates/hub/guild_detail.html
@@ -265,7 +265,7 @@ function guildCart(guildPk) {
             }
             this.addModalOpen = false;
             window.dispatchEvent(new CustomEvent('show-toast', {
-                detail: {message: this.addModalProduct.name + ' x' + this.addModalQty + ' added to cart', type: 'success'}
+                detail: {message: this.addModalProduct.name + ' x' + this.addModalQty + ' added to cart', type: 'success', position: 'center'}
             }));
         },
 

--- a/tests/core/pull_prod_db_spec.py
+++ b/tests/core/pull_prod_db_spec.py
@@ -1,0 +1,81 @@
+"""BDD-style tests for the pull_prod_db management command."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import ANY, patch
+
+import pytest
+from django.core.management import CommandError, call_command
+
+
+def describe_pull_prod_db():
+    def describe_guard_rails():
+        def it_refuses_to_run_when_debug_is_false(settings):
+            settings.DEBUG = False
+            with pytest.raises(CommandError, match="DEBUG is not True"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())
+
+        @patch.dict("os.environ", {"PROD_DATABASE_URL": ""}, clear=False)
+        def it_refuses_when_prod_database_url_is_empty(settings):
+            settings.DEBUG = True
+            with pytest.raises(CommandError, match="PROD_DATABASE_URL is not set"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())
+
+        @patch.dict("os.environ", {"PROD_DATABASE_URL": "postgres://prod:5432/db"}, clear=False)
+        def it_refuses_when_local_db_is_sqlite(settings):
+            settings.DEBUG = True
+            settings.DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite3"}}
+            with pytest.raises(CommandError, match="local database must be PostgreSQL"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())
+
+    def describe_interactive_confirmation():
+        @patch.dict("os.environ", {"PROD_DATABASE_URL": "postgres://prod:5432/db"}, clear=False)
+        @patch("builtins.input", return_value="n")
+        def it_aborts_when_user_declines(mock_input, settings):
+            settings.DEBUG = True
+            settings.DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "localdb"}}
+            out = StringIO()
+            call_command("pull_prod_db", stdout=out)
+            assert "Aborted" in out.getvalue()
+
+    def describe_successful_pull():
+        @patch.dict(
+            "os.environ",
+            {"PROD_DATABASE_URL": "postgres://user:pass@host:5432/proddb"},
+            clear=False,
+        )
+        @patch("core.management.commands.pull_prod_db.call_command")
+        @patch("subprocess.run")
+        def it_dumps_and_loads_prod_data(mock_run, mock_call_command, settings):
+            settings.DEBUG = True
+            settings.DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "localdb"}}
+            mock_run.return_value.returncode = 0
+
+            out = StringIO()
+            call_command("pull_prod_db", "--no-input", stdout=out)
+
+            commands_run = [c.args[0][0] for c in mock_run.call_args_list]
+            assert "pg_dump" in commands_run
+            assert "psql" in commands_run
+
+            mock_call_command.assert_called_once_with("migrate", verbosity=1, stdout=ANY)
+
+            output = out.getvalue()
+            assert "Done" in output
+
+        @patch.dict(
+            "os.environ",
+            {"PROD_DATABASE_URL": "postgres://user:pass@host:5432/proddb"},
+            clear=False,
+        )
+        @patch("core.management.commands.pull_prod_db.call_command")
+        @patch("subprocess.run")
+        def it_fails_gracefully_on_pg_dump_error(mock_run, mock_call_command, settings):
+            settings.DEBUG = True
+            settings.DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "localdb"}}
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stderr = "connection refused"
+
+            with pytest.raises(CommandError, match="pg_dump failed"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())

--- a/tests/core/pull_prod_db_spec.py
+++ b/tests/core/pull_prod_db_spec.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from io import StringIO
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from django.core.management import CommandError, call_command
@@ -38,6 +38,23 @@ def describe_pull_prod_db():
             out = StringIO()
             call_command("pull_prod_db", stdout=out)
             assert "Aborted" in out.getvalue()
+
+        @patch.dict(
+            "os.environ",
+            {"PROD_DATABASE_URL": "postgres://user:pass@host:5432/proddb"},
+            clear=False,
+        )
+        @patch("core.management.commands.pull_prod_db.call_command")
+        @patch("subprocess.run")
+        @patch("builtins.input", return_value="y")
+        def it_proceeds_when_user_confirms(mock_input, mock_run, mock_call_command, settings):
+            settings.DEBUG = True
+            settings.DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "localdb"}}
+            mock_run.return_value.returncode = 0
+
+            out = StringIO()
+            call_command("pull_prod_db", stdout=out)
+            assert "Done" in out.getvalue()
 
     def describe_successful_pull():
         @patch.dict(
@@ -78,4 +95,22 @@ def describe_pull_prod_db():
             mock_run.return_value.stderr = "connection refused"
 
             with pytest.raises(CommandError, match="pg_dump failed"):
+                call_command("pull_prod_db", "--no-input", stdout=StringIO())
+
+        @patch.dict(
+            "os.environ",
+            {"PROD_DATABASE_URL": "postgres://user:pass@host:5432/proddb"},
+            clear=False,
+        )
+        @patch("core.management.commands.pull_prod_db.call_command")
+        @patch("subprocess.run")
+        def it_fails_gracefully_on_psql_error(mock_run, mock_call_command, settings):
+            settings.DEBUG = True
+            settings.DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "localdb"}}
+            # pg_dump succeeds, psql fails
+            success = MagicMock(returncode=0)
+            failure = MagicMock(returncode=1, stderr="permission denied")
+            mock_run.side_effect = [success, failure]
+
+            with pytest.raises(CommandError, match="psql failed"):
                 call_command("pull_prod_db", "--no-input", stdout=StringIO())

--- a/tests/plfog/adapters_spec.py
+++ b/tests/plfog/adapters_spec.py
@@ -694,6 +694,17 @@ def describe_AdminRedirectAccountAdapter():
 
             assert not hasattr(request, "_dev_login_code")
 
+        def it_handles_missing_request_in_context(settings):
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            context = {"code": "123456"}  # no "request" key
+
+            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "send_mail"):
+                adapter.send_mail("account/email/login_code", "user@example.com", context)
+            # Should not raise — just doesn't stash anything
+
     def describe_add_message():
         def it_appends_dev_code_message_when_code_is_stashed(rf, settings):
             from django.contrib.messages import get_messages

--- a/tests/plfog/adapters_spec.py
+++ b/tests/plfog/adapters_spec.py
@@ -4,6 +4,7 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.contrib import messages
 from django.contrib.auth.models import User
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
@@ -652,6 +653,113 @@ def describe_AdminRedirectAccountAdapter():
                 return_value=None,
             ):
                 adapter.pre_login(request, user, signup=True)  # Should not raise
+
+    def describe_send_mail():
+        def it_stashes_login_code_on_request_in_debug_mode(rf, settings):
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            context = {"request": request, "code": "123456"}
+
+            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "send_mail"):
+                adapter.send_mail("account/email/login_code", "user@example.com", context)
+
+            assert request._dev_login_code == "123456"
+
+        def it_does_not_stash_code_when_debug_is_false(rf, settings):
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = False
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            context = {"request": request, "code": "123456"}
+
+            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "send_mail"):
+                adapter.send_mail("account/email/login_code", "user@example.com", context)
+
+            assert not hasattr(request, "_dev_login_code")
+
+        def it_does_not_stash_code_for_other_templates(rf, settings):
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            context = {"request": request, "code": "123456"}
+
+            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "send_mail"):
+                adapter.send_mail("account/email/password_reset", "user@example.com", context)
+
+            assert not hasattr(request, "_dev_login_code")
+
+    def describe_add_message():
+        def it_appends_dev_code_message_when_code_is_stashed(rf, settings):
+            from django.contrib.messages import get_messages
+            from django.contrib.messages.storage.fallback import FallbackStorage
+
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            setattr(request, "session", {})
+            setattr(request, "_messages", FallbackStorage(request))
+            request._dev_login_code = "654321"
+
+            adapter.add_message(
+                request,
+                messages.SUCCESS,
+                message_template="account/messages/login_code_sent.txt",
+                message_context={"recipient": "user@example.com", "email": "user@example.com"},
+            )
+
+            all_messages = [str(m) for m in get_messages(request)]
+            assert any("[DEV] Your login code is: 654321" in m for m in all_messages)
+
+        def it_does_not_append_code_when_none_stashed(rf, settings):
+            from django.contrib.messages import get_messages
+            from django.contrib.messages.storage.fallback import FallbackStorage
+
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            setattr(request, "session", {})
+            setattr(request, "_messages", FallbackStorage(request))
+
+            adapter.add_message(
+                request,
+                messages.SUCCESS,
+                message_template="account/messages/login_code_sent.txt",
+                message_context={"recipient": "user@example.com", "email": "user@example.com"},
+            )
+
+            all_messages = [str(m) for m in get_messages(request)]
+            assert not any("[DEV]" in m for m in all_messages)
+
+        def it_cleans_up_stashed_code_after_use(rf, settings):
+            from django.contrib.messages.storage.fallback import FallbackStorage
+
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            settings.DEBUG = True
+            adapter = AdminRedirectAccountAdapter()
+            request = rf.get("/")
+            setattr(request, "session", {})
+            setattr(request, "_messages", FallbackStorage(request))
+            request._dev_login_code = "111222"
+
+            adapter.add_message(
+                request,
+                messages.SUCCESS,
+                message_template="account/messages/login_code_sent.txt",
+                message_context={"recipient": "user@example.com", "email": "user@example.com"},
+            )
+
+            assert not hasattr(request, "_dev_login_code")
 
 
 def describe_AutoCreateUserLoginCodeForm():


### PR DESCRIPTION
## Summary
- **Center cart toast**: "Added to cart" notification now uses a centered toast instead of top-right, so it doesn't cover the tab balance pill
- **Docker Compose**: Adds `docker-compose.yml` with PostgreSQL 16 for local dev
- **`.env.example`**: Documents every env var with sensible local defaults
- **Makefile**: Standardized commands (`make setup`, `make server`, `make db-pull-prod`, etc.)
- **`pull_prod_db` command**: Downloads the Render production database into local Postgres
- **Dev login code display**: Shows the 6-digit login code directly in the green banner when `DEBUG=True` — no more checking the terminal

## Test plan
- [ ] `make help` shows all commands
- [ ] `make db-up` starts PostgreSQL via Docker Compose
- [ ] `make db-pull-prod` downloads prod data (requires `PROD_DATABASE_URL` in `.env`)
- [ ] Login flow shows `[DEV] Your login code is: XXXXXX` in the green banner
- [ ] Adding a product to cart shows centered toast (not top-right)
- [ ] All 1263 tests pass with 100% coverage