### PR TITLE
fix(deploy): dummy DATABASE_URL for collectstatic build (1.7.0.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN python manage.py collectstatic --noinput
+RUN DATABASE_URL="sqlite:///tmp/build.db" python manage.py collectstatic --noinput
 
 EXPOSE ${PORT:-10000}
 

--- a/classes/managers.py
+++ b/classes/managers.py
@@ -1,16 +1,12 @@
-"""Custom managers / querysets for classes models."""
+"""Custom managers / querysets for classes models.
+
+The concrete ``ClassOfferingQuerySet`` lives in ``classes.models`` alongside the
+model so django-stubs can resolve the manager type. This module re-exports it
+for backwards compatibility with any callers still importing from here.
+"""
 
 from __future__ import annotations
 
-from django.db import models
+from classes.models import ClassOfferingQuerySet
 
-
-class ClassOfferingQuerySet(models.QuerySet):
-    def public(self) -> "ClassOfferingQuerySet":
-        return self.filter(status="published")
-
-    def pending_review(self) -> "ClassOfferingQuerySet":
-        return self.filter(status="pending")
-
-    def for_instructor(self, instructor) -> "ClassOfferingQuerySet":
-        return self.filter(instructor=instructor)
+__all__ = ["ClassOfferingQuerySet"]

--- a/classes/models.py
+++ b/classes/models.py
@@ -10,8 +10,6 @@ from django.db import models
 from django.db.models import CheckConstraint, F, Q
 from django.utils import timezone
 
-from classes.managers import ClassOfferingQuerySet
-
 DEFAULT_LIABILITY_TEXT = """ASSUMPTION OF RISK AND WAIVER OF LIABILITY
 
 I understand that participation in classes, workshops, and activities at Past Lives Makerspace ("PLM") involves inherent risks, including but not limited to: exposure to tools, machinery, and equipment; risk of cuts, burns, eye injury, hearing damage, and other physical harm; and exposure to dust, fumes, chemicals, and other materials.
@@ -71,6 +69,17 @@ class Instructor(models.Model):
 
     def __str__(self) -> str:
         return self.display_name
+
+
+class ClassOfferingQuerySet(models.QuerySet["ClassOffering"]):
+    def public(self) -> "ClassOfferingQuerySet":
+        return self.filter(status="published")
+
+    def pending_review(self) -> "ClassOfferingQuerySet":
+        return self.filter(status="pending")
+
+    def for_instructor(self, instructor: "Instructor") -> "ClassOfferingQuerySet":
+        return self.filter(instructor=instructor)
 
 
 class ClassOffering(models.Model):

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-VERSION = "1.7.0.1"
+VERSION = "1.7.0.2"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.7.0.2",
+        "date": "2026-04-21",
+        "title": "Hotfix: deploy failing on Render",
+        "changes": [
+            "Fixed a deploy failure that was blocking new releases from going live on Render — the build step that packages up static files was being rejected because it couldn't see the production database settings. It now uses a harmless placeholder just for that build step, so deploys go through again",
+        ],
+    },
     {
         "version": "1.7.0.1",
         "date": "2026-04-21",


### PR DESCRIPTION
## Summary
- Render deploys were failing in the Docker build at `RUN python manage.py collectstatic --noinput` because `settings.py` hard-fails when `DATABASE_URL` is unset.
- `collectstatic` never touches the database — pass a throwaway `sqlite:///tmp/build.db` just for that build step. Runtime still uses Render's real `DATABASE_URL`.
- Bumps version to 1.7.0.2 with a member-friendly changelog entry.

## Test plan
- [ ] Merge and confirm Render build completes past the `collectstatic` step
- [ ] Confirm app boots on Render with the real `DATABASE_URL` from env
- [ ] Confirm Discord release announcement posts on merge