### PR TITLE
fix: style logout confirmation page

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-VERSION = "1.7.1"
+VERSION = "1.7.2"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.7.2",
+        "date": "2026-04-23",
+        "title": "Fix: logout page styling",
+        "changes": [
+            "Fixed the logout confirmation page so it uses the normal Past Lives site styling instead of showing an unstyled default page",
+        ],
+    },
     {
         "version": "1.7.1",
         "date": "2026-04-21",

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Log Out - Past Lives{% endblock %}
+
+{% block content %}
+<div class="auth-page">
+    <h1 class="auth-page__title">Log Out</h1>
+    <p class="auth-page__subtitle">Are you sure you want to end your session?</p>
+    <div class="auth-card">
+        <form method="POST" action="{% url 'account_logout' %}">
+            {% csrf_token %}
+            <button type="submit" class="btn btn--primary btn--full">Log Out</button>
+        </form>
+        <div class="auth-links">
+            <p><a href="{% url 'home' %}">Cancel</a></p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/auth/allauth_spec.py
+++ b/tests/auth/allauth_spec.py
@@ -15,6 +15,17 @@ def describe_allauth_urls():
         response = client.get("/accounts/login/")
         assert response.status_code == 200
 
+    def it_logout_page_uses_custom_template(client):
+        user = User.objects.create_user(username="logoutuser", email="logout@example.com", password="pass")
+        client.force_login(user)
+
+        response = client.get("/accounts/logout/")
+
+        assert response.status_code == 200
+        template_names = [t.name for t in response.templates]
+        assert "account/logout.html" in template_names
+        assert "Are you sure you want to end your session?" in response.content.decode()
+
     def it_signup_page_returns_200(client):
         # Default is invite_only, so signup_closed is rendered
         response = client.get("/accounts/signup/")


### PR DESCRIPTION
## Summary
- add a styled allauth logout confirmation template
- cover the logout template with an auth regression spec
- bump version and changelog for the fix

## Screenshot
<img width="977" height="640" alt="image" src="https://github.com/user-attachments/assets/30343e56-f6bc-4e04-b8ea-c7a1fb084261" />

## Testing
- Verified manually in local development.