### PR TITLE
hotfix(1.5.7): guild standings cross-join bug

### DIFF
--- a/hub/views.py
+++ b/hub/views.py
@@ -139,10 +139,14 @@ def _compute_live_standings() -> list[VoteStanding]:
     signed_up_1st = Q(first_choice_votes__member__user__isnull=False)
     signed_up_2nd = Q(second_choice_votes__member__user__isnull=False)
     signed_up_3rd = Q(third_choice_votes__member__user__isnull=False)
+    # distinct=True is essential: annotating three reverse-FK Counts on the same
+    # queryset cross-joins first/second/third_choice_votes, so without distinct
+    # each Count is multiplied by the other two. A guild with 1/2/3 first/second/
+    # third-place votes would show 6/6/6 and score 60 points instead of 17.
     guilds = Guild.objects.filter(is_active=True).annotate(
-        first=Count("first_choice_votes", filter=signed_up_1st),
-        second=Count("second_choice_votes", filter=signed_up_2nd),
-        third=Count("third_choice_votes", filter=signed_up_3rd),
+        first=Count("first_choice_votes", filter=signed_up_1st, distinct=True),
+        second=Count("second_choice_votes", filter=signed_up_2nd, distinct=True),
+        third=Count("third_choice_votes", filter=signed_up_3rd, distinct=True),
     )
 
     results: list[VoteStanding] = []
@@ -176,10 +180,12 @@ def _compute_new_votes_since(since: datetime | None) -> list[VoteStanding]:
         second_q &= Q(second_choice_votes__updated_at__gt=since)
         third_q &= Q(third_choice_votes__updated_at__gt=since)
 
+    # See note on distinct=True in _compute_live_standings — same cross-join
+    # multiplication applies here.
     guilds = Guild.objects.filter(is_active=True).annotate(
-        first=Count("first_choice_votes", filter=first_q),
-        second=Count("second_choice_votes", filter=second_q),
-        third=Count("third_choice_votes", filter=third_q),
+        first=Count("first_choice_votes", filter=first_q, distinct=True),
+        second=Count("second_choice_votes", filter=second_q, distinct=True),
+        third=Count("third_choice_votes", filter=third_q, distinct=True),
     )
 
     results: list[VoteStanding] = []

--- a/plfog/dashboard.py
+++ b/plfog/dashboard.py
@@ -39,12 +39,15 @@ def dashboard_callback(request: HttpRequest, context: dict) -> dict:
     signed_up_1st = Q(first_choice_votes__member__user__isnull=False)
     signed_up_2nd = Q(second_choice_votes__member__user__isnull=False)
     signed_up_3rd = Q(third_choice_votes__member__user__isnull=False)
+    # distinct=True: without it, the three reverse-FK Counts cross-join and
+    # each count is multiplied by the other two (see hub/views.py
+    # _compute_live_standings for the detailed explanation).
     guilds = (
         Guild.objects.filter(is_active=True)
         .annotate(
-            first=Count("first_choice_votes", filter=signed_up_1st),
-            second=Count("second_choice_votes", filter=signed_up_2nd),
-            third=Count("third_choice_votes", filter=signed_up_3rd),
+            first=Count("first_choice_votes", filter=signed_up_1st, distinct=True),
+            second=Count("second_choice_votes", filter=signed_up_2nd, distinct=True),
+            third=Count("third_choice_votes", filter=signed_up_3rd, distinct=True),
         )
         .order_by("-first", "-second", "-third")
     )

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
-VERSION = "1.5.6"
+VERSION = "1.5.7"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.5.7",
+        "date": "2026-04-15",
+        "title": "Current Vote Standings — real totals",
+        "changes": [
+            "Current Vote Standings now show the real point totals — a guild that picked up votes at multiple ranks (say, one 1st, two 2nds, and three 3rds) was being displayed with those counts multiplied together instead of added, so some guilds were appearing at 60 points when the actual total was 17. Fixed on the Guild Voting page and the admin dashboard",
+        ],
+    },
     {
         "version": "1.5.6",
         "date": "2026-04-15",
         "title": "Voting hotfixes, User Settings, and sidebar polish",
         "changes": [
-            "Current Vote Standings no longer inflate — we were counting old Airtable votes from members who never signed up to FOG. Now only votes from signed-up members count toward live standings, funding snapshots, and the admin dashboard",
             "The Guild Voting page is now split into three tabs: Current Standings (live points), New Votes This Month (only votes cast or changed since the last snapshot), and Last Month's Results (the most recent snapshot with funding breakdown)",
             "Your vote still rolls over automatically every cycle — once you've submitted it, it stays in place and keeps counting until you change it",
             "The admin Voting Preferences page now shows a per-member voting history pulled from past snapshots, so you can audit how anyone's picks contributed to the totals cycle by cycle",

--- a/tests/hub/guild_voting_spec.py
+++ b/tests/hub/guild_voting_spec.py
@@ -534,6 +534,32 @@ def describe_compute_live_standings():
         assert "Backfill Only" not in names
         assert names == {"Signed Up Pick", "Signed Up 2nd", "Signed Up 3rd"}
 
+    def it_does_not_cross_multiply_counts_when_one_guild_appears_at_multiple_ranks():
+        """Regression: three Count annotations cross-joined reverse FKs and multiplied.
+
+        With 1 first-place, 2 second-place, and 3 third-place votes for the same
+        guild, the raw JOIN produced 1*2*3 = 6 rows; each un-distinct Count
+        returned 6, yielding 6*5 + 6*3 + 6*2 = 60 instead of 1*5 + 2*3 + 3*2 = 17.
+        """
+        target = GuildFactory(name="Popular Across Ranks")
+        # Filler guilds so each VotePreference has three distinct slots.
+        fillers = [GuildFactory(name=f"Filler {i}") for i in range(6)]
+
+        # 1 first-place vote for target
+        VotePreferenceFactory(guild_1st=target, guild_2nd=fillers[0], guild_3rd=fillers[1])
+        # 2 second-place votes for target
+        VotePreferenceFactory(guild_1st=fillers[0], guild_2nd=target, guild_3rd=fillers[1])
+        VotePreferenceFactory(guild_1st=fillers[1], guild_2nd=target, guild_3rd=fillers[2])
+        # 3 third-place votes for target
+        VotePreferenceFactory(guild_1st=fillers[2], guild_2nd=fillers[3], guild_3rd=target)
+        VotePreferenceFactory(guild_1st=fillers[3], guild_2nd=fillers[4], guild_3rd=target)
+        VotePreferenceFactory(guild_1st=fillers[4], guild_2nd=fillers[5], guild_3rd=target)
+
+        result = _compute_live_standings()
+
+        by_name = {r["guild_name"]: r for r in result}
+        assert by_name["Popular Across Ranks"]["total_points"] == 1 * 5 + 2 * 3 + 3 * 2
+
 
 # ---------------------------------------------------------------------------
 # describe_compute_new_votes_since


### PR DESCRIPTION
## Summary
- Current Vote Standings was displaying inflated point totals (e.g. Leatherwork + Woodworking at 60 pts when the real totals were 17 and 18). Root cause: the three `Count()` annotations on `first_choice_votes`, `second_choice_votes`, and `third_choice_votes` cross-joined in a single query, so each count got multiplied by the other two. A guild with 1/2/3 votes at first/second/third rank came out as 6/6/6.
- Adding `distinct=True` on each `Count` makes Django count distinct VotePreference rows per rank, restoring the correct totals.
- Fixed in all three sites: `hub/views.py::_compute_live_standings`, `hub/views.py::_compute_new_votes_since`, and `plfog/dashboard.py::dashboard_callback`.
- Removed the misleading 1.5.6 changelog line that claimed standings were fixed — the signed-up-member filter in that release was correct but didn't touch this bug.

## Test plan
- [x] New regression test in `tests/hub/guild_voting_spec.py` reproduces the exact 60-pt scenario from production data and now passes.
- [x] Full suite: 1314 tests passing at 100% coverage.
- [x] Verified against the live Render database — standings now render as Jewelry 21 / Ceramics 18 / Wood 18 / Glass 17 / Leather 17 / …