### PR TITLE
fix(htmx): full-page load on login redirect — fixes broken CSS (1.5.8)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-VERSION = "1.6.1"
+VERSION = "1.6.2"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.6.2",
+        "date": "2026-04-15",
+        "title": "Fix: login page CSS broken after navigating from the hub",
+        "changes": [
+            "Fixed a bug where navigating to a protected page with an expired session would redirect you to the login page with completely broken styles — it now does a proper full-page load so the login page looks correct",
+        ],
+    },
     {
         "version": "1.6.1",
         "date": "2026-04-15",

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -222,6 +222,17 @@
         document.body.addEventListener('htmx:configRequest', function(event) {
             event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
         });
+
+        // When hx-boost follows a redirect to the login page, do a full page
+        // load instead of a partial swap — the login page uses different CSS
+        // and layout so a swap would render it completely unstyled.
+        document.addEventListener('htmx:beforeSwap', function(event) {
+            var url = event.detail.xhr && event.detail.xhr.responseURL;
+            if (url && url.includes('/accounts/login/')) {
+                event.detail.shouldSwap = false;
+                window.location.href = url;
+            }
+        });
     </script>
     <script defer src="{% static 'js/alpine.min.js' %}"></script>
     <script>


### PR DESCRIPTION
## Problem

When a user navigates to a protected hub page with an expired session, Django issues a 302 redirect to `/accounts/login/`. Because `<body hx-boost="true">` is set in `hub/base.html`, HTMX intercepts the link click as an AJAX request and follows the redirect silently — swapping only the `<body>` content while leaving the hub's `<head>` (with `hub.css` and `components.css`) in place.

The login page extends the root `base.html` which uses `style.css` and completely different markup. The login body rendered inside the hub's CSS context means all `.auth-page` / `.auth-card` classes are unstyled — the page looks completely broken.

## Fix

Added a `htmx:beforeSwap` listener that detects when the final response URL contains `/accounts/login/`. It cancels the HTMX swap and redirects the browser normally (`window.location.href`), triggering a real full-page load with the correct CSS.

```js
document.addEventListener('htmx:beforeSwap', function(event) {
    var url = event.detail.xhr && event.detail.xhr.responseURL;
    if (url && url.includes('/accounts/login/')) {
        event.detail.shouldSwap = false;
        window.location.href = url;
    }
});
```

## Test plan

- [ ] While logged in, open a hub page and let your session expire (or clear cookies), then navigate to a protected page via a sidebar link — confirm you land on the login page with correct styling
- [ ] Confirm the `?next=` redirect parameter is preserved so you're sent back after login