### PR TITLE
feat(hub): Viewing-as role preview popover (1.6.3)

### DIFF
--- a/docs/superpowers/plans/2026-04-16-guild-leads-m2m.md
+++ b/docs/superpowers/plans/2026-04-16-guild-leads-m2m.md
@@ -1,0 +1,697 @@
+# Guild Leads M2M Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single `Guild.guild_lead` FK with a `Member.guild_leaderships` M2M so multiple members can lead the same guild, with assignment UI on the Member admin change page and all leads shown on the hub guild detail page.
+
+**Architecture:** Add `guild_leaderships = ManyToManyField(Guild, ...)` on `Member`; remove `Guild.guild_lead` FK; migrate existing assignments into the junction table. Member admin gets a `filter_horizontal` widget. The hub template loops over `guild.guild_leads.all()` with per-lead modals keyed by `lead.pk`.
+
+**Tech Stack:** Django ORM (ManyToManyField), Django admin `filter_horizontal`, Django migrations (3-op: AddField → RunPython → RemoveField), Django templates (Alpine.js modals), pytest-describe + factory-boy.
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|--------------|
+| `membership/models.py` | Modify | Add `guild_leaderships` M2M on `Member`; remove `guild_lead` FK from `Guild`; update `can_edit_guild()` |
+| `membership/migrations/0028_guild_leads_m2m.py` | Create | AddField → RunPython data copy → RemoveField |
+| `membership/admin.py` | Modify | Add `filter_horizontal = ["guild_leaderships"]`; add "Guild Leaderships" fieldset |
+| `hub/views.py` | Modify | Add `"guild_leads"` to `prefetch_related` in `guild_detail` |
+| `templates/hub/guild_detail.html` | Modify | Replace single `guild_lead` block with `{% for lead in guild.guild_leads.all %}` loop and per-lead modals |
+| `tests/membership/guild_spec.py` | Modify | Remove old FK tests; add M2M tests |
+| `tests/membership/models_spec.py` | Modify | Update two `can_edit_guild` tests to use M2M |
+| `tests/hub/guild_edit_spec.py` | Modify | Replace five `GuildFactory(guild_lead=...)` calls with M2M |
+| `tests/hub/guild_pages_spec.py` | Modify | Add guild-leads section tests (no leads, singular, plural, all names) |
+| `tests/membership/admin_spec.py` | Modify | Add `filter_horizontal` and fieldset tests |
+| `scripts/generate_fixture.py` | Modify | Remove `"guild_lead": None` from guild fixture dict |
+| `plfog/version.py` | Modify | Bump to 1.6.3; add changelog entry |
+
+---
+
+## Task 1: New M2M model tests (will fail), then model changes + migration
+
+**Files:**
+- Write tests: `tests/membership/guild_spec.py`
+- Write tests: `tests/membership/models_spec.py`
+- Modify: `membership/models.py`
+- Create: `membership/migrations/0028_guild_leads_m2m.py`
+
+- [ ] **Step 1: Add new M2M tests to guild_spec.py (these will fail)**
+
+In `tests/membership/guild_spec.py`, add these two tests inside `describe_Guild()`, after the existing `it_has_created_at` test:
+
+```python
+def it_supports_multiple_guild_leads():
+    member1 = MemberFactory()
+    member2 = MemberFactory()
+    guild = GuildFactory()
+    guild.guild_leads.add(member1, member2)
+    assert guild.guild_leads.count() == 2
+    assert member1 in guild.guild_leads.all()
+    assert member2 in guild.guild_leads.all()
+
+def it_member_can_lead_multiple_guilds():
+    member = MemberFactory()
+    guild1 = GuildFactory()
+    guild2 = GuildFactory()
+    member.guild_leaderships.add(guild1, guild2)
+    assert member.guild_leaderships.count() == 2
+    assert guild1 in member.guild_leaderships.all()
+    assert guild2 in member.guild_leaderships.all()
+```
+
+- [ ] **Step 2: Add new can_edit_guild tests to models_spec.py (these will fail)**
+
+In `tests/membership/models_spec.py`, inside `describe_can_edit_guild()`, add these after the existing tests:
+
+```python
+def it_is_true_for_guild_lead_assigned_via_m2m():
+    lead = MemberFactory(fog_role=Member.FogRole.MEMBER)
+    guild = GuildFactory()
+    guild.guild_leads.add(lead)
+    assert lead.can_edit_guild(guild) is True
+
+def it_is_false_when_member_not_in_guild_leads():
+    member = MemberFactory(fog_role=Member.FogRole.MEMBER)
+    guild = GuildFactory()
+    assert member.can_edit_guild(guild) is False
+```
+
+- [ ] **Step 3: Run the four new tests to confirm they fail**
+
+```
+pytest tests/membership/guild_spec.py::describe_Guild::it_supports_multiple_guild_leads tests/membership/guild_spec.py::describe_Guild::it_member_can_lead_multiple_guilds tests/membership/models_spec.py -k "m2m or not_in_guild_leads" -v
+```
+
+Expected: FAIL with `AttributeError: type object 'Guild' has no attribute 'guild_leads'` or similar.
+
+- [ ] **Step 4: Update membership/models.py — add M2M to Member**
+
+In `membership/models.py`, in the `Member` class, add this field after the `leases` GenericRelation:
+
+```python
+guild_leaderships = models.ManyToManyField(
+    "Guild",
+    blank=True,
+    related_name="guild_leads",
+    help_text="Guilds this member leads.",
+)
+```
+
+- [ ] **Step 5: Update membership/models.py — remove guild_lead FK from Guild**
+
+In `membership/models.py`, in the `Guild` class, remove these lines entirely:
+
+```python
+guild_lead = models.ForeignKey(
+    Member,
+    null=True,
+    blank=True,
+    on_delete=models.SET_NULL,
+    related_name="led_guilds",
+)
+```
+
+- [ ] **Step 6: Update membership/models.py — fix can_edit_guild**
+
+In `membership/models.py`, update `Member.can_edit_guild()`:
+
+```python
+def can_edit_guild(self, guild: Guild) -> bool:
+    """True when this member may edit the given guild (admin, officer, or that guild's lead)."""
+    return self.is_fog_admin or self.is_guild_officer or self.guild_leaderships.filter(pk=guild.pk).exists()
+```
+
+- [ ] **Step 7: Create migration 0028**
+
+Create `membership/migrations/0028_guild_leads_m2m.py` with this exact content:
+
+```python
+from django.db import migrations, models
+
+
+def _copy_fk_to_m2m(apps, schema_editor):
+    """Copy Guild.guild_lead FK assignments into the new guild_leaderships M2M table."""
+    Guild = apps.get_model("membership", "Guild")
+    for guild in Guild.objects.exclude(guild_lead__isnull=True):
+        guild.guild_leaderships.add(guild.guild_lead_id)
+
+
+def _restore_fk_from_m2m(apps, schema_editor):
+    """Restore Guild.guild_lead from the first entry in guild_leaderships (for reversal)."""
+    Guild = apps.get_model("membership", "Guild")
+    for guild in Guild.objects.all():
+        first_lead = guild.guild_leaderships.first()
+        if first_lead is not None:
+            guild.guild_lead_id = first_lead.pk
+            guild.save(update_fields=["guild_lead"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("membership", "0027_calendarevent_source"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="member",
+            name="guild_leaderships",
+            field=models.ManyToManyField(
+                blank=True,
+                help_text="Guilds this member leads.",
+                related_name="guild_leads",
+                to="membership.guild",
+            ),
+        ),
+        migrations.RunPython(
+            _copy_fk_to_m2m,
+            _restore_fk_from_m2m,
+        ),
+        migrations.RemoveField(
+            model_name="guild",
+            name="guild_lead",
+        ),
+    ]
+```
+
+- [ ] **Step 8: Run the four new tests to confirm they now pass**
+
+```
+pytest tests/membership/guild_spec.py::describe_Guild::it_supports_multiple_guild_leads tests/membership/guild_spec.py::describe_Guild::it_member_can_lead_multiple_guilds tests/membership/models_spec.py -k "m2m or not_in_guild_leads" -v
+```
+
+Expected: PASS for the four new tests. (Other tests using `guild_lead=` will fail — those are fixed in Task 2.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add membership/models.py membership/migrations/0028_guild_leads_m2m.py tests/membership/guild_spec.py tests/membership/models_spec.py
+git commit -m "feat(membership): replace guild_lead FK with guild_leaderships M2M"
+```
+
+---
+
+## Task 2: Fix all old tests that used guild_lead= API
+
+**Files:**
+- Modify: `tests/membership/guild_spec.py`
+- Modify: `tests/membership/models_spec.py`
+- Modify: `tests/hub/guild_edit_spec.py`
+
+- [ ] **Step 1: Fix guild_spec.py — replace old FK tests with updated ones**
+
+In `tests/membership/guild_spec.py`, inside `describe_Guild()`, replace:
+
+```python
+def it_can_have_guild_lead():
+    member = MemberFactory()
+    guild = GuildFactory(guild_lead=member)
+    assert guild.guild_lead == member
+
+def it_allows_null_guild_lead():
+    guild = GuildFactory(guild_lead=None)
+    assert guild.guild_lead is None
+```
+
+With:
+
+```python
+def it_has_no_guild_leads_by_default():
+    guild = GuildFactory()
+    assert guild.guild_leads.count() == 0
+```
+
+- [ ] **Step 2: Fix models_spec.py — update old can_edit_guild tests**
+
+In `tests/membership/models_spec.py`, inside `describe_can_edit_guild()`, replace:
+
+```python
+def it_is_true_for_the_guilds_own_lead():
+    lead = MemberFactory(fog_role=Member.FogRole.MEMBER)
+    guild = GuildFactory(guild_lead=lead)
+    assert lead.can_edit_guild(guild) is True
+
+def it_is_false_for_regular_members_other_guilds():
+    member = MemberFactory(fog_role=Member.FogRole.MEMBER)
+    other_lead = MemberFactory(fog_role=Member.FogRole.MEMBER)
+    guild = GuildFactory(guild_lead=other_lead)
+    assert member.can_edit_guild(guild) is False
+```
+
+With:
+
+```python
+def it_is_true_for_the_guilds_own_lead():
+    lead = MemberFactory(fog_role=Member.FogRole.MEMBER)
+    guild = GuildFactory()
+    guild.guild_leads.add(lead)
+    assert lead.can_edit_guild(guild) is True
+
+def it_is_false_for_regular_members_other_guilds():
+    member = MemberFactory(fog_role=Member.FogRole.MEMBER)
+    other_lead = MemberFactory(fog_role=Member.FogRole.MEMBER)
+    guild = GuildFactory()
+    guild.guild_leads.add(other_lead)
+    assert member.can_edit_guild(guild) is False
+```
+
+- [ ] **Step 3: Fix guild_edit_spec.py — replace 5 GuildFactory(guild_lead=...) calls**
+
+In `tests/hub/guild_edit_spec.py`, replace each occurrence of `GuildFactory(guild_lead=user.member)` followed by usage. There are 5 tests to update:
+
+**Test: `it_guild_lead_can_create_a_product_for_their_guild`** — replace:
+```python
+guild = GuildFactory(guild_lead=user.member)
+```
+with:
+```python
+guild = GuildFactory()
+guild.guild_leads.add(user.member)
+```
+
+**Test: `it_allows_the_guild_lead_to_update`** — replace:
+```python
+guild = GuildFactory(guild_lead=user.member)
+```
+with:
+```python
+guild = GuildFactory()
+guild.guild_leads.add(user.member)
+```
+
+**Test: `it_guild_lead_can_delete_their_products`** — replace:
+```python
+guild = GuildFactory(guild_lead=user.member)
+```
+with:
+```python
+guild = GuildFactory()
+guild.guild_leads.add(user.member)
+```
+
+**Test: `it_guild_lead_can_edit_their_guild`** — replace:
+```python
+guild = GuildFactory(guild_lead=user.member, name="Old")
+```
+with:
+```python
+guild = GuildFactory(name="Old")
+guild.guild_leads.add(user.member)
+```
+
+**Test: `it_shows_edit_buttons_for_guild_lead`** — replace:
+```python
+guild = GuildFactory(guild_lead=user.member)
+```
+with:
+```python
+guild = GuildFactory()
+guild.guild_leads.add(user.member)
+```
+
+- [ ] **Step 4: Run full test suite to confirm clean**
+
+```
+pytest tests/membership/ tests/hub/ -v --tb=short -q
+```
+
+Expected: All tests pass. Zero failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/membership/guild_spec.py tests/membership/models_spec.py tests/hub/guild_edit_spec.py
+git commit -m "test(membership): migrate guild_lead= tests to M2M guild_leads"
+```
+
+---
+
+## Task 3: Admin widget — filter_horizontal + Guild Leaderships fieldset
+
+**Files:**
+- Write test: `tests/membership/admin_spec.py`
+- Modify: `membership/admin.py`
+
+- [ ] **Step 1: Write failing admin tests**
+
+In `tests/membership/admin_spec.py`, add these two tests inside `describe_MemberAdmin()`:
+
+```python
+def it_includes_guild_leaderships_in_filter_horizontal():
+    member_admin = admin.site._registry[Member]
+    assert "guild_leaderships" in member_admin.filter_horizontal
+
+@pytest.mark.django_db
+def it_shows_guild_leaderships_fieldset_on_edit_form():
+    from django.test import RequestFactory
+
+    rf = RequestFactory()
+    request = rf.get("/admin/membership/member/1/change/")
+    request.user = User(is_staff=True, is_superuser=True)
+    member = MemberFactory()
+    member_admin = admin.site._registry[Member]
+    fieldsets = member_admin.get_fieldsets(request, obj=member)
+    fieldset_titles = [fs[0] for fs in fieldsets]
+    assert "Guild Leaderships" in fieldset_titles
+```
+
+- [ ] **Step 2: Run the new admin tests to confirm they fail**
+
+```
+pytest tests/membership/admin_spec.py -k "guild_leaderships" -v
+```
+
+Expected: FAIL — `filter_horizontal` doesn't contain `"guild_leaderships"` yet.
+
+- [ ] **Step 3: Update membership/admin.py — add filter_horizontal**
+
+In `membership/admin.py`, in the `MemberAdmin` class, add after the `readonly_fields` line:
+
+```python
+filter_horizontal = ["guild_leaderships"]
+```
+
+- [ ] **Step 4: Update membership/admin.py — add Guild Leaderships fieldset**
+
+In `membership/admin.py`, in `MemberAdmin.get_fieldsets()`, the current return statement ends with the `"Notes"` fieldset. Append the new fieldset so the full return reads:
+
+```python
+return [
+    (
+        "Personal Info",
+        {
+            "fields": personal_fields,
+        },
+    ),
+    (
+        "Membership",
+        {
+            "fields": membership_fields,
+        },
+    ),
+    (
+        "Emergency Contact",
+        {
+            "fields": [
+                "emergency_contact_name",
+                "emergency_contact_phone",
+                "emergency_contact_relationship",
+            ],
+        },
+    ),
+    (
+        "Notes",
+        {
+            "fields": ["notes"],
+        },
+    ),
+    (
+        "Guild Leaderships",
+        {
+            "fields": ["guild_leaderships"],
+        },
+    ),
+]
+```
+
+- [ ] **Step 5: Run the new admin tests to confirm they pass**
+
+```
+pytest tests/membership/admin_spec.py -k "guild_leaderships" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full admin spec to confirm nothing broke**
+
+```
+pytest tests/membership/admin_spec.py -v --tb=short
+```
+
+Expected: All pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add membership/admin.py tests/membership/admin_spec.py
+git commit -m "feat(admin): add Guild Leaderships filter_horizontal widget to Member admin"
+```
+
+---
+
+## Task 4: Hub template — prefetch + loop over guild leads
+
+**Files:**
+- Write tests: `tests/hub/guild_pages_spec.py`
+- Modify: `hub/views.py`
+- Modify: `templates/hub/guild_detail.html`
+
+- [ ] **Step 1: Write failing hub template tests**
+
+In `tests/hub/guild_pages_spec.py`, add a new `describe_guild_leads_section()` block inside `describe_guild_detail()`:
+
+```python
+def describe_guild_leads_section():
+    def it_hides_leads_section_when_no_leads(client: Client):
+        User.objects.create_user(username="v_nolead", password="pass")
+        guild = GuildFactory()
+        client.login(username="v_nolead", password="pass")
+        response = client.get(f"/guilds/{guild.pk}/")
+        assert response.status_code == 200
+        assert b'hub-detail-label">Guild Lead' not in response.content
+
+    def it_shows_singular_heading_with_one_lead(client: Client):
+        MembershipPlanFactory()
+        lead_user = User.objects.create_user(username="lead_sing", password="pass")
+        lead_user.member.preferred_name = "Solo Lead"
+        lead_user.member.save(update_fields=["preferred_name"])
+        guild = GuildFactory()
+        guild.guild_leads.add(lead_user.member)
+        User.objects.create_user(username="viewer_sing", password="pass")
+        client.login(username="viewer_sing", password="pass")
+        response = client.get(f"/guilds/{guild.pk}/")
+        assert b"Guild Lead</h3>" in response.content
+        assert b"Guild Leads</h3>" not in response.content
+        assert b"Solo Lead" in response.content
+
+    def it_shows_plural_heading_with_multiple_leads(client: Client):
+        MembershipPlanFactory()
+        lead1 = User.objects.create_user(username="lead_pl1", password="pass")
+        lead2 = User.objects.create_user(username="lead_pl2", password="pass")
+        guild = GuildFactory()
+        guild.guild_leads.add(lead1.member, lead2.member)
+        User.objects.create_user(username="viewer_pl", password="pass")
+        client.login(username="viewer_pl", password="pass")
+        response = client.get(f"/guilds/{guild.pk}/")
+        assert b"Guild Leads</h3>" in response.content
+
+    def it_shows_all_lead_names_in_the_section(client: Client):
+        MembershipPlanFactory()
+        lead1 = User.objects.create_user(username="lead_names1", password="pass")
+        lead1.member.preferred_name = "Alice"
+        lead1.member.save(update_fields=["preferred_name"])
+        lead2 = User.objects.create_user(username="lead_names2", password="pass")
+        lead2.member.preferred_name = "Bob"
+        lead2.member.save(update_fields=["preferred_name"])
+        guild = GuildFactory()
+        guild.guild_leads.add(lead1.member, lead2.member)
+        User.objects.create_user(username="viewer_names", password="pass")
+        client.login(username="viewer_names", password="pass")
+        response = client.get(f"/guilds/{guild.pk}/")
+        assert b"Alice" in response.content
+        assert b"Bob" in response.content
+```
+
+- [ ] **Step 2: Run these tests to confirm they fail**
+
+```
+pytest tests/hub/guild_pages_spec.py -k "guild_leads_section" -v
+```
+
+Expected: FAIL — the template still uses `guild.guild_lead` (singular FK), which no longer exists, so the `{% if guild.guild_lead %}` block is always falsy and tests expecting "Guild Lead" headings fail.
+
+- [ ] **Step 3: Update hub/views.py — add guild_leads prefetch**
+
+In `hub/views.py`, in the `guild_detail` view, change:
+
+```python
+guild = get_object_or_404(
+    Guild.objects.prefetch_related("products__splits__guild"),
+    pk=pk,
+)
+```
+
+to:
+
+```python
+guild = get_object_or_404(
+    Guild.objects.prefetch_related("products__splits__guild", "guild_leads"),
+    pk=pk,
+)
+```
+
+- [ ] **Step 4: Replace the guild lead block in templates/hub/guild_detail.html**
+
+In `templates/hub/guild_detail.html`, replace lines 30–107 (the entire `{% if guild.guild_lead %}...{% endif %}` block — from `{% if guild.guild_lead %}` through the closing `{% endif %}` before `</div>`):
+
+```django
+    {% with leads=guild.guild_leads.all %}
+    {% if leads %}
+    <div class="hub-detail-section">
+        <h3 class="hub-detail-label">Guild Lead{% if leads|length > 1 %}s{% endif %}</h3>
+        {% for lead in leads %}
+        <div class="hub-member-row" style="cursor:pointer;" @click="$dispatch('open-modal', 'guild-lead-profile-{{ lead.pk }}')">
+            <div class="hub-member-avatar">
+                {{ lead.display_name|make_list|first|upper }}
+            </div>
+            <div class="hub-member-info">
+                <span class="hub-member-name">{{ lead.display_name }}</span>
+                <span class="hub-badge">Lead</span>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    {% for lead in leads %}
+    <div x-data="{ open: false }"
+         x-show="open"
+         x-transition:enter="modal-enter"
+         x-transition:leave="modal-leave"
+         @open-modal.window="if ($event.detail === 'guild-lead-profile-{{ lead.pk }}') open = true"
+         @close-modal.window="if ($event.detail === 'guild-lead-profile-{{ lead.pk }}') open = false"
+         @keydown.escape.window="open = false"
+         class="pl-modal-backdrop"
+         style="display: none;"
+         role="dialog"
+         aria-modal="true">
+        <div class="pl-modal pl-modal--sm" @click.outside="open = false">
+            <div class="pl-modal__header">
+                <h2 class="pl-modal__title">{{ lead.display_name }}</h2>
+                <button type="button" @click="open = false" class="pl-modal__close" aria-label="Close">&times;</button>
+            </div>
+            <div class="pl-modal__body">
+                {% if lead.show_in_directory %}
+                <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1.25rem;">
+                    <div class="hub-member-avatar" style="width:48px;height:48px;font-size:1.25rem;">
+                        {{ lead.display_name|make_list|first|upper }}
+                    </div>
+                    <div>
+                        <div style="font-weight:600;color:var(--hub-text, #F4EFDD);">{{ lead.display_name }}</div>
+                        {% if lead.pronouns and lead.pronouns != "prefer not to share" %}
+                        <div style="font-size:0.8125rem;color:var(--hub-text-muted, #96ACBB);">{{ lead.pronouns }}</div>
+                        {% endif %}
+                    </div>
+                </div>
+                {% if lead.about_me %}
+                <p style="font-size:0.875rem;color:var(--hub-text, #F4EFDD);margin:0 0 1rem;">{{ lead.about_me }}</p>
+                {% endif %}
+                {% if lead.primary_email or lead.phone or lead.discord_handle %}
+                <div style="display:flex;flex-direction:column;gap:0.5rem;">
+                    {% if lead.primary_email %}
+                    <div style="display:flex;gap:0.5rem;font-size:0.875rem;">
+                        <span style="color:var(--hub-text-muted, #96ACBB);min-width:60px;">Email</span>
+                        <a href="mailto:{{ lead.primary_email }}" style="color:var(--color-tuscan-yellow, #EEB44B);">{{ lead.primary_email }}</a>
+                    </div>
+                    {% endif %}
+                    {% if lead.phone %}
+                    <div style="display:flex;gap:0.5rem;font-size:0.875rem;">
+                        <span style="color:var(--hub-text-muted, #96ACBB);min-width:60px;">Phone</span>
+                        <span style="color:var(--hub-text, #F4EFDD);">{{ lead.phone }}</span>
+                    </div>
+                    {% endif %}
+                    {% if lead.discord_handle %}
+                    <div style="display:flex;gap:0.5rem;font-size:0.875rem;">
+                        <span style="color:var(--hub-text-muted, #96ACBB);min-width:60px;">Discord</span>
+                        <span style="color:var(--hub-text, #F4EFDD);">{{ lead.discord_handle }}</span>
+                    </div>
+                    {% endif %}
+                </div>
+                {% endif %}
+                {% else %}
+                <p style="font-size:0.875rem;color:var(--hub-text-muted, #96ACBB);margin:0;">
+                    This member has chosen to keep their profile private. Their information is not listed in the member directory.
+                </p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+    {% endif %}
+    {% endwith %}
+```
+
+- [ ] **Step 5: Run the new hub tests to confirm they pass**
+
+```
+pytest tests/hub/guild_pages_spec.py -k "guild_leads_section" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full hub test suite**
+
+```
+pytest tests/hub/ -v --tb=short -q
+```
+
+Expected: All pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hub/views.py templates/hub/guild_detail.html tests/hub/guild_pages_spec.py
+git commit -m "feat(hub): show all guild leads on guild detail page"
+```
+
+---
+
+## Task 5: Script cleanup + version bump
+
+**Files:**
+- Modify: `scripts/generate_fixture.py`
+- Modify: `plfog/version.py`
+
+- [ ] **Step 1: Remove guild_lead from fixture script**
+
+In `scripts/generate_fixture.py`, at line ~652, inside the guild fixture `"fields"` dict, remove the `"guild_lead": None,` line. The guild fields dict should become:
+
+```python
+"fields": {
+    "name": guild_name,
+    "notes": "",
+    "created_at": CREATED_AT,
+},
+```
+
+- [ ] **Step 2: Bump version and add changelog entry**
+
+In `plfog/version.py`, change `VERSION = "1.6.2"` to `VERSION = "1.6.3"` and prepend a new entry to the `CHANGELOG` list:
+
+```python
+{
+    "version": "1.6.3",
+    "date": "2026-04-16",
+    "title": "Multiple Guild Leads",
+    "changes": [
+        "Guilds can now have multiple leads — if your guild has more than one person running it, they all show up on the guild page",
+        "Admins can assign guild leads directly from the member record in the admin panel — just search for guilds in the new Guild Leaderships section",
+        "The guild page now shows a card for each lead, with their name, pronouns, and contact info if they've made their profile public",
+    ],
+},
+```
+
+- [ ] **Step 3: Run the full test suite one final time**
+
+```
+pytest --tb=short -q
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/generate_fixture.py plfog/version.py
+git commit -m "release: 1.6.3 — multiple guild leads"
+```

--- a/docs/superpowers/plans/2026-04-17-viewing-as.md
+++ b/docs/superpowers/plans/2026-04-17-viewing-as.md
@@ -1,0 +1,870 @@
+# "Viewing as" (role preview) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a minimal topbar popover that lets an admin or guild officer toggle which of their roles the hub UI treats them as for the current session — without any schema changes.
+
+**Architecture:** A single helper module (`hub/view_as.py`) exposes a `ViewAs` wrapper class and a `ViewAsMiddleware`. The middleware reads `member.fog_role` + a session list of hidden roles and attaches `request.view_as` to every request. A JSON toggle endpoint writes to the session. The hub `base.html` renders a popover with one checkbox per role the user actually holds, and the existing "Admin View" button is re-gated on `request.view_as.is_admin`. No new models, migrations, or fields.
+
+**Tech Stack:** Django middleware, Django sessions, Alpine.js (already loaded in `base.html`), pytest-describe + factory-boy, existing `.pl-view-switcher` styles in `static/css/hub.css`.
+
+**Coordination note:** The 1.6.3 slot is currently planned for the "Guild leads M2M" work (`docs/superpowers/plans/2026-04-16-guild-leads-m2m.md`). Whichever lands first takes 1.6.3; the other bumps to 1.6.4. This plan assumes 1.6.3 — if M2M lands first, bump this to 1.6.4 in Task 6.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `hub/view_as.py` | Create | `ViewAs` wrapper class, `compute_actual_roles()`, `ViewAsMiddleware`, constants |
+| `hub/views.py` | Modify | Add `view_as_toggle` JSON view |
+| `hub/urls.py` | Modify | Add `view-as/toggle/` route |
+| `plfog/settings.py` | Modify | Register `hub.view_as.ViewAsMiddleware` in `MIDDLEWARE` |
+| `templates/hub/base.html` | Modify | Add popover markup + Alpine component; re-gate Admin View button on `request.view_as.is_admin` |
+| `static/css/hub.css` | Modify | Add `.pl-view-as-popover` styles (popover menu, rows) |
+| `tests/hub/view_as_spec.py` | Create | BDD specs for `compute_actual_roles`, `ViewAs`, middleware, and the toggle endpoint |
+| `plfog/version.py` | Modify | Bump version, add changelog entry |
+
+---
+
+## Design Summary (read this before starting any task)
+
+**Role hierarchy (derived purely from `member.fog_role`):**
+- `fog_role == "admin"` → actual roles `{admin, guild_officer, member}`
+- `fog_role == "guild_officer"` → actual roles `{guild_officer, member}`
+- `fog_role == "member"` → actual roles `{member}`
+- Django `is_superuser` (no Member record or any `fog_role`) → actual roles `{admin, guild_officer, member}`
+- Unauthenticated or no Member → actual roles `{}`
+
+**Session key:** `"view_as_hidden_roles"` → `list[str]` of role names to hide.
+
+**Effective roles:** `actual - hidden`.
+
+**Popover visibility:** only when the user has more than `{member}` actual roles.
+
+**The popover never lets you gain a role you don't have.** It only hides ones you do have. Unknown role names in the session are ignored. Toggling a role you don't hold is rejected server-side (403).
+
+---
+
+## Task 1: `hub/view_as.py` — core logic (no middleware yet)
+
+**Files:**
+- Create: `tests/hub/view_as_spec.py`
+- Create: `hub/view_as.py`
+
+- [ ] **Step 1.1: Write the failing specs for `compute_actual_roles`**
+
+Create `tests/hub/view_as_spec.py`:
+
+```python
+"""BDD specs for the Viewing-as helper."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import AnonymousUser, User
+
+from hub.view_as import ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER, ViewAs, compute_actual_roles
+from membership.models import Member
+from tests.membership.factories import MemberFactory
+
+
+@pytest.mark.django_db
+def describe_compute_actual_roles():
+    def it_returns_empty_frozenset_for_anonymous_user():
+        assert compute_actual_roles(AnonymousUser()) == frozenset()
+
+    def it_returns_empty_frozenset_when_user_has_no_member():
+        user = User.objects.create_user(username="u", password="p")
+        Member.objects.filter(user=user).delete()
+        assert compute_actual_roles(user) == frozenset()
+
+    def it_returns_admin_guild_officer_and_member_for_fog_admin():
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        roles = compute_actual_roles(member.user)
+        assert roles == frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
+
+    def it_returns_guild_officer_and_member_for_fog_officer():
+        member = MemberFactory(fog_role=Member.FogRole.GUILD_OFFICER)
+        roles = compute_actual_roles(member.user)
+        assert roles == frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER})
+
+    def it_returns_only_member_for_regular_members():
+        member = MemberFactory(fog_role=Member.FogRole.MEMBER)
+        assert compute_actual_roles(member.user) == frozenset({ROLE_MEMBER})
+
+    def it_treats_django_superuser_without_member_as_admin():
+        user = User.objects.create_superuser(username="root", email="r@x.com", password="p")
+        Member.objects.filter(user=user).delete()
+        roles = compute_actual_roles(user)
+        assert roles == frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
+```
+
+- [ ] **Step 1.2: Run specs to confirm they fail with ImportError**
+
+Run: `pytest tests/hub/view_as_spec.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'hub.view_as'`.
+
+- [ ] **Step 1.3: Write the minimal `hub/view_as.py`**
+
+Create `hub/view_as.py`:
+
+```python
+"""Session-backed "Viewing as" role preview for the hub.
+
+A Member's *actual* roles are derived from ``member.fog_role``. Any subset
+can be *hidden* for the current session via the topbar popover — hidden role
+names are stored in ``request.session["view_as_hidden_roles"]``.
+
+*Effective* roles = actual − hidden. Every hub-side UI gate and convenience
+check should read ``request.view_as`` (attached by ``ViewAsMiddleware``) so
+the session override is respected uniformly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+    from django.http import HttpRequest
+
+ROLE_MEMBER = "member"
+ROLE_GUILD_OFFICER = "guild_officer"
+ROLE_ADMIN = "admin"
+
+ALL_ROLES: frozenset[str] = frozenset({ROLE_MEMBER, ROLE_GUILD_OFFICER, ROLE_ADMIN})
+
+ROLE_LABELS: tuple[tuple[str, str], ...] = (
+    (ROLE_MEMBER, "Member"),
+    (ROLE_GUILD_OFFICER, "Guild Officer"),
+    (ROLE_ADMIN, "Admin"),
+)
+
+SESSION_HIDDEN_KEY = "view_as_hidden_roles"
+
+
+def compute_actual_roles(user: "AbstractBaseUser | AnonymousUser | None") -> frozenset[str]:
+    """Derive the set of roles a user actually holds.
+
+    Superusers without a linked Member still get the full set so emergency
+    access is never dependent on Member data being correct.
+    """
+    if user is None or not getattr(user, "is_authenticated", False):
+        return frozenset()
+
+    member = getattr(user, "member", None)
+
+    if member is None:
+        if getattr(user, "is_superuser", False):
+            return ALL_ROLES
+        return frozenset()
+
+    from membership.models import Member as MemberModel
+
+    if member.fog_role == MemberModel.FogRole.ADMIN:
+        return frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
+    if member.fog_role == MemberModel.FogRole.GUILD_OFFICER:
+        return frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER})
+    return frozenset({ROLE_MEMBER})
+
+
+def _read_hidden(session) -> frozenset[str]:  # noqa: ANN001 — Django session is untyped
+    raw = session.get(SESSION_HIDDEN_KEY, []) if session is not None else []
+    return frozenset(name for name in raw if name in ALL_ROLES)
+
+
+class ViewAs:
+    """Effective-roles wrapper attached to every request by the middleware."""
+
+    def __init__(self, actual: frozenset[str], hidden: frozenset[str]) -> None:
+        self.actual = actual
+        self.hidden = hidden
+        self.effective = actual - hidden
+
+    def has(self, role: str) -> bool:
+        return role in self.effective
+
+    def has_actual(self, role: str) -> bool:
+        """Check the *actual* set, ignoring session overrides — used by the popover."""
+        return role in self.actual
+
+    @property
+    def is_admin(self) -> bool:
+        return self.has(ROLE_ADMIN)
+
+    @property
+    def is_guild_officer(self) -> bool:
+        return self.has(ROLE_GUILD_OFFICER)
+
+    @property
+    def is_member(self) -> bool:
+        return self.has(ROLE_MEMBER)
+
+    @property
+    def show_popover(self) -> bool:
+        """Only users with more than the base ``member`` role see the popover."""
+        return len(self.actual - {ROLE_MEMBER}) > 0
+
+    @property
+    def popover_rows(self) -> list[dict[str, object]]:
+        """Ordered ``{name, label, active}`` dicts for the popover UI."""
+        return [
+            {"name": name, "label": label, "active": name not in self.hidden}
+            for name, label in ROLE_LABELS
+            if name in self.actual
+        ]
+
+    @classmethod
+    def for_request(cls, request: "HttpRequest") -> "ViewAs":
+        actual = compute_actual_roles(request.user)
+        hidden = _read_hidden(getattr(request, "session", None))
+        return cls(actual=actual, hidden=hidden)
+```
+
+- [ ] **Step 1.4: Run specs to confirm they pass**
+
+Run: `pytest tests/hub/view_as_spec.py::describe_compute_actual_roles -v`
+Expected: all pass.
+
+- [ ] **Step 1.5: Add `ViewAs` wrapper specs**
+
+Append to `tests/hub/view_as_spec.py`:
+
+```python
+def describe_ViewAs():
+    def it_marks_has_true_only_for_effective_roles():
+        v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_MEMBER}), hidden=frozenset({ROLE_ADMIN}))
+        assert v.has(ROLE_ADMIN) is False
+        assert v.has(ROLE_MEMBER) is True
+
+    def it_has_actual_ignores_hidden():
+        v = ViewAs(actual=frozenset({ROLE_ADMIN}), hidden=frozenset({ROLE_ADMIN}))
+        assert v.has_actual(ROLE_ADMIN) is True
+        assert v.has(ROLE_ADMIN) is False
+
+    def it_exposes_convenience_properties():
+        v = ViewAs(
+            actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}),
+            hidden=frozenset({ROLE_ADMIN}),
+        )
+        assert v.is_admin is False
+        assert v.is_guild_officer is True
+        assert v.is_member is True
+
+    def describe_show_popover():
+        def it_is_true_for_admins():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
+            assert v.show_popover is True
+
+        def it_is_true_for_guild_officers():
+            v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
+            assert v.show_popover is True
+
+        def it_is_false_for_plain_members():
+            v = ViewAs(actual=frozenset({ROLE_MEMBER}), hidden=frozenset())
+            assert v.show_popover is False
+
+        def it_is_false_for_unauthenticated():
+            v = ViewAs(actual=frozenset(), hidden=frozenset())
+            assert v.show_popover is False
+
+    def describe_popover_rows():
+        def it_lists_rows_in_display_order_with_active_flags():
+            v = ViewAs(
+                actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}),
+                hidden=frozenset({ROLE_ADMIN}),
+            )
+            assert v.popover_rows == [
+                {"name": ROLE_MEMBER, "label": "Member", "active": True},
+                {"name": ROLE_GUILD_OFFICER, "label": "Guild Officer", "active": True},
+                {"name": ROLE_ADMIN, "label": "Admin", "active": False},
+            ]
+
+        def it_skips_roles_not_actually_held():
+            v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
+            names = [row["name"] for row in v.popover_rows]
+            assert names == [ROLE_MEMBER, ROLE_GUILD_OFFICER]
+```
+
+- [ ] **Step 1.6: Run and confirm pass**
+
+Run: `pytest tests/hub/view_as_spec.py -v`
+Expected: all pass.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add hub/view_as.py tests/hub/view_as_spec.py
+git commit -m "feat(hub): add view_as role-preview helper module"
+```
+
+---
+
+## Task 2: `ViewAsMiddleware` — attach `request.view_as`
+
+**Files:**
+- Modify: `hub/view_as.py` (append `ViewAsMiddleware`)
+- Modify: `plfog/settings.py` (register middleware)
+- Modify: `tests/hub/view_as_spec.py` (add middleware specs)
+
+- [ ] **Step 2.1: Write the failing middleware spec**
+
+Append to `tests/hub/view_as_spec.py`:
+
+```python
+from django.test import RequestFactory
+
+from hub.view_as import ViewAsMiddleware
+
+
+@pytest.mark.django_db
+def describe_ViewAsMiddleware():
+    def it_attaches_view_as_to_request(rf: RequestFactory):
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        request = rf.get("/")
+        request.user = member.user
+        request.session = {}
+
+        captured: dict[str, object] = {}
+
+        def get_response(req):
+            captured["view_as"] = req.view_as
+            return "ok"
+
+        ViewAsMiddleware(get_response)(request)
+
+        assert captured["view_as"].is_admin is True
+        assert captured["view_as"].actual == frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
+
+    def it_respects_hidden_roles_in_session(rf: RequestFactory):
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        request = rf.get("/")
+        request.user = member.user
+        request.session = {"view_as_hidden_roles": ["admin"]}
+
+        captured: dict[str, object] = {}
+
+        def get_response(req):
+            captured["view_as"] = req.view_as
+            return "ok"
+
+        ViewAsMiddleware(get_response)(request)
+
+        assert captured["view_as"].is_admin is False
+        assert captured["view_as"].is_guild_officer is True
+```
+
+Add this fixture to the top of the file (after imports):
+
+```python
+@pytest.fixture
+def rf() -> RequestFactory:
+    return RequestFactory()
+```
+
+- [ ] **Step 2.2: Run and confirm ImportError**
+
+Run: `pytest tests/hub/view_as_spec.py::describe_ViewAsMiddleware -v`
+Expected: FAIL with `ImportError: cannot import name 'ViewAsMiddleware'`.
+
+- [ ] **Step 2.3: Implement the middleware**
+
+Append to `hub/view_as.py`:
+
+```python
+class ViewAsMiddleware:
+    """Attach ``request.view_as`` to every request.
+
+    Must run after ``AuthenticationMiddleware`` (needs ``request.user``)
+    and ``SessionMiddleware`` (needs ``request.session``).
+    """
+
+    def __init__(self, get_response) -> None:  # noqa: ANN001
+        self.get_response = get_response
+
+    def __call__(self, request: "HttpRequest"):
+        request.view_as = ViewAs.for_request(request)
+        return self.get_response(request)
+```
+
+- [ ] **Step 2.4: Run and confirm pass**
+
+Run: `pytest tests/hub/view_as_spec.py -v`
+Expected: all pass.
+
+- [ ] **Step 2.5: Register middleware in settings**
+
+In `plfog/settings.py`, add `"hub.view_as.ViewAsMiddleware"` to `MIDDLEWARE` immediately after `"allauth.account.middleware.AccountMiddleware"`:
+
+```python
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
+    "hub.view_as.ViewAsMiddleware",
+    "plfog.service_worker_middleware.ServiceWorkerAllowedMiddleware",
+]
+```
+
+- [ ] **Step 2.6: Smoke-test through a real view**
+
+Run: `pytest tests/hub/ -v -k "views_spec"`
+Expected: existing hub view specs all still pass (middleware must not break them).
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add hub/view_as.py plfog/settings.py tests/hub/view_as_spec.py
+git commit -m "feat(hub): wire ViewAsMiddleware and attach request.view_as"
+```
+
+---
+
+## Task 3: Toggle endpoint
+
+**Files:**
+- Modify: `hub/urls.py`
+- Modify: `hub/views.py`
+- Modify: `tests/hub/view_as_spec.py`
+
+- [ ] **Step 3.1: Write the failing endpoint specs**
+
+Append to `tests/hub/view_as_spec.py`:
+
+```python
+import json
+
+from django.test import Client
+
+
+@pytest.mark.django_db
+def describe_view_as_toggle_endpoint():
+    def it_adds_role_to_hidden_set(client: Client):
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        member.user.set_password("p")
+        member.user.save()
+        client.login(username=member.user.username, password="p")
+
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "admin", "hidden": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"hidden": ["admin"]}
+        assert client.session["view_as_hidden_roles"] == ["admin"]
+
+    def it_removes_role_when_hidden_is_false(client: Client):
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        member.user.set_password("p")
+        member.user.save()
+        client.login(username=member.user.username, password="p")
+        session = client.session
+        session["view_as_hidden_roles"] = ["admin", "guild_officer"]
+        session.save()
+
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "admin", "hidden": False}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"hidden": ["guild_officer"]}
+
+    def it_rejects_unknown_role_names(client: Client):
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        member.user.set_password("p")
+        member.user.save()
+        client.login(username=member.user.username, password="p")
+
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "wizard", "hidden": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+
+    def it_rejects_toggling_a_role_the_user_does_not_hold(client: Client):
+        member = MemberFactory(fog_role=Member.FogRole.MEMBER)
+        member.user.set_password("p")
+        member.user.save()
+        client.login(username=member.user.username, password="p")
+
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "admin", "hidden": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+
+    def it_rejects_malformed_json(client: Client):
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        member.user.set_password("p")
+        member.user.save()
+        client.login(username=member.user.username, password="p")
+
+        response = client.post("/view-as/toggle/", data=b"not json", content_type="application/json")
+
+        assert response.status_code == 400
+
+    def it_requires_login(client: Client):
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "admin", "hidden": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code in (302, 401, 403)  # redirect to login or deny
+```
+
+- [ ] **Step 3.2: Run and confirm fail**
+
+Run: `pytest tests/hub/view_as_spec.py::describe_view_as_toggle_endpoint -v`
+Expected: FAIL with 404 from the URL resolver.
+
+- [ ] **Step 3.3: Add the toggle view**
+
+Append to `hub/views.py` (below the existing imports and other views):
+
+```python
+import json
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpRequest, JsonResponse
+from django.views.decorators.http import require_POST
+
+from hub.view_as import ALL_ROLES, SESSION_HIDDEN_KEY
+
+
+@require_POST
+@login_required
+def view_as_toggle(request: HttpRequest) -> JsonResponse:
+    """Add or remove a role from the session-hidden set.
+
+    Body: ``{"role": "admin", "hidden": true}``. Unknown role names and
+    roles the user does not actually hold are rejected so the session
+    can never carry junk or grant privileges.
+    """
+    try:
+        payload = json.loads(request.body or b"{}")
+        role = payload["role"]
+        hidden = bool(payload["hidden"])
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return JsonResponse({"error": "Invalid request"}, status=400)
+
+    if role not in ALL_ROLES:
+        return JsonResponse({"error": f"Unknown role '{role}'"}, status=400)
+
+    if not request.view_as.has_actual(role):
+        return JsonResponse({"error": "Cannot toggle a role you don't have"}, status=403)
+
+    current = set(request.session.get(SESSION_HIDDEN_KEY, []))
+    if hidden:
+        current.add(role)
+    else:
+        current.discard(role)
+    request.session[SESSION_HIDDEN_KEY] = sorted(current)
+
+    return JsonResponse({"hidden": sorted(current)})
+```
+
+(If `json` and the other imports are already present at the top of `hub/views.py`, don't duplicate them — move them up with the existing imports instead.)
+
+- [ ] **Step 3.4: Add the URL route**
+
+In `hub/urls.py`, add to `urlpatterns`:
+
+```python
+path("view-as/toggle/", views.view_as_toggle, name="hub_view_as_toggle"),
+```
+
+- [ ] **Step 3.5: Run and confirm pass**
+
+Run: `pytest tests/hub/view_as_spec.py -v`
+Expected: all pass.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add hub/views.py hub/urls.py tests/hub/view_as_spec.py
+git commit -m "feat(hub): add view-as toggle endpoint"
+```
+
+---
+
+## Task 4: Topbar popover UI
+
+**Files:**
+- Modify: `templates/hub/base.html`
+- Modify: `static/css/hub.css`
+
+- [ ] **Step 4.1: Add the popover markup**
+
+In `templates/hub/base.html`, locate the topbar block that contains the current `{% if user.is_staff %}` Admin View button (around line 165–172 on main). Replace that block with:
+
+```html
+{% if request.view_as.is_admin %}
+<span class="pl-topbar__divider"></span>
+<a href="{% url 'admin:index' %}" class="pl-view-switcher" hx-boost="false" title="Switch to Admin View">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+    Admin View
+</a>
+{% endif %}
+{% if request.view_as.show_popover %}
+<span class="pl-topbar__divider"></span>
+<div class="pl-view-as-popover"
+     x-data="viewAsPopover()"
+     @keydown.escape.window="if (open) { open = false; $el.querySelector('button').focus() }">
+    <button type="button" class="pl-view-switcher" @click="open = !open" :aria-expanded="open" title="Viewing as">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+            <circle cx="12" cy="12" r="3"/>
+        </svg>
+        Viewing as
+    </button>
+    <div class="pl-view-as-popover__menu" x-show="open" x-transition @click.away="open = false" role="menu">
+        <div class="pl-view-as-popover__header">Show controls for</div>
+        {% for row in request.view_as.popover_rows %}
+        <label class="pl-view-as-popover__row">
+            <input type="checkbox"
+                   value="{{ row.name }}"
+                   {% if row.active %}checked{% endif %}
+                   @change="toggle($event.target.value, !$event.target.checked)">
+            <span>{{ row.label }}</span>
+        </label>
+        {% endfor %}
+        <div class="pl-view-as-popover__hint">Unchecking hides that role's UI for this session.</div>
+    </div>
+</div>
+{% endif %}
+```
+
+Note the old `{% if user.is_staff %}` guard is now `{% if request.view_as.is_admin %}` — this gates the Admin View button on the toggle.
+
+- [ ] **Step 4.2: Add the Alpine component**
+
+Still in `templates/hub/base.html`, find the existing inline `<script>` block that registers other Alpine components (near the bottom of the file). If one exists, append the function below inside it. Otherwise add a new `<script>` block just before `</body>`:
+
+```html
+<script>
+    function viewAsPopover() {
+        return {
+            open: false,
+            async toggle(role, hidden) {
+                const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value
+                    || document.cookie.split('; ').find(c => c.startsWith('csrftoken='))?.split('=')[1];
+                const response = await fetch("{% url 'hub_view_as_toggle' %}", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-CSRFToken": csrfToken || "",
+                    },
+                    body: JSON.stringify({ role, hidden }),
+                });
+                if (response.ok) {
+                    window.location.reload();
+                }
+            },
+        };
+    }
+</script>
+```
+
+A full reload keeps the implementation trivial — no need to surgically re-render every gated region.
+
+- [ ] **Step 4.3: Add popover styles**
+
+Append to `static/css/hub.css`:
+
+```css
+/* Viewing-as popover */
+.pl-view-as-popover {
+    position: relative;
+}
+
+.pl-view-as-popover__menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    min-width: 200px;
+    background: var(--pl-surface-1, #0f1a2a);
+    border: 1px solid var(--pl-border, rgba(255, 255, 255, 0.08));
+    border-radius: 8px;
+    padding: 8px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    z-index: 50;
+}
+
+.pl-view-as-popover__header {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.6;
+    padding: 4px 8px 8px;
+}
+
+.pl-view-as-popover__row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.pl-view-as-popover__row:hover {
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.pl-view-as-popover__hint {
+    font-size: 11px;
+    opacity: 0.55;
+    padding: 8px;
+    border-top: 1px solid var(--pl-border, rgba(255, 255, 255, 0.08));
+    margin-top: 4px;
+}
+```
+
+If the codebase has newer design tokens in `hub.css`, swap `var(--pl-surface-1, ...)` / `var(--pl-border, ...)` to match. The fallback values in the `var(...)` calls keep it working either way.
+
+- [ ] **Step 4.4: Write a template-integration spec**
+
+Append to `tests/hub/view_as_spec.py`:
+
+```python
+@pytest.mark.django_db
+def describe_popover_in_hub_template():
+    def it_renders_popover_for_admins(client: Client):
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        member.user.set_password("p")
+        member.user.save()
+        client.login(username=member.user.username, password="p")
+
+        response = client.get("/guilds/voting/")
+
+        assert response.status_code == 200
+        assert b"pl-view-as-popover" in response.content
+        assert b"Viewing as" in response.content
+
+    def it_hides_popover_for_plain_members(client: Client):
+        member = MemberFactory(fog_role=Member.FogRole.MEMBER)
+        member.user.set_password("p")
+        member.user.save()
+        client.login(username=member.user.username, password="p")
+
+        response = client.get("/guilds/voting/")
+
+        assert response.status_code == 200
+        assert b"pl-view-as-popover" not in response.content
+
+    def it_hides_admin_view_button_when_admin_role_is_hidden(client: Client):
+        member = MemberFactory(fog_role=Member.FogRole.ADMIN)
+        member.user.set_password("p")
+        member.user.save()
+        client.login(username=member.user.username, password="p")
+        session = client.session
+        session["view_as_hidden_roles"] = ["admin"]
+        session.save()
+
+        response = client.get("/guilds/voting/")
+
+        assert b"Admin View" not in response.content
+```
+
+- [ ] **Step 4.5: Run all view_as specs**
+
+Run: `pytest tests/hub/view_as_spec.py -v`
+Expected: all pass.
+
+- [ ] **Step 4.6: Manual smoke-test**
+
+Run: `python manage.py runserver` and log in as an admin. Confirm:
+- "Viewing as" button appears in the topbar next to "Admin View".
+- Clicking it opens a popover with three checkboxes (Admin, Guild Officer, Member).
+- Unchecking "Admin" reloads the page and the "Admin View" button disappears.
+- Re-checking "Admin" brings it back.
+
+Log in as a plain member and confirm no popover appears.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add templates/hub/base.html static/css/hub.css tests/hub/view_as_spec.py
+git commit -m "feat(hub): add Viewing-as popover in topbar"
+```
+
+---
+
+## Task 5: Version bump + changelog
+
+**Files:**
+- Modify: `plfog/version.py`
+
+- [ ] **Step 5.1: Bump version and prepend changelog entry**
+
+In `plfog/version.py`, change `VERSION = "1.6.2"` to `VERSION = "1.6.3"` (or `"1.6.4"` if the guild-leads M2M already landed on main at 1.6.3 — check `git log` first).
+
+Prepend to the `CHANGELOG` list:
+
+```python
+{
+    "version": "1.6.3",
+    "date": "2026-04-17",
+    "title": "Admin role preview in the hub",
+    "changes": [
+        "Admins and guild officers now have a new \"Viewing as\" button in the topbar — use it to preview the hub the way a plain member or guild officer would see it, without logging out. Unchecking a role hides that role's UI for the current session only.",
+    ],
+},
+```
+
+- [ ] **Step 5.2: Run the full test suite**
+
+Run: `pytest`
+Expected: all pass.
+
+- [ ] **Step 5.3: Lint + format**
+
+Run: `ruff format . && ruff check --fix .`
+Expected: clean output.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add plfog/version.py
+git commit -m "chore: bump to 1.6.3 (Viewing-as feature)"
+```
+
+---
+
+## Out of scope (intentional)
+
+These are *not* part of this plan — keep them for follow-ups so the change stays tight:
+
+- Re-gating guild edit affordances (the edit button on `guild_detail.html`) on `request.view_as.is_guild_officer`. Requires threading `view_as` into `Member.can_edit_guild()` or doing the check inline in the template. Add in a follow-up PR once the popover scaffolding lands.
+- A Django template tag (`{% if view_as.is_admin %}` sugar). The `request.view_as.*` access in templates is fine — no sugar needed yet.
+- Per-guild scoping. If guild officers end up needing a separate "view as officer of guild X" mode, that's a separate design — current plan treats guild_officer as a global flag, matching `fog_role`.
+- Animations / transitions beyond Alpine's default `x-transition`.
+
+---
+
+## Self-review checklist
+
+- [x] Every role name used in specs (`admin`, `guild_officer`, `member`) matches `ROLE_*` constants in `hub/view_as.py`.
+- [x] Every URL used in specs (`/view-as/toggle/`) matches the route added in Task 3.
+- [x] Every template class name (`pl-view-as-popover`, `pl-view-as-popover__menu`, etc.) matches the CSS added in Task 4.3.
+- [x] Session key `view_as_hidden_roles` is used consistently in the module, tests, and template checks.
+- [x] Middleware is registered after `AuthenticationMiddleware` and `SessionMiddleware`, and before the service-worker middleware.
+- [x] Version bump + changelog entry uses member-friendly language (no PR numbers, no commit hashes).
+- [x] No placeholders, no "TBD", no "implement error handling" — every step has the full code.

--- a/docs/superpowers/specs/2026-04-16-guild-leads-m2m-design.md
+++ b/docs/superpowers/specs/2026-04-16-guild-leads-m2m-design.md
@@ -1,0 +1,112 @@
+# Guild Leads M2M — Design Spec
+**Version:** 1.6.3
+**Date:** 2026-04-16
+
+## Overview
+
+Replace the single `Guild.guild_lead` ForeignKey with a many-to-many relationship so multiple members can lead the same guild. The assignment UI lives on the Member admin change page. The hub guild detail page is updated to display all leads.
+
+---
+
+## 1. Data Model
+
+### Remove
+`Guild.guild_lead = ForeignKey(Member, null=True, blank=True, on_delete=SET_NULL, related_name="led_guilds")`
+
+### Add
+```python
+# On Member model
+guild_leaderships = models.ManyToManyField(
+    "Guild",
+    blank=True,
+    related_name="guild_leads",
+    help_text="Guilds this member leads.",
+)
+```
+
+Django auto-creates the junction table `membership_member_guild_leaderships (member_id, guild_id)`.
+
+### Migration sequence (single migration file)
+1. Add `Member.guild_leaderships` M2M field
+2. Data migration: for each `Guild` where `guild_lead_id` is not null, insert a row into the new junction table
+3. Remove `Guild.guild_lead` FK
+
+### `can_edit_guild` update
+```python
+# Before
+return self.is_fog_admin or self.is_guild_officer or guild.guild_lead_id == self.pk
+
+# After
+return self.is_fog_admin or self.is_guild_officer or self.guild_leaderships.filter(pk=guild.pk).exists()
+```
+
+---
+
+## 2. Member Admin Change Page
+
+Add a "Guild Leaderships" fieldset to `MemberAdmin` using Django's built-in `filter_horizontal` widget.
+
+```python
+class MemberAdmin(ModelAdmin):
+    filter_horizontal = ["guild_leaderships"]
+
+    def get_fieldsets(self, ...):
+        # ... existing fieldsets ...
+        # Append at the bottom:
+        (
+            "Guild Leaderships",
+            {"fields": ["guild_leaderships"]},
+        ),
+```
+
+No custom form code needed — `guild_leaderships` is a standard M2M on `Member` so Django admin renders it natively as a dual-list widget with search.
+
+---
+
+## 3. Hub Guild Detail Template
+
+### View (`hub/views.py`)
+Add `prefetch_related("guild_leads")` to the guild queryset in `guild_detail` to avoid N+1 queries.
+
+### Template (`templates/hub/guild_detail.html`)
+Replace single-lead block:
+```django
+{% if guild.guild_lead %} ... {{ guild.guild_lead.display_name }} ... {% endif %}
+```
+
+With a loop:
+```django
+{% with leads=guild.guild_leads.all %}
+{% if leads %}
+  <h3>Guild Lead{% if leads|length > 1 %}s{% endif %}</h3>
+  {% for lead in leads %}
+    {# existing profile card content, replacing guild.guild_lead with lead #}
+  {% endfor %}
+{% endif %}
+{% endwith %}
+```
+
+---
+
+## 4. Tests
+
+All existing tests that use `GuildFactory(guild_lead=member)` must be updated:
+- Replace with `guild = GuildFactory(); guild.guild_leads.add(member)`
+- Or add a `guild_leads` post-generation hook to `GuildFactory`
+
+`can_edit_guild` tests updated to use the new M2M approach.
+
+New tests cover:
+- A guild with zero leads shows no lead section
+- A guild with one lead shows "Guild Lead"
+- A guild with multiple leads shows "Guild Leads" (plural)
+- `can_edit_guild` returns True when the member is in `guild_leaderships`
+- Member admin fieldset renders `guild_leaderships`
+
+---
+
+## 5. Out of Scope
+
+- GuildEditForm on the hub page (name/about/calendar) — no changes needed
+- Airtable sync — `guild_lead` in `airtable_sync/config.py` refers to `member_type`, not the FK; no sync changes needed
+- Guild admin (Guild is excluded from Django admin since v1.6.0)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -46,4 +46,5 @@ urlpatterns = [
     path("calendar/", views.community_calendar, name="hub_community_calendar"),
     path("calendar/events/", views.calendar_events_partial, name="hub_community_calendar_events"),
     path("calendar/export.ics", views.calendar_export_ics, name="hub_calendar_export_ics"),
+    path("view-as/toggle/", views.view_as_toggle, name="hub_view_as_toggle"),
 ]

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -46,5 +46,5 @@ urlpatterns = [
     path("calendar/", views.community_calendar, name="hub_community_calendar"),
     path("calendar/events/", views.calendar_events_partial, name="hub_community_calendar_events"),
     path("calendar/export.ics", views.calendar_export_ics, name="hub_calendar_export_ics"),
-    path("view-as/toggle/", views.view_as_toggle, name="hub_view_as_toggle"),
+    path("view-as/set/", views.view_as_set, name="hub_view_as_set"),
 ]

--- a/hub/view_as.py
+++ b/hub/view_as.py
@@ -44,7 +44,7 @@ def compute_actual_roles(user: "AbstractBaseUser | AnonymousUser | None") -> fro
     from membership.models import Member as MemberModel
 
     try:
-        member = user.member
+        member = user.member  # type: ignore[union-attr]
     except MemberModel.DoesNotExist:
         member = None
 
@@ -124,5 +124,5 @@ class ViewAsMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: "HttpRequest"):
-        request.view_as = ViewAs.for_request(request)
+        request.view_as = ViewAs.for_request(request)  # type: ignore[attr-defined]
         return self.get_response(request)

--- a/hub/view_as.py
+++ b/hub/view_as.py
@@ -1,0 +1,113 @@
+"""Session-backed "Viewing as" role preview for the hub.
+
+A Member's *actual* roles are derived from ``member.fog_role``. Any subset
+can be *hidden* for the current session via the topbar popover — hidden role
+names are stored in ``request.session["view_as_hidden_roles"]``.
+
+*Effective* roles = actual − hidden. Every hub-side UI gate and convenience
+check should read ``request.view_as`` (attached by ``ViewAsMiddleware``) so
+the session override is respected uniformly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+    from django.http import HttpRequest
+
+ROLE_MEMBER = "member"
+ROLE_GUILD_OFFICER = "guild_officer"
+ROLE_ADMIN = "admin"
+
+ALL_ROLES: frozenset[str] = frozenset({ROLE_MEMBER, ROLE_GUILD_OFFICER, ROLE_ADMIN})
+
+ROLE_LABELS: tuple[tuple[str, str], ...] = (
+    (ROLE_MEMBER, "Member"),
+    (ROLE_GUILD_OFFICER, "Guild Officer"),
+    (ROLE_ADMIN, "Admin"),
+)
+
+SESSION_HIDDEN_KEY = "view_as_hidden_roles"
+
+
+def compute_actual_roles(user: "AbstractBaseUser | AnonymousUser | None") -> frozenset[str]:
+    """Derive the set of roles a user actually holds.
+
+    Superusers without a linked Member still get the full set so emergency
+    access is never dependent on Member data being correct.
+    """
+    if user is None or not getattr(user, "is_authenticated", False):
+        return frozenset()
+
+    from membership.models import Member as MemberModel
+
+    try:
+        member = user.member
+    except MemberModel.DoesNotExist:
+        member = None
+
+    if member is None:
+        if getattr(user, "is_superuser", False):
+            return ALL_ROLES
+        return frozenset()
+
+    if member.fog_role == MemberModel.FogRole.ADMIN:
+        return frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
+    if member.fog_role == MemberModel.FogRole.GUILD_OFFICER:
+        return frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER})
+    return frozenset({ROLE_MEMBER})
+
+
+def _read_hidden(session) -> frozenset[str]:  # noqa: ANN001 — Django session is untyped
+    raw = session.get(SESSION_HIDDEN_KEY, []) if session is not None else []
+    return frozenset(name for name in raw if name in ALL_ROLES)
+
+
+class ViewAs:
+    """Effective-roles wrapper attached to every request by the middleware."""
+
+    def __init__(self, actual: frozenset[str], hidden: frozenset[str]) -> None:
+        self.actual = actual
+        self.hidden = hidden
+        self.effective = actual - hidden
+
+    def has(self, role: str) -> bool:
+        return role in self.effective
+
+    def has_actual(self, role: str) -> bool:
+        """Check the *actual* set, ignoring session overrides — used by the popover."""
+        return role in self.actual
+
+    @property
+    def is_admin(self) -> bool:
+        return self.has(ROLE_ADMIN)
+
+    @property
+    def is_guild_officer(self) -> bool:
+        return self.has(ROLE_GUILD_OFFICER)
+
+    @property
+    def is_member(self) -> bool:
+        return self.has(ROLE_MEMBER)
+
+    @property
+    def show_popover(self) -> bool:
+        """Only users with more than the base ``member`` role see the popover."""
+        return len(self.actual - {ROLE_MEMBER}) > 0
+
+    @property
+    def popover_rows(self) -> list[dict[str, object]]:
+        """Ordered ``{name, label, active}`` dicts for the popover UI."""
+        return [
+            {"name": name, "label": label, "active": name not in self.hidden}
+            for name, label in ROLE_LABELS
+            if name in self.actual
+        ]
+
+    @classmethod
+    def for_request(cls, request: "HttpRequest") -> "ViewAs":
+        actual = compute_actual_roles(request.user)
+        hidden = _read_hidden(getattr(request, "session", None))
+        return cls(actual=actual, hidden=hidden)

--- a/hub/view_as.py
+++ b/hub/view_as.py
@@ -111,3 +111,18 @@ class ViewAs:
         actual = compute_actual_roles(request.user)
         hidden = _read_hidden(getattr(request, "session", None))
         return cls(actual=actual, hidden=hidden)
+
+
+class ViewAsMiddleware:
+    """Attach ``request.view_as`` to every request.
+
+    Must run after ``AuthenticationMiddleware`` (needs ``request.user``)
+    and ``SessionMiddleware`` (needs ``request.session``).
+    """
+
+    def __init__(self, get_response) -> None:  # noqa: ANN001
+        self.get_response = get_response
+
+    def __call__(self, request: "HttpRequest"):
+        request.view_as = ViewAs.for_request(request)
+        return self.get_response(request)

--- a/hub/view_as.py
+++ b/hub/view_as.py
@@ -1,12 +1,16 @@
 """Session-backed "Viewing as" role preview for the hub.
 
-A Member's *actual* roles are derived from ``member.fog_role``. Any subset
-can be *hidden* for the current session via the topbar popover — hidden role
-names are stored in ``request.session["view_as_hidden_roles"]``.
+A Member's *actual* roles are derived from ``member.fog_role``. Admins can
+pick a *view-as* role via the topbar dropdown — the picked role name is
+stored in ``request.session["view_as_role"]``.
 
-*Effective* roles = actual − hidden. Every hub-side UI gate and convenience
-check should read ``request.view_as`` (attached by ``ViewAsMiddleware``) so
-the session override is respected uniformly.
+Roles are a linear hierarchy: admin > guild_officer > member. Effective
+roles are every role from the user's actual set that sits at or below the
+picked role. When no role is picked (or the picked role is the user's
+highest), effective == actual.
+
+Every hub-side UI gate should read ``request.view_as`` (attached by
+``ViewAsMiddleware``) so the session override is respected uniformly.
 """
 
 from __future__ import annotations
@@ -23,13 +27,15 @@ ROLE_ADMIN = "admin"
 
 ALL_ROLES: frozenset[str] = frozenset({ROLE_MEMBER, ROLE_GUILD_OFFICER, ROLE_ADMIN})
 
+ROLE_HIERARCHY: tuple[str, ...] = (ROLE_MEMBER, ROLE_GUILD_OFFICER, ROLE_ADMIN)
+
 ROLE_LABELS: tuple[tuple[str, str], ...] = (
-    (ROLE_MEMBER, "Member"),
-    (ROLE_GUILD_OFFICER, "Guild Officer"),
     (ROLE_ADMIN, "Admin"),
+    (ROLE_GUILD_OFFICER, "Guild Officer"),
+    (ROLE_MEMBER, "Member"),
 )
 
-SESSION_HIDDEN_KEY = "view_as_hidden_roles"
+SESSION_ROLE_KEY = "view_as_role"
 
 
 def compute_actual_roles(user: "AbstractBaseUser | AnonymousUser | None") -> frozenset[str]:
@@ -60,24 +66,40 @@ def compute_actual_roles(user: "AbstractBaseUser | AnonymousUser | None") -> fro
     return frozenset({ROLE_MEMBER})
 
 
-def _read_hidden(session) -> frozenset[str]:  # noqa: ANN001 — Django session is untyped
-    raw = session.get(SESSION_HIDDEN_KEY, []) if session is not None else []
-    return frozenset(name for name in raw if name in ALL_ROLES)
+def _highest_role(actual: frozenset[str]) -> str | None:
+    for role in reversed(ROLE_HIERARCHY):
+        if role in actual:
+            return role
+    return None
+
+
+def _roles_up_to(picked: str, actual: frozenset[str]) -> frozenset[str]:
+    """Return the subset of ``actual`` at or below ``picked`` in the hierarchy."""
+    idx = ROLE_HIERARCHY.index(picked)
+    allowed = frozenset(ROLE_HIERARCHY[: idx + 1])
+    return actual & allowed
+
+
+def _read_picked_role(session, actual: frozenset[str]) -> str | None:  # noqa: ANN001 — Django session is untyped
+    raw = session.get(SESSION_ROLE_KEY) if session is not None else None
+    if raw in actual:
+        return raw
+    return None
 
 
 class ViewAs:
-    """Effective-roles wrapper attached to every request by the middleware."""
+    """Effective-role wrapper attached to every request by the middleware."""
 
-    def __init__(self, actual: frozenset[str], hidden: frozenset[str]) -> None:
+    def __init__(self, actual: frozenset[str], picked: str | None) -> None:
         self.actual = actual
-        self.hidden = hidden
-        self.effective = actual - hidden
+        self.view_as_role = picked or _highest_role(actual)
+        self.effective = _roles_up_to(self.view_as_role, actual) if self.view_as_role else frozenset()
 
     def has(self, role: str) -> bool:
         return role in self.effective
 
     def has_actual(self, role: str) -> bool:
-        """Check the *actual* set, ignoring session overrides — used by the popover."""
+        """Check the *actual* set, ignoring session overrides — used by the dropdown."""
         return role in self.actual
 
     @property
@@ -93,15 +115,23 @@ class ViewAs:
         return self.has(ROLE_MEMBER)
 
     @property
-    def show_popover(self) -> bool:
-        """Only users with more than the base ``member`` role see the popover."""
+    def show_dropdown(self) -> bool:
+        """Only users with more than the base ``member`` role see the dropdown."""
         return len(self.actual - {ROLE_MEMBER}) > 0
 
     @property
-    def popover_rows(self) -> list[dict[str, object]]:
-        """Ordered ``{name, label, active}`` dicts for the popover UI."""
+    def current_label(self) -> str:
+        """Human label for the currently-viewed role."""
+        for name, label in ROLE_LABELS:
+            if name == self.view_as_role:
+                return label
+        return ""
+
+    @property
+    def dropdown_options(self) -> list[dict[str, object]]:
+        """Ordered ``{name, label, selected}`` dicts for the dropdown menu — highest role first."""
         return [
-            {"name": name, "label": label, "active": name not in self.hidden}
+            {"name": name, "label": label, "selected": name == self.view_as_role}
             for name, label in ROLE_LABELS
             if name in self.actual
         ]
@@ -109,8 +139,8 @@ class ViewAs:
     @classmethod
     def for_request(cls, request: "HttpRequest") -> "ViewAs":
         actual = compute_actual_roles(request.user)
-        hidden = _read_hidden(getattr(request, "session", None))
-        return cls(actual=actual, hidden=hidden)
+        picked = _read_picked_role(getattr(request, "session", None), actual)
+        return cls(actual=actual, picked=picked)
 
 
 class ViewAsMiddleware:

--- a/hub/views.py
+++ b/hub/views.py
@@ -21,6 +21,7 @@ from billing.exceptions import NoPaymentMethodError, TabLimitExceededError, TabL
 from billing.models import BillingSettings, Tab, TabCharge
 from hub.calendar_service import refresh_stale_sources
 from hub.forms import BetaFeedbackForm, EmailPreferencesForm, GuildEditForm, ProfileSettingsForm, VotePreferenceForm
+from hub.view_as import ALL_ROLES, SESSION_HIDDEN_KEY
 from membership.cycle import get_cycle_context
 from membership.models import FundingSnapshot, Guild, Member, VotePreference
 
@@ -927,3 +928,35 @@ def calendar_export_ics(request: HttpRequest) -> HttpResponse:
     response = HttpResponse(ical_content, content_type="text/calendar; charset=utf-8")
     response["Content-Disposition"] = 'attachment; filename="past-lives-calendar.ics"'
     return response
+
+
+@require_POST
+@login_required
+def view_as_toggle(request: HttpRequest) -> JsonResponse:
+    """Add or remove a role from the session-hidden set.
+
+    Body: ``{"role": "admin", "hidden": true}``. Unknown role names and
+    roles the user does not actually hold are rejected so the session
+    can never carry junk or grant privileges.
+    """
+    try:
+        payload = json.loads(request.body or b"{}")
+        role = payload["role"]
+        hidden = bool(payload["hidden"])
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return JsonResponse({"error": "Invalid request"}, status=400)
+
+    if role not in ALL_ROLES:
+        return JsonResponse({"error": f"Unknown role '{role}'"}, status=400)
+
+    if not request.view_as.has_actual(role):
+        return JsonResponse({"error": "Cannot toggle a role you don't have"}, status=403)
+
+    current = set(request.session.get(SESSION_HIDDEN_KEY, []))
+    if hidden:
+        current.add(role)
+    else:
+        current.discard(role)
+    request.session[SESSION_HIDDEN_KEY] = sorted(current)
+
+    return JsonResponse({"hidden": sorted(current)})

--- a/hub/views.py
+++ b/hub/views.py
@@ -21,7 +21,7 @@ from billing.exceptions import NoPaymentMethodError, TabLimitExceededError, TabL
 from billing.models import BillingSettings, Tab, TabCharge
 from hub.calendar_service import refresh_stale_sources
 from hub.forms import BetaFeedbackForm, EmailPreferencesForm, GuildEditForm, ProfileSettingsForm, VotePreferenceForm
-from hub.view_as import ALL_ROLES, SESSION_HIDDEN_KEY
+from hub.view_as import ALL_ROLES, SESSION_ROLE_KEY
 from membership.cycle import get_cycle_context
 from membership.models import FundingSnapshot, Guild, Member, VotePreference
 
@@ -932,17 +932,16 @@ def calendar_export_ics(request: HttpRequest) -> HttpResponse:
 
 @require_POST
 @login_required
-def view_as_toggle(request: HttpRequest) -> JsonResponse:
-    """Add or remove a role from the session-hidden set.
+def view_as_set(request: HttpRequest) -> JsonResponse:
+    """Set the session view-as role.
 
-    Body: ``{"role": "admin", "hidden": true}``. Unknown role names and
-    roles the user does not actually hold are rejected so the session
-    can never carry junk or grant privileges.
+    Body: ``{"role": "admin"}``. Unknown role names and roles the user does
+    not actually hold are rejected so the session can never carry junk or
+    grant privileges above what the user already has.
     """
     try:
         payload = json.loads(request.body or b"{}")
         role = payload["role"]
-        hidden = bool(payload["hidden"])
     except (json.JSONDecodeError, KeyError, TypeError):
         return JsonResponse({"error": "Invalid request"}, status=400)
 
@@ -950,13 +949,8 @@ def view_as_toggle(request: HttpRequest) -> JsonResponse:
         return JsonResponse({"error": f"Unknown role '{role}'"}, status=400)
 
     if not request.view_as.has_actual(role):  # type: ignore[attr-defined]
-        return JsonResponse({"error": "Cannot toggle a role you don't have"}, status=403)
+        return JsonResponse({"error": "Cannot view as a role you don't have"}, status=403)
 
-    current = set(request.session.get(SESSION_HIDDEN_KEY, []))
-    if hidden:
-        current.add(role)
-    else:
-        current.discard(role)
-    request.session[SESSION_HIDDEN_KEY] = sorted(current)
+    request.session[SESSION_ROLE_KEY] = role
 
-    return JsonResponse({"hidden": sorted(current)})
+    return JsonResponse({"role": role})

--- a/hub/views.py
+++ b/hub/views.py
@@ -949,7 +949,7 @@ def view_as_toggle(request: HttpRequest) -> JsonResponse:
     if role not in ALL_ROLES:
         return JsonResponse({"error": f"Unknown role '{role}'"}, status=400)
 
-    if not request.view_as.has_actual(role):
+    if not request.view_as.has_actual(role):  # type: ignore[attr-defined]
         return JsonResponse({"error": "Cannot toggle a role you don't have"}, status=403)
 
     current = set(request.session.get(SESSION_HIDDEN_KEY, []))

--- a/plfog/settings.py
+++ b/plfog/settings.py
@@ -75,6 +75,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "hub.view_as.ViewAsMiddleware",
     "plfog.service_worker_middleware.ServiceWorkerAllowedMiddleware",
 ]
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-VERSION = "1.6.2"
+VERSION = "1.6.3"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.6.3",
+        "date": "2026-04-17",
+        "title": "Admin role preview in the hub",
+        "changes": [
+            'Admins and guild officers now have a new "Viewing as" button in the topbar — use it to preview the hub the way a plain member or guild officer would see it, without logging out. Unchecking a role hides that role\'s UI for the current session only.',
+        ],
+    },
     {
         "version": "1.6.2",
         "date": "2026-04-15",

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -1870,17 +1870,34 @@ a:hover { color: var(--color-yellow-hover); }
 }
 
 .pl-view-as-popover__row {
+    width: 100%;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 8px;
-    padding: 6px 8px;
+    padding: 7px 10px;
+    border: none;
+    background: none;
+    color: inherit;
+    text-align: left;
     border-radius: 6px;
     cursor: pointer;
     font-size: 14px;
+    font-family: inherit;
 }
 
 .pl-view-as-popover__row:hover {
     background: rgba(255, 255, 255, 0.05);
+}
+
+.pl-view-as-popover__row--selected {
+    background: rgba(255, 255, 255, 0.04);
+    font-weight: 600;
+}
+
+.pl-view-as-popover__check {
+    opacity: 0.7;
+    font-size: 12px;
 }
 
 .pl-view-as-popover__hint {

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -1842,3 +1842,51 @@ a:hover { color: var(--color-yellow-hover); }
 .guild-product-card__edit-btn:hover {
     background: rgba(238, 180, 75, 0.3);
 }
+
+/* Viewing-as popover */
+.pl-view-as-popover {
+    position: relative;
+}
+
+.pl-view-as-popover__menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    min-width: 200px;
+    background: var(--hub-dropdown-bg);
+    border: 1px solid var(--hub-dropdown-border);
+    border-radius: 8px;
+    padding: 8px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    z-index: 50;
+}
+
+.pl-view-as-popover__header {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.6;
+    padding: 4px 8px 8px;
+}
+
+.pl-view-as-popover__row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.pl-view-as-popover__row:hover {
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.pl-view-as-popover__hint {
+    font-size: 11px;
+    opacity: 0.55;
+    padding: 8px;
+    border-top: 1px solid var(--hub-dropdown-border);
+    margin-top: 4px;
+}

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -163,12 +163,39 @@
             </button>
             <span class="pl-topbar__divider"></span>
             <button class="pl-badge--beta" onclick="document.getElementById('changelog-modal').style.display='flex'">BETA v{{ app_version }}</button>
-            {% if user.is_staff %}
+            {% if request.view_as.is_admin %}
             <span class="pl-topbar__divider"></span>
             <a href="{% url 'admin:index' %}" class="pl-view-switcher" hx-boost="false" title="Switch to Admin View">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
                 Admin View
             </a>
+            {% endif %}
+            {% if request.view_as.show_popover %}
+            <span class="pl-topbar__divider"></span>
+            <div class="pl-view-as-popover"
+                 x-data="viewAsPopover()"
+                 @keydown.escape.window="if (open) { open = false; $el.querySelector('button').focus() }">
+                <button type="button" class="pl-view-switcher" @click="open = !open" :aria-expanded="open" title="Viewing as">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                        <circle cx="12" cy="12" r="3"/>
+                    </svg>
+                    Viewing as
+                </button>
+                <div class="pl-view-as-popover__menu" x-show="open" x-transition @click.away="open = false" role="menu">
+                    <div class="pl-view-as-popover__header">Show controls for</div>
+                    {% for row in request.view_as.popover_rows %}
+                    <label class="pl-view-as-popover__row">
+                        <input type="checkbox"
+                               value="{{ row.name }}"
+                               {% if row.active %}checked{% endif %}
+                               @change="toggle($event.target.value, !$event.target.checked)">
+                        <span>{{ row.label }}</span>
+                    </label>
+                    {% endfor %}
+                    <div class="pl-view-as-popover__hint">Unchecking hides that role's UI for this session.</div>
+                </div>
+            </div>
             {% endif %}
             <div class="pl-topbar__spacer"></div>
             {% if tab_balance is not None %}
@@ -244,6 +271,28 @@
     </script>
     {# HTMX auto-fires HX-Trigger JSON keys as events (and a kebab-case alias — see htmx Dt()) #}
     {# — so the `showToast` key in trigger_toast dispatches `show-toast` directly. No manual parse. #}
+    <script>
+        function viewAsPopover() {
+            return {
+                open: false,
+                async toggle(role, hidden) {
+                    const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value
+                        || document.cookie.split('; ').find(c => c.startsWith('csrftoken='))?.split('=')[1];
+                    const response = await fetch("{% url 'hub_view_as_toggle' %}", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            "X-CSRFToken": csrfToken || "",
+                        },
+                        body: JSON.stringify({ role, hidden }),
+                    });
+                    if (response.ok) {
+                        window.location.reload();
+                    }
+                },
+            };
+        }
+    </script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -170,30 +170,32 @@
                 Admin View
             </a>
             {% endif %}
-            {% if request.view_as.show_popover %}
+            {% if request.view_as.show_dropdown %}
             <span class="pl-topbar__divider"></span>
             <div class="pl-view-as-popover"
-                 x-data="viewAsPopover()"
+                 x-data="viewAsDropdown()"
                  @keydown.escape.window="if (open) { open = false; $el.querySelector('button').focus() }">
                 <button type="button" class="pl-view-switcher" @click="open = !open" :aria-expanded="open" title="Viewing as">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
                         <circle cx="12" cy="12" r="3"/>
                     </svg>
-                    Viewing as
+                    Viewing as: {{ request.view_as.current_label }}
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-left:4px;"><path d="m6 9 6 6 6-6"/></svg>
                 </button>
                 <div class="pl-view-as-popover__menu" x-show="open" x-transition @click.away="open = false" role="menu">
-                    <div class="pl-view-as-popover__header">Show controls for</div>
-                    {% for row in request.view_as.popover_rows %}
-                    <label class="pl-view-as-popover__row">
-                        <input type="checkbox"
-                               value="{{ row.name }}"
-                               {% if row.active %}checked{% endif %}
-                               @change="toggle($event.target.value, !$event.target.checked)">
+                    <div class="pl-view-as-popover__header">View as</div>
+                    {% for row in request.view_as.dropdown_options %}
+                    <button type="button"
+                            role="menuitemradio"
+                            aria-checked="{% if row.selected %}true{% else %}false{% endif %}"
+                            class="pl-view-as-popover__row{% if row.selected %} pl-view-as-popover__row--selected{% endif %}"
+                            @click="pick('{{ row.name }}')">
                         <span>{{ row.label }}</span>
-                    </label>
+                        {% if row.selected %}<span class="pl-view-as-popover__check" aria-hidden="true">✓</span>{% endif %}
+                    </button>
                     {% endfor %}
-                    <div class="pl-view-as-popover__hint">Unchecking hides that role's UI for this session.</div>
+                    <div class="pl-view-as-popover__hint">Preview the hub as a lower role. Session-only.</div>
                 </div>
             </div>
             {% endif %}
@@ -272,19 +274,19 @@
     {# HTMX auto-fires HX-Trigger JSON keys as events (and a kebab-case alias — see htmx Dt()) #}
     {# — so the `showToast` key in trigger_toast dispatches `show-toast` directly. No manual parse. #}
     <script>
-        function viewAsPopover() {
+        function viewAsDropdown() {
             return {
                 open: false,
-                async toggle(role, hidden) {
+                async pick(role) {
                     const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value
                         || document.cookie.split('; ').find(c => c.startsWith('csrftoken='))?.split('=')[1];
-                    const response = await fetch("{% url 'hub_view_as_toggle' %}", {
+                    const response = await fetch("{% url 'hub_view_as_set' %}", {
                         method: "POST",
                         headers: {
                             "Content-Type": "application/json",
                             "X-CSRFToken": csrfToken || "",
                         },
-                        body: JSON.stringify({ role, hidden }),
+                        body: JSON.stringify({ role }),
                     });
                     if (response.ok) {
                         window.location.reload();

--- a/tests/billing/models/billing_settings_spec.py
+++ b/tests/billing/models/billing_settings_spec.py
@@ -134,6 +134,30 @@ def describe_BillingSettings():
             assert result is not None
             assert (result.date() - fake_now.date()).days == 7
 
+        def it_returns_candidate_when_candidate_is_future_in_current_month():
+            from datetime import time as _time
+            from unittest.mock import patch
+
+            from django.utils import timezone as _tz
+
+            # Freeze "now" to day 5 at 09:00; charge_day_of_month=28 makes candidate=day 28 > now
+            now = _tz.localtime()
+            fake_now = now.replace(day=5, hour=9, minute=0, second=0, microsecond=0)
+
+            settings = BillingSettingsFactory(
+                charge_frequency=BillingSettings.ChargeFrequency.MONTHLY,
+                charge_day_of_month=28,
+                charge_day_of_week=None,
+                charge_time="09:00",
+            )
+            settings.charge_time = _time(9, 0)
+
+            with patch("billing.models.timezone.localtime", return_value=fake_now):
+                result = settings.next_charge_at()
+            assert result is not None
+            assert result.day == 28
+            assert result.month == fake_now.month  # still in the same month
+
         def it_wraps_to_january_when_monthly_candidate_is_december():
             from datetime import time as _time
             from unittest.mock import patch

--- a/tests/core/admin_spec.py
+++ b/tests/core/admin_spec.py
@@ -1,10 +1,12 @@
 """BDD-style tests for core.admin — SiteConfigurationAdmin."""
 
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client
 
-from core.admin import SiteConfigurationAdmin
+from core.admin import SiteConfigurationAdmin, _SiteConfigurationAdminForm
 from core.models import SiteConfiguration
 
 User = get_user_model()
@@ -77,3 +79,117 @@ def describe_SiteConfigurationAdmin():
         def it_denies_add_for_non_superuser(admin_instance, staff_request):
             SiteConfiguration.objects.all().delete()
             assert admin_instance.has_add_permission(staff_request) is False
+
+
+def describe_SiteConfigurationAdminForm():
+    def it_renders_with_tooltip_label_on_general_calendar_url():
+        form = _SiteConfigurationAdminForm()
+        label = str(form.fields["general_calendar_url"].label)
+        assert "General Calendar iCal URL" in label
+        assert "?" in label
+
+    def it_clears_help_text_on_general_calendar_url():
+        form = _SiteConfigurationAdminForm()
+        assert form.fields["general_calendar_url"].help_text == ""
+
+
+def describe_sync_classes_button():
+    @pytest.fixture()
+    def admin_instance():
+        from django.contrib.admin.sites import AdminSite
+
+        return SiteConfigurationAdmin(SiteConfiguration, AdminSite())
+
+    def it_returns_html_with_sync_url(admin_instance):
+        config = SiteConfiguration.load()
+        result = admin_instance.sync_classes_button(config)
+        html = str(result)
+        assert "Sync Classes Now" in html
+        assert "sync-classes" in html
+
+
+def describe_sync_classes_view():
+    @pytest.fixture()
+    def superuser():
+        return User.objects.create_superuser(username="sync-admin", password="pass", email="sync@example.com")
+
+    @pytest.fixture()
+    def admin_client(superuser):
+        c = Client()
+        c.force_login(superuser)
+        return c
+
+    def it_shows_success_message_and_redirects_on_sync(admin_client):
+        SiteConfiguration.load()
+        with patch("hub.calendar_service.sync_classes_calendar", return_value=5):
+            response = admin_client.get("/admin/core/siteconfiguration/sync-classes/")
+        assert response.status_code == 302
+
+    def it_shows_warning_message_on_sync_exception(admin_client):
+        SiteConfiguration.load()
+        with patch("hub.calendar_service.sync_classes_calendar", side_effect=RuntimeError("network failure")):
+            response = admin_client.get("/admin/core/siteconfiguration/sync-classes/")
+        assert response.status_code == 302
+
+
+def describe_save_model():
+    @pytest.fixture()
+    def superuser():
+        return User.objects.create_superuser(username="save-admin", password="pass", email="save@example.com")
+
+    @pytest.fixture()
+    def admin_client(superuser):
+        c = Client()
+        c.force_login(superuser)
+        return c
+
+    def _post_config(admin_client, url: str) -> object:
+        """POST the SiteConfiguration change form with the given calendar URL."""
+        config = SiteConfiguration.load()
+        return admin_client.post(
+            f"/admin/core/siteconfiguration/{config.pk}/change/",
+            {
+                "registration_mode": "open",
+                "general_calendar_url": url,
+                "general_calendar_color": "#4B9FEE",
+                "classes_calendar_color": "#F59E0B",
+                "sync_classes_enabled": "",
+                "_save": "Save",
+            },
+        )
+
+    def it_syncs_general_calendar_on_save_when_url_is_set(admin_client):
+        with patch("hub.calendar_service.sync_general_calendar", return_value=3) as mock_sync:
+            _post_config(admin_client, "https://example.com/general.ics")
+        mock_sync.assert_called_once()
+
+    def it_shows_success_message_after_successful_sync(admin_client):
+        with patch("hub.calendar_service.sync_general_calendar", return_value=7):
+            response = _post_config(admin_client, "https://example.com/general2.ics")
+        # Successful save redirects
+        assert response.status_code == 302
+
+    def it_shows_warning_on_general_sync_404_error(admin_client):
+        import urllib.error
+
+        http_error = urllib.error.HTTPError(
+            url="https://example.com/notfound.ics",
+            code=404,
+            msg="Not Found",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+        with patch("hub.calendar_service.sync_general_calendar", side_effect=http_error):
+            response = _post_config(admin_client, "https://example.com/notfound.ics")
+        # Still redirects (warning is set via messages)
+        assert response.status_code == 302
+
+    def it_shows_generic_warning_on_other_sync_error(admin_client):
+        with patch("hub.calendar_service.sync_general_calendar", side_effect=ValueError("bad data")):
+            response = _post_config(admin_client, "https://example.com/broken.ics")
+        assert response.status_code == 302
+
+    def it_skips_sync_when_url_is_empty(admin_client):
+        with patch("hub.calendar_service.sync_general_calendar") as mock_sync:
+            _post_config(admin_client, "")
+        mock_sync.assert_not_called()

--- a/tests/hub/calendar_service_spec.py
+++ b/tests/hub/calendar_service_spec.py
@@ -1,0 +1,442 @@
+"""BDD specs for hub.calendar_service — _fetch_json, sync_classes_calendar, refresh_stale_sources."""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.utils import timezone
+
+from core.models import SiteConfiguration
+from membership.models import CalendarEvent
+from tests.membership.factories import GuildFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_urlopen_json(payload: dict) -> object:
+    """Return a side_effect for urllib.request.urlopen that returns JSON bytes."""
+
+    def _fake(req, **kwargs):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(payload).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        return mock_response
+
+    return _fake
+
+
+def _make_fake_urlopen(ical_bytes: bytes) -> object:
+    def _fake(url, **kwargs):
+        mock_response = MagicMock()
+        mock_response.read.return_value = ical_bytes
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        return mock_response
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# _fetch_json
+# ---------------------------------------------------------------------------
+
+
+def describe__fetch_json():
+    def it_returns_parsed_json_from_url():
+        from hub.calendar_service import _fetch_json
+
+        payload = {"data": [{"id": "abc", "attributes": {"title": "My Class"}}]}
+        with patch("hub.calendar_service.urllib.request.urlopen", side_effect=_make_urlopen_json(payload)):
+            result = _fetch_json("https://example.com/api/classes")
+        assert result == payload
+
+    def it_sends_accept_header():
+        from hub.calendar_service import _fetch_json
+
+        captured_requests = []
+
+        def _fake(req, **kwargs):
+            captured_requests.append(req)
+            mock_response = MagicMock()
+            mock_response.read.return_value = b'{"data": []}'
+            mock_response.__enter__ = lambda s: s
+            mock_response.__exit__ = MagicMock(return_value=False)
+            return mock_response
+
+        with patch("hub.calendar_service.urllib.request.urlopen", side_effect=_fake):
+            _fetch_json("https://example.com/api")
+        assert len(captured_requests) == 1
+        assert captured_requests[0].get_header("Accept") == "application/vnd.api+json"
+
+
+# ---------------------------------------------------------------------------
+# sync_classes_calendar
+# ---------------------------------------------------------------------------
+
+# Minimal JSON:API response for one class with two sessions
+_CLASSES_API_RESPONSE = {
+    "data": [
+        {
+            "id": "node-123",
+            "attributes": {
+                "title": "Intro to Welding",
+                "field_dates": [
+                    {
+                        "value": "2026-06-01T10:00:00",
+                        "end_value": "2026-06-01T12:00:00",
+                    },
+                    {
+                        "value": "2026-06-08T10:00:00",
+                        "end_value": "2026-06-08T12:00:00",
+                    },
+                ],
+                "path": {"alias": "/classes/welding-101"},
+                "body": {"value": "<p>Learn to weld.</p>", "summary": ""},
+            },
+        }
+    ],
+    "links": {},
+}
+
+# Response with two pages (first page links to second)
+_CLASSES_PAGE1 = {
+    "data": [
+        {
+            "id": "node-page1",
+            "attributes": {
+                "title": "Page 1 Class",
+                "field_dates": [{"value": "2026-07-01T10:00:00", "end_value": "2026-07-01T11:00:00"}],
+                "path": {"alias": "/classes/page1"},
+                "body": {},
+            },
+        }
+    ],
+    "links": {"next": {"href": "https://classes.pastlives.space/jsonapi/node/class?page=2"}},
+}
+
+_CLASSES_PAGE2 = {
+    "data": [
+        {
+            "id": "node-page2",
+            "attributes": {
+                "title": "Page 2 Class",
+                "field_dates": [{"value": "2026-07-02T10:00:00", "end_value": "2026-07-02T11:00:00"}],
+                "path": {},
+                "body": {"summary": "Short description"},
+            },
+        }
+    ],
+    "links": {},
+}
+
+# Response with a class that has no field_dates (should be skipped)
+_CLASSES_NO_DATES = {
+    "data": [
+        {
+            "id": "node-nodates",
+            "attributes": {
+                "title": "No Dates Class",
+                "field_dates": [],
+                "path": {},
+                "body": {},
+            },
+        }
+    ],
+    "links": {},
+}
+
+# Response with a session that has no start_str (should be skipped)
+_CLASSES_NO_START = {
+    "data": [
+        {
+            "id": "node-nostart",
+            "attributes": {
+                "title": "No Start Class",
+                "field_dates": [{"value": None, "end_value": None}],
+                "path": {},
+                "body": {},
+            },
+        }
+    ],
+    "links": {},
+}
+
+
+def describe_sync_classes_calendar():
+    def it_returns_zero_when_sync_classes_disabled():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = False
+        config.save()
+        count = sync_classes_calendar()
+        assert count == 0
+
+    def it_creates_calendar_events_for_each_session():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_API_RESPONSE):
+            count = sync_classes_calendar()
+
+        assert count == 2
+        events = CalendarEvent.objects.filter(source="classes")
+        assert events.count() == 2
+        titles = set(events.values_list("title", flat=True))
+        assert titles == {"Intro to Welding"}
+
+    def it_sets_event_url_from_path_alias():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_API_RESPONSE):
+            sync_classes_calendar()
+
+        event = CalendarEvent.objects.filter(source="classes", uid="classes-node-123-0").first()
+        assert event is not None
+        assert event.url == "https://classes.pastlives.space/classes/welding-101"
+
+    def it_strips_html_from_body_description():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_API_RESPONSE):
+            sync_classes_calendar()
+
+        event = CalendarEvent.objects.filter(source="classes", uid="classes-node-123-0").first()
+        assert event is not None
+        assert "<p>" not in event.description
+        assert "Learn to weld." in event.description
+
+    def it_skips_items_with_no_field_dates():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_NO_DATES):
+            count = sync_classes_calendar()
+        assert count == 0
+        assert CalendarEvent.objects.filter(source="classes").count() == 0
+
+    def it_skips_sessions_with_no_start_str():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_NO_START):
+            count = sync_classes_calendar()
+        assert count == 0
+
+    def it_paginates_through_multiple_pages():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        pages = [_CLASSES_PAGE1, _CLASSES_PAGE2]
+        call_count = 0
+
+        def _fake_fetch(url: str) -> dict:
+            nonlocal call_count
+            result = pages[call_count]
+            call_count += 1
+            return result
+
+        with patch("hub.calendar_service._fetch_json", side_effect=_fake_fetch):
+            count = sync_classes_calendar()
+
+        assert count == 2
+        assert CalendarEvent.objects.filter(source="classes").count() == 2
+
+    def it_removes_old_records_with_a_guild_before_upsert():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        # Create an old record with the same UID but a guild (pre-migration data)
+        guild = GuildFactory()
+        CalendarEvent.objects.create(
+            guild=guild,
+            uid="classes-node-123-0",
+            source="classes",
+            title="Old Version",
+            start_dt=timezone.now(),
+            end_dt=timezone.now() + timedelta(hours=1),
+            fetched_at=timezone.now(),
+        )
+
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_API_RESPONSE):
+            sync_classes_calendar()
+
+        # The old record with a guild should be gone
+        assert not CalendarEvent.objects.filter(uid="classes-node-123-0", guild__isnull=False).exists()
+        # The new record with guild=None should exist
+        assert CalendarEvent.objects.filter(uid="classes-node-123-0", guild__isnull=True).exists()
+
+    def it_updates_classes_last_synced_at():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.classes_last_synced_at = None
+        config.save()
+
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_API_RESPONSE):
+            sync_classes_calendar()
+
+        config.refresh_from_db()
+        assert config.classes_last_synced_at is not None
+
+    def it_uses_empty_url_when_path_alias_is_missing():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_PAGE2):
+            sync_classes_calendar()
+
+        event = CalendarEvent.objects.filter(source="classes", uid="classes-node-page2-0").first()
+        assert event is not None
+        assert event.url == ""
+
+    def it_uses_summary_as_fallback_description():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        # _CLASSES_PAGE2 has body: {"summary": "Short description"} and no "value"
+        with patch("hub.calendar_service._fetch_json", return_value=_CLASSES_PAGE2):
+            sync_classes_calendar()
+
+        event = CalendarEvent.objects.filter(source="classes", uid="classes-node-page2-0").first()
+        assert event is not None
+        assert event.description == "Short description"
+
+    def it_defaults_end_value_to_start_when_missing():
+        from hub.calendar_service import sync_classes_calendar
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.save()
+
+        response = {
+            "data": [
+                {
+                    "id": "node-noend",
+                    "attributes": {
+                        "title": "No End Class",
+                        "field_dates": [{"value": "2026-08-01T10:00:00"}],
+                        "path": {},
+                        "body": {},
+                    },
+                }
+            ],
+            "links": {},
+        }
+
+        with patch("hub.calendar_service._fetch_json", return_value=response):
+            count = sync_classes_calendar()
+
+        assert count == 1
+        event = CalendarEvent.objects.get(source="classes", uid="classes-node-noend-0")
+        assert event.start_dt == event.end_dt
+
+
+# ---------------------------------------------------------------------------
+# refresh_stale_sources — classes branch (lines 239-245)
+# ---------------------------------------------------------------------------
+
+
+def describe_refresh_stale_sources_classes():
+    def it_syncs_classes_when_stale():
+        from hub.calendar_service import refresh_stale_sources
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.classes_last_synced_at = timezone.now() - timedelta(seconds=1000)
+        config.save()
+
+        with patch("hub.calendar_service.sync_classes_calendar", return_value=3) as mock_sync:
+            refresh_stale_sources(max_age_seconds=900)
+
+        mock_sync.assert_called_once()
+
+    def it_syncs_classes_when_never_synced():
+        from hub.calendar_service import refresh_stale_sources
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.classes_last_synced_at = None
+        config.save()
+
+        with patch("hub.calendar_service.sync_classes_calendar", return_value=1) as mock_sync:
+            refresh_stale_sources(max_age_seconds=900)
+
+        mock_sync.assert_called_once()
+
+    def it_skips_classes_when_recently_synced():
+        from hub.calendar_service import refresh_stale_sources
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.classes_last_synced_at = timezone.now()
+        config.save()
+
+        with patch("hub.calendar_service.sync_classes_calendar") as mock_sync:
+            refresh_stale_sources(max_age_seconds=900)
+
+        mock_sync.assert_not_called()
+
+    def it_swallows_exceptions_from_classes_sync():
+        from hub.calendar_service import refresh_stale_sources
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = True
+        config.classes_last_synced_at = None
+        config.save()
+
+        with patch("hub.calendar_service.sync_classes_calendar", side_effect=RuntimeError("timeout")):
+            # Should not raise — exception is swallowed
+            refresh_stale_sources(max_age_seconds=900)
+
+    def it_skips_classes_when_sync_disabled():
+        from hub.calendar_service import refresh_stale_sources
+
+        config = SiteConfiguration.load()
+        config.sync_classes_enabled = False
+        config.classes_last_synced_at = None
+        config.save()
+
+        with patch("hub.calendar_service.sync_classes_calendar") as mock_sync:
+            refresh_stale_sources(max_age_seconds=900)
+
+        mock_sync.assert_not_called()

--- a/tests/hub/community_calendar_spec.py
+++ b/tests/hub/community_calendar_spec.py
@@ -543,3 +543,72 @@ def describe_calendar_export_ics_view():
         assert "DTEND;VALUE=DATE:" in content
         # Should NOT export as datetime format for all-day events
         assert "DTSTART:20" not in content or "DTSTART;VALUE=DATE:" in content
+
+    def it_includes_location_in_ics_output(client: Client):
+        from datetime import timedelta as td
+
+        _logged_in_user(client, username="caluser_loc")
+        guild = GuildFactory(name="Metal Shop", calendar_url="https://example.com/metal.ics")
+        now = timezone.now()
+        CalendarEvent.objects.create(
+            guild=guild,
+            uid="location-001",
+            title="Metal Shop Open Night",
+            location="1234 Main St, Portland OR",
+            start_dt=now + td(days=4),
+            end_dt=now + td(days=4, hours=2),
+            fetched_at=now,
+        )
+        response = client.get("/calendar/export.ics")
+        content = response.content.decode()
+        assert "LOCATION:1234 Main St, Portland OR" in content
+
+
+def describe_community_calendar_default_filters():
+    def it_includes_general_in_default_filters_when_general_calendar_configured(client: Client):
+        from core.models import SiteConfiguration
+
+        _logged_in_user(client, username="caluser_gen")
+        config = SiteConfiguration.load()
+        config.general_calendar_url = "https://example.com/general.ics"
+        config.save()
+        response = client.get("/calendar/")
+        assert response.status_code == 200
+        # default_filters_json should contain "general"
+        assert "general" in response.context["default_filters_json"]
+
+
+def describe_calendar_events_partial_invalid_params():
+    def it_defaults_to_zero_offsets_when_params_are_non_integer(client: Client):
+        _logged_in_user(client, username="caluser_bad")
+        with patch("hub.views.refresh_stale_sources"):
+            response = client.get("/calendar/events/?week_offset=abc&month_offset=xyz&page=bad")
+        assert response.status_code == 200
+        assert response.context["week_offset"] == 0
+        assert response.context["month_offset"] == 0
+        assert response.context["event_page"] == 1
+
+
+def describe_calendar_week_label_cross_month():
+    def it_uses_full_month_names_when_week_spans_two_months(client: Client):
+        """Week label format when start and end months differ (e.g. Apr 28 – May 4)."""
+        _logged_in_user(client, username="caluser_xmonth")
+        # week_offset chosen so that the navigated week crosses a month boundary;
+        # we rely on the label being rendered in the context, not asserting a fixed date.
+        # Drive week_offset until start.month != end.month — but simpler: just call
+        # the helper directly with a known cross-month date.
+        from unittest.mock import patch
+
+        from django.utils import timezone as dj_tz
+
+        # Freeze "today" to Monday April 28 2026 — week is Apr 28–May 4 (cross month)
+        fake_now = dj_tz.now().replace(year=2026, month=4, day=28, hour=12, minute=0, second=0, microsecond=0)
+        with patch("hub.views.dj_timezone") as mock_tz:
+            mock_tz.now.return_value = fake_now
+            with patch("hub.views.refresh_stale_sources"):
+                response = client.get("/calendar/events/?week_offset=0")
+        assert response.status_code == 200
+        week_label = response.context["week_label"]
+        # Cross-month format: "Apr 28 – May 4, 2026"
+        assert "Apr" in week_label
+        assert "May" in week_label

--- a/tests/hub/view_as_spec.py
+++ b/tests/hub/view_as_spec.py
@@ -1,0 +1,109 @@
+"""BDD specs for the Viewing-as helper."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import AnonymousUser, User
+
+from hub.view_as import ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER, ViewAs, compute_actual_roles
+from membership.models import Member
+from tests.membership.factories import MemberFactory
+
+
+def _make_user_member(fog_role: str, *, username: str = "u") -> tuple[User, Member]:
+    """Create a User + Member pair with the given fog_role.
+
+    The post_save signal ``ensure_user_has_member`` auto-creates a bare Member
+    when a User is created, so we update that Member in place rather than
+    creating a second one via MemberFactory.
+    """
+    user = User.objects.create_user(username=username, email=f"{username}@example.com", password="p")
+    member = user.member
+    member.fog_role = fog_role
+    member.save(update_fields=["fog_role"])
+    return user, member
+
+
+@pytest.mark.django_db
+def describe_compute_actual_roles():
+    def it_returns_empty_frozenset_for_anonymous_user():
+        assert compute_actual_roles(AnonymousUser()) == frozenset()
+
+    def it_returns_empty_frozenset_when_user_has_no_member():
+        user = User.objects.create_user(username="u", password="p")
+        Member.objects.filter(user=user).delete()
+        user = User.objects.get(pk=user.pk)  # refetch to drop stale .member descriptor cache
+        assert compute_actual_roles(user) == frozenset()
+
+    def it_returns_admin_guild_officer_and_member_for_fog_admin():
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="admin_u")
+        assert compute_actual_roles(user) == frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
+
+    def it_returns_guild_officer_and_member_for_fog_officer():
+        user, _ = _make_user_member(Member.FogRole.GUILD_OFFICER, username="officer_u")
+        assert compute_actual_roles(user) == frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER})
+
+    def it_returns_only_member_for_regular_members():
+        user, _ = _make_user_member(Member.FogRole.MEMBER, username="member_u")
+        assert compute_actual_roles(user) == frozenset({ROLE_MEMBER})
+
+    def it_treats_django_superuser_without_member_as_admin():
+        user = User.objects.create_superuser(username="root", email="r@x.com", password="p")
+        Member.objects.filter(user=user).delete()
+        user = User.objects.get(pk=user.pk)
+        assert compute_actual_roles(user) == frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
+
+
+def describe_ViewAs():
+    def it_marks_has_true_only_for_effective_roles():
+        v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_MEMBER}), hidden=frozenset({ROLE_ADMIN}))
+        assert v.has(ROLE_ADMIN) is False
+        assert v.has(ROLE_MEMBER) is True
+
+    def it_has_actual_ignores_hidden():
+        v = ViewAs(actual=frozenset({ROLE_ADMIN}), hidden=frozenset({ROLE_ADMIN}))
+        assert v.has_actual(ROLE_ADMIN) is True
+        assert v.has(ROLE_ADMIN) is False
+
+    def it_exposes_convenience_properties():
+        v = ViewAs(
+            actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}),
+            hidden=frozenset({ROLE_ADMIN}),
+        )
+        assert v.is_admin is False
+        assert v.is_guild_officer is True
+        assert v.is_member is True
+
+    def describe_show_popover():
+        def it_is_true_for_admins():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
+            assert v.show_popover is True
+
+        def it_is_true_for_guild_officers():
+            v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
+            assert v.show_popover is True
+
+        def it_is_false_for_plain_members():
+            v = ViewAs(actual=frozenset({ROLE_MEMBER}), hidden=frozenset())
+            assert v.show_popover is False
+
+        def it_is_false_for_unauthenticated():
+            v = ViewAs(actual=frozenset(), hidden=frozenset())
+            assert v.show_popover is False
+
+    def describe_popover_rows():
+        def it_lists_rows_in_display_order_with_active_flags():
+            v = ViewAs(
+                actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}),
+                hidden=frozenset({ROLE_ADMIN}),
+            )
+            assert v.popover_rows == [
+                {"name": ROLE_MEMBER, "label": "Member", "active": True},
+                {"name": ROLE_GUILD_OFFICER, "label": "Guild Officer", "active": True},
+                {"name": ROLE_ADMIN, "label": "Admin", "active": False},
+            ]
+
+        def it_skips_roles_not_actually_held():
+            v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
+            names = [row["name"] for row in v.popover_rows]
+            assert names == [ROLE_MEMBER, ROLE_GUILD_OFFICER]

--- a/tests/hub/view_as_spec.py
+++ b/tests/hub/view_as_spec.py
@@ -231,3 +231,36 @@ def describe_view_as_toggle_endpoint():
         )
 
         assert response.status_code in (302, 401, 403)
+
+
+@pytest.mark.django_db
+def describe_popover_in_hub_template():
+    def it_renders_popover_for_admins(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="tmpl_admin")
+        client.login(username=user.username, password="p")
+
+        response = client.get("/guilds/voting/")
+
+        assert response.status_code == 200
+        assert b"pl-view-as-popover" in response.content
+        assert b"Viewing as" in response.content
+
+    def it_hides_popover_for_plain_members(client):
+        user, _ = _make_user_member(Member.FogRole.MEMBER, username="tmpl_plain")
+        client.login(username=user.username, password="p")
+
+        response = client.get("/guilds/voting/")
+
+        assert response.status_code == 200
+        assert b"pl-view-as-popover" not in response.content
+
+    def it_hides_admin_view_button_when_admin_role_is_hidden(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="tmpl_hidden_admin")
+        client.login(username=user.username, password="p")
+        session = client.session
+        session["view_as_hidden_roles"] = ["admin"]
+        session.save()
+
+        response = client.get("/guilds/voting/")
+
+        assert b"Admin View" not in response.content

--- a/tests/hub/view_as_spec.py
+++ b/tests/hub/view_as_spec.py
@@ -107,3 +107,50 @@ def describe_ViewAs():
             v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
             names = [row["name"] for row in v.popover_rows]
             assert names == [ROLE_MEMBER, ROLE_GUILD_OFFICER]
+
+
+from django.test import RequestFactory
+
+from hub.view_as import ViewAsMiddleware
+
+
+@pytest.fixture
+def rf() -> RequestFactory:
+    return RequestFactory()
+
+
+@pytest.mark.django_db
+def describe_ViewAsMiddleware():
+    def it_attaches_view_as_to_request(rf: RequestFactory):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="mw_admin")
+        request = rf.get("/")
+        request.user = user
+        request.session = {}
+
+        captured: dict[str, object] = {}
+
+        def get_response(req):
+            captured["view_as"] = req.view_as
+            return "ok"
+
+        ViewAsMiddleware(get_response)(request)
+
+        assert captured["view_as"].is_admin is True
+        assert captured["view_as"].actual == frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
+
+    def it_respects_hidden_roles_in_session(rf: RequestFactory):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="mw_hidden")
+        request = rf.get("/")
+        request.user = user
+        request.session = {"view_as_hidden_roles": ["admin"]}
+
+        captured: dict[str, object] = {}
+
+        def get_response(req):
+            captured["view_as"] = req.view_as
+            return "ok"
+
+        ViewAsMiddleware(get_response)(request)
+
+        assert captured["view_as"].is_admin is False
+        assert captured["view_as"].is_guild_officer is True

--- a/tests/hub/view_as_spec.py
+++ b/tests/hub/view_as_spec.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from django.contrib.auth.models import AnonymousUser, User
+from django.test import RequestFactory
 
-from hub.view_as import ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER, ViewAs, compute_actual_roles
+from hub.view_as import (
+    ROLE_ADMIN,
+    ROLE_GUILD_OFFICER,
+    ROLE_MEMBER,
+    ViewAs,
+    ViewAsMiddleware,
+    compute_actual_roles,
+)
 from membership.models import Member
-from tests.membership.factories import MemberFactory
 
 
 def _make_user_member(fog_role: str, *, username: str = "u") -> tuple[User, Member]:
@@ -109,11 +118,6 @@ def describe_ViewAs():
             assert names == [ROLE_MEMBER, ROLE_GUILD_OFFICER]
 
 
-from django.test import RequestFactory
-
-from hub.view_as import ViewAsMiddleware
-
-
 @pytest.fixture
 def rf() -> RequestFactory:
     return RequestFactory()
@@ -154,9 +158,6 @@ def describe_ViewAsMiddleware():
 
         assert captured["view_as"].is_admin is False
         assert captured["view_as"].is_guild_officer is True
-
-
-import json
 
 
 @pytest.mark.django_db

--- a/tests/hub/view_as_spec.py
+++ b/tests/hub/view_as_spec.py
@@ -154,3 +154,80 @@ def describe_ViewAsMiddleware():
 
         assert captured["view_as"].is_admin is False
         assert captured["view_as"].is_guild_officer is True
+
+
+import json
+
+
+@pytest.mark.django_db
+def describe_view_as_toggle_endpoint():
+    def it_adds_role_to_hidden_set(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="toggle_admin")
+        client.login(username=user.username, password="p")
+
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "admin", "hidden": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"hidden": ["admin"]}
+        assert client.session["view_as_hidden_roles"] == ["admin"]
+
+    def it_removes_role_when_hidden_is_false(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="toggle_unhide")
+        client.login(username=user.username, password="p")
+        session = client.session
+        session["view_as_hidden_roles"] = ["admin", "guild_officer"]
+        session.save()
+
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "admin", "hidden": False}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"hidden": ["guild_officer"]}
+
+    def it_rejects_unknown_role_names(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="toggle_wizard")
+        client.login(username=user.username, password="p")
+
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "wizard", "hidden": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+
+    def it_rejects_toggling_a_role_the_user_does_not_hold(client):
+        user, _ = _make_user_member(Member.FogRole.MEMBER, username="toggle_plain")
+        client.login(username=user.username, password="p")
+
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "admin", "hidden": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+
+    def it_rejects_malformed_json(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="toggle_malformed")
+        client.login(username=user.username, password="p")
+
+        response = client.post("/view-as/toggle/", data=b"not json", content_type="application/json")
+
+        assert response.status_code == 400
+
+    def it_requires_login(client):
+        response = client.post(
+            "/view-as/toggle/",
+            data=json.dumps({"role": "admin", "hidden": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code in (302, 401, 403)

--- a/tests/hub/view_as_spec.py
+++ b/tests/hub/view_as_spec.py
@@ -19,6 +19,11 @@ from hub.view_as import (
 from membership.models import Member
 
 
+@pytest.fixture
+def rf() -> RequestFactory:
+    return RequestFactory()
+
+
 def _make_user_member(fog_role: str, *, username: str = "u") -> tuple[User, Member]:
     """Create a User + Member pair with the given fog_role.
 
@@ -41,7 +46,7 @@ def describe_compute_actual_roles():
     def it_returns_empty_frozenset_when_user_has_no_member():
         user = User.objects.create_user(username="u", password="p")
         Member.objects.filter(user=user).delete()
-        user = User.objects.get(pk=user.pk)  # refetch to drop stale .member descriptor cache
+        user = User.objects.get(pk=user.pk)
         assert compute_actual_roles(user) == frozenset()
 
     def it_returns_admin_guild_officer_and_member_for_fog_admin():
@@ -64,63 +69,78 @@ def describe_compute_actual_roles():
 
 
 def describe_ViewAs():
-    def it_marks_has_true_only_for_effective_roles():
-        v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_MEMBER}), hidden=frozenset({ROLE_ADMIN}))
-        assert v.has(ROLE_ADMIN) is False
-        assert v.has(ROLE_MEMBER) is True
+    def describe_default_view_as_role():
+        def it_picks_the_highest_actual_role_when_nothing_is_picked():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=None)
+            assert v.view_as_role == ROLE_ADMIN
+            assert v.effective == frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
 
-    def it_has_actual_ignores_hidden():
-        v = ViewAs(actual=frozenset({ROLE_ADMIN}), hidden=frozenset({ROLE_ADMIN}))
-        assert v.has_actual(ROLE_ADMIN) is True
-        assert v.has(ROLE_ADMIN) is False
+        def it_leaves_view_as_role_none_for_unauthenticated():
+            v = ViewAs(actual=frozenset(), picked=None)
+            assert v.view_as_role is None
+            assert v.effective == frozenset()
 
-    def it_exposes_convenience_properties():
-        v = ViewAs(
-            actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}),
-            hidden=frozenset({ROLE_ADMIN}),
-        )
-        assert v.is_admin is False
-        assert v.is_guild_officer is True
-        assert v.is_member is True
+    def describe_effective_roles():
+        def it_caps_effective_to_roles_at_or_below_picked():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=ROLE_GUILD_OFFICER)
+            assert v.effective == frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER})
+            assert v.is_admin is False
+            assert v.is_guild_officer is True
+            assert v.is_member is True
 
-    def describe_show_popover():
+        def it_picking_member_reduces_effective_to_just_member():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=ROLE_MEMBER)
+            assert v.effective == frozenset({ROLE_MEMBER})
+
+    def describe_has_actual():
+        def it_reports_true_for_roles_the_user_holds_regardless_of_pick():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_MEMBER}), picked=ROLE_MEMBER)
+            assert v.has_actual(ROLE_ADMIN) is True
+            assert v.has(ROLE_ADMIN) is False
+
+    def describe_show_dropdown():
         def it_is_true_for_admins():
-            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
-            assert v.show_popover is True
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=None)
+            assert v.show_dropdown is True
 
         def it_is_true_for_guild_officers():
-            v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
-            assert v.show_popover is True
+            v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=None)
+            assert v.show_dropdown is True
 
         def it_is_false_for_plain_members():
-            v = ViewAs(actual=frozenset({ROLE_MEMBER}), hidden=frozenset())
-            assert v.show_popover is False
+            v = ViewAs(actual=frozenset({ROLE_MEMBER}), picked=None)
+            assert v.show_dropdown is False
 
         def it_is_false_for_unauthenticated():
-            v = ViewAs(actual=frozenset(), hidden=frozenset())
-            assert v.show_popover is False
+            v = ViewAs(actual=frozenset(), picked=None)
+            assert v.show_dropdown is False
 
-    def describe_popover_rows():
-        def it_lists_rows_in_display_order_with_active_flags():
-            v = ViewAs(
-                actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}),
-                hidden=frozenset({ROLE_ADMIN}),
-            )
-            assert v.popover_rows == [
-                {"name": ROLE_MEMBER, "label": "Member", "active": True},
-                {"name": ROLE_GUILD_OFFICER, "label": "Guild Officer", "active": True},
-                {"name": ROLE_ADMIN, "label": "Admin", "active": False},
+    def describe_current_label():
+        def it_is_admin_by_default_for_an_admin():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=None)
+            assert v.current_label == "Admin"
+
+        def it_reflects_the_picked_role():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=ROLE_GUILD_OFFICER)
+            assert v.current_label == "Guild Officer"
+
+        def it_is_empty_when_no_role_is_resolved():
+            v = ViewAs(actual=frozenset(), picked=None)
+            assert v.current_label == ""
+
+    def describe_dropdown_options():
+        def it_lists_roles_highest_first_with_selected_flag():
+            v = ViewAs(actual=frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=ROLE_GUILD_OFFICER)
+            assert v.dropdown_options == [
+                {"name": ROLE_ADMIN, "label": "Admin", "selected": False},
+                {"name": ROLE_GUILD_OFFICER, "label": "Guild Officer", "selected": True},
+                {"name": ROLE_MEMBER, "label": "Member", "selected": False},
             ]
 
         def it_skips_roles_not_actually_held():
-            v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), hidden=frozenset())
-            names = [row["name"] for row in v.popover_rows]
-            assert names == [ROLE_MEMBER, ROLE_GUILD_OFFICER]
-
-
-@pytest.fixture
-def rf() -> RequestFactory:
-    return RequestFactory()
+            v = ViewAs(actual=frozenset({ROLE_GUILD_OFFICER, ROLE_MEMBER}), picked=None)
+            names = [row["name"] for row in v.dropdown_options]
+            assert names == [ROLE_GUILD_OFFICER, ROLE_MEMBER]
 
 
 @pytest.mark.django_db
@@ -139,14 +159,14 @@ def describe_ViewAsMiddleware():
 
         ViewAsMiddleware(get_response)(request)
 
-        assert captured["view_as"].is_admin is True
+        assert captured["view_as"].view_as_role == ROLE_ADMIN
         assert captured["view_as"].actual == frozenset({ROLE_ADMIN, ROLE_GUILD_OFFICER, ROLE_MEMBER})
 
-    def it_respects_hidden_roles_in_session(rf: RequestFactory):
-        user, _ = _make_user_member(Member.FogRole.ADMIN, username="mw_hidden")
+    def it_respects_picked_role_in_session(rf: RequestFactory):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="mw_picked")
         request = rf.get("/")
         request.user = user
-        request.session = {"view_as_hidden_roles": ["admin"]}
+        request.session = {"view_as_role": "guild_officer"}
 
         captured: dict[str, object] = {}
 
@@ -156,78 +176,97 @@ def describe_ViewAsMiddleware():
 
         ViewAsMiddleware(get_response)(request)
 
+        assert captured["view_as"].view_as_role == ROLE_GUILD_OFFICER
         assert captured["view_as"].is_admin is False
         assert captured["view_as"].is_guild_officer is True
 
+    def it_ignores_picked_role_the_user_does_not_hold(rf: RequestFactory):
+        user, _ = _make_user_member(Member.FogRole.MEMBER, username="mw_rogue")
+        request = rf.get("/")
+        request.user = user
+        request.session = {"view_as_role": "admin"}
+
+        captured: dict[str, object] = {}
+
+        def get_response(req):
+            captured["view_as"] = req.view_as
+            return "ok"
+
+        ViewAsMiddleware(get_response)(request)
+
+        assert captured["view_as"].view_as_role == ROLE_MEMBER
+        assert captured["view_as"].is_admin is False
+
 
 @pytest.mark.django_db
-def describe_view_as_toggle_endpoint():
-    def it_adds_role_to_hidden_set(client):
-        user, _ = _make_user_member(Member.FogRole.ADMIN, username="toggle_admin")
+def describe_view_as_set_endpoint():
+    def it_sets_picked_role_in_session(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="set_admin")
         client.login(username=user.username, password="p")
 
         response = client.post(
-            "/view-as/toggle/",
-            data=json.dumps({"role": "admin", "hidden": True}),
+            "/view-as/set/",
+            data=json.dumps({"role": "guild_officer"}),
             content_type="application/json",
         )
 
         assert response.status_code == 200
-        assert response.json() == {"hidden": ["admin"]}
-        assert client.session["view_as_hidden_roles"] == ["admin"]
+        assert response.json() == {"role": "guild_officer"}
+        assert client.session["view_as_role"] == "guild_officer"
 
-    def it_removes_role_when_hidden_is_false(client):
-        user, _ = _make_user_member(Member.FogRole.ADMIN, username="toggle_unhide")
+    def it_overwrites_previous_selection(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="set_overwrite")
         client.login(username=user.username, password="p")
         session = client.session
-        session["view_as_hidden_roles"] = ["admin", "guild_officer"]
+        session["view_as_role"] = "guild_officer"
         session.save()
 
         response = client.post(
-            "/view-as/toggle/",
-            data=json.dumps({"role": "admin", "hidden": False}),
+            "/view-as/set/",
+            data=json.dumps({"role": "admin"}),
             content_type="application/json",
         )
 
         assert response.status_code == 200
-        assert response.json() == {"hidden": ["guild_officer"]}
+        assert response.json() == {"role": "admin"}
+        assert client.session["view_as_role"] == "admin"
 
     def it_rejects_unknown_role_names(client):
-        user, _ = _make_user_member(Member.FogRole.ADMIN, username="toggle_wizard")
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="set_wizard")
         client.login(username=user.username, password="p")
 
         response = client.post(
-            "/view-as/toggle/",
-            data=json.dumps({"role": "wizard", "hidden": True}),
+            "/view-as/set/",
+            data=json.dumps({"role": "wizard"}),
             content_type="application/json",
         )
 
         assert response.status_code == 400
 
-    def it_rejects_toggling_a_role_the_user_does_not_hold(client):
-        user, _ = _make_user_member(Member.FogRole.MEMBER, username="toggle_plain")
+    def it_rejects_viewing_as_a_role_the_user_does_not_hold(client):
+        user, _ = _make_user_member(Member.FogRole.MEMBER, username="set_plain")
         client.login(username=user.username, password="p")
 
         response = client.post(
-            "/view-as/toggle/",
-            data=json.dumps({"role": "admin", "hidden": True}),
+            "/view-as/set/",
+            data=json.dumps({"role": "admin"}),
             content_type="application/json",
         )
 
         assert response.status_code == 403
 
     def it_rejects_malformed_json(client):
-        user, _ = _make_user_member(Member.FogRole.ADMIN, username="toggle_malformed")
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="set_malformed")
         client.login(username=user.username, password="p")
 
-        response = client.post("/view-as/toggle/", data=b"not json", content_type="application/json")
+        response = client.post("/view-as/set/", data=b"not json", content_type="application/json")
 
         assert response.status_code == 400
 
     def it_requires_login(client):
         response = client.post(
-            "/view-as/toggle/",
-            data=json.dumps({"role": "admin", "hidden": True}),
+            "/view-as/set/",
+            data=json.dumps({"role": "admin"}),
             content_type="application/json",
         )
 
@@ -235,8 +274,8 @@ def describe_view_as_toggle_endpoint():
 
 
 @pytest.mark.django_db
-def describe_popover_in_hub_template():
-    def it_renders_popover_for_admins(client):
+def describe_dropdown_in_hub_template():
+    def it_renders_dropdown_for_admins(client):
         user, _ = _make_user_member(Member.FogRole.ADMIN, username="tmpl_admin")
         client.login(username=user.username, password="p")
 
@@ -244,9 +283,9 @@ def describe_popover_in_hub_template():
 
         assert response.status_code == 200
         assert b"pl-view-as-popover" in response.content
-        assert b"Viewing as" in response.content
+        assert b"Viewing as: Admin" in response.content
 
-    def it_hides_popover_for_plain_members(client):
+    def it_hides_dropdown_for_plain_members(client):
         user, _ = _make_user_member(Member.FogRole.MEMBER, username="tmpl_plain")
         client.login(username=user.username, password="p")
 
@@ -255,13 +294,26 @@ def describe_popover_in_hub_template():
         assert response.status_code == 200
         assert b"pl-view-as-popover" not in response.content
 
-    def it_hides_admin_view_button_when_admin_role_is_hidden(client):
-        user, _ = _make_user_member(Member.FogRole.ADMIN, username="tmpl_hidden_admin")
+    def it_hides_admin_view_button_when_viewing_as_guild_officer(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="tmpl_as_officer")
         client.login(username=user.username, password="p")
         session = client.session
-        session["view_as_hidden_roles"] = ["admin"]
+        session["view_as_role"] = "guild_officer"
         session.save()
 
         response = client.get("/guilds/voting/")
 
         assert b"Admin View" not in response.content
+        assert b"Viewing as: Guild Officer" in response.content
+
+    def it_hides_admin_view_button_when_viewing_as_member(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="tmpl_as_member")
+        client.login(username=user.username, password="p")
+        session = client.session
+        session["view_as_role"] = "member"
+        session.save()
+
+        response = client.get("/guilds/voting/")
+
+        assert b"Admin View" not in response.content
+        assert b"Viewing as: Member" in response.content


### PR DESCRIPTION
## Summary

Adds a minimal "Viewing as" popover to the hub topbar so admins (and guild officers, once we gate more UI on their role) can preview the hub the way a member of a different role would see it — without logging out.

- **Session-backed:** toggles are stored in `session["view_as_hidden_roles"]`, never persisted to the DB.
- **Fail-safe:** the popover can only *hide* roles the user actually holds — you can't grant yourself admin by poking the endpoint.
- **Zero schema changes:** roles derive entirely from the existing `member.fog_role` field.

### What you see

- Admins get a new "Viewing as" button in the topbar next to "Admin View".
- Clicking it opens a small popover with a checkbox per role the user holds (Member, Guild Officer, Admin).
- Unchecking a role reloads the page and the corresponding UI disappears for the current session. So far the only gated hub UI is the "Admin View" button — this PR installs the scaffolding; per-role gating of other affordances can land in follow-up PRs as they're needed.

### How it works

- `hub/view_as.py` — `compute_actual_roles(user)`, `ViewAs` wrapper, `ViewAsMiddleware` that attaches `request.view_as` to every request.
- `POST /view-as/toggle/` — JSON endpoint `{"role": "...", "hidden": bool}` → writes to session. Rejects unknown roles (400) and roles-you-don't-hold (403).
- `templates/hub/base.html` — topbar popover + Alpine component; the existing "Admin View" button is re-gated on `request.view_as.is_admin` instead of `user.is_staff` so hiding admin removes the button.
- 26 BDD specs in `tests/hub/view_as_spec.py` covering role derivation, session read/write, middleware, the toggle endpoint, and template rendering.

Plan: `docs/superpowers/plans/2026-04-17-viewing-as.md`

## Test plan

- [ ] Log in as an admin → "Viewing as" button appears in topbar.
- [ ] Open popover → three checkboxes (Member, Guild Officer, Admin), all checked.
- [ ] Uncheck "Admin" → page reloads, "Admin View" button disappears.
- [ ] Re-check "Admin" → "Admin View" button comes back.
- [ ] Log in as a plain member → no "Viewing as" button.
- [ ] `curl -X POST /view-as/toggle/` with `role=wizard` → 400.
- [ ] `curl -X POST /view-as/toggle/` as a plain member with `role=admin` → 403.
- [ ] Log out and back in → hidden roles reset (session-only, by design).