### PR TITLE
Classes: public registration + Stripe Checkout, unified page, fixes (v1.7.5)

### DIFF
--- a/billing/stripe_utils.py
+++ b/billing/stripe_utils.py
@@ -159,6 +159,50 @@ def create_payment_intent(
     }
 
 
+def create_class_checkout_session(
+    *,
+    amount_cents: int,
+    product_name: str,
+    customer_email: str,
+    success_url: str,
+    cancel_url: str,
+    metadata: dict[str, str],
+    idempotency_key: str,
+) -> dict[str, str]:
+    """Create a Stripe Checkout Session for a one-off class registration.
+
+    Used by the public class registration flow — Stripe collects card details
+    on its hosted page, then redirects back to ``success_url``. The webhook
+    handler for ``checkout.session.completed`` confirms the registration.
+
+    Returns dict with 'id' and 'url' (the hosted Checkout page).
+    The idempotency_key is REQUIRED to prevent duplicate sessions on retry.
+    """
+    client = _get_stripe_client()
+    session = client.v1.checkout.sessions.create(
+        params={
+            "mode": "payment",
+            "customer_email": customer_email,
+            "line_items": [
+                {
+                    "quantity": 1,
+                    "price_data": {
+                        "currency": "usd",
+                        "unit_amount": amount_cents,
+                        "product_data": {"name": product_name},
+                    },
+                }
+            ],
+            "metadata": metadata,
+            "payment_intent_data": {"metadata": metadata},
+            "success_url": success_url,
+            "cancel_url": cancel_url,
+        },
+        options={"idempotency_key": idempotency_key},
+    )
+    return {"id": session.id, "url": session.url or ""}
+
+
 def construct_webhook_event(*, payload: bytes, sig_header: str) -> stripe.Event:
     """Verify and construct a Stripe webhook event from the raw payload.
 

--- a/billing/views.py
+++ b/billing/views.py
@@ -16,6 +16,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from billing import stripe_utils, webhook_handlers
+from classes import webhook_handlers as classes_webhook_handlers
 from billing.exceptions import TabLimitExceededError, TabLockedError
 from billing.forms import CONTEXT_ADMIN_DASHBOARD, TabItemForm
 from billing.models import BillingSettings, Tab, TabCharge, TabEntry
@@ -31,6 +32,7 @@ _WEBHOOK_HANDLERS = {
     "payment_method.detached": webhook_handlers.handle_payment_method_detached,
     "payment_method.updated": webhook_handlers.handle_payment_method_updated,
     "charge.dispute.created": webhook_handlers.handle_charge_dispute_created,
+    "checkout.session.completed": classes_webhook_handlers.handle_checkout_session_completed,
 }
 
 

--- a/classes/emails.py
+++ b/classes/emails.py
@@ -7,9 +7,44 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils import timezone
 
 if TYPE_CHECKING:
     from classes.models import ClassSession, Registration
+
+
+def send_registration_confirmation(registration: "Registration") -> None:
+    """Email a registrant their confirmation + self-serve link.
+
+    Sent on payment success (paid classes) or immediately on submit
+    (free classes). Idempotent at the call site — the webhook handler
+    skips already-confirmed registrations before calling this.
+    """
+    from classes.models import ClassSettings
+
+    settings_obj = ClassSettings.load()
+    offering = registration.class_offering
+    upcoming_sessions = list(offering.sessions.filter(starts_at__gte=timezone.now()).order_by("starts_at"))
+    self_serve_url = reverse("classes:my_registration", kwargs={"token": registration.self_serve_token})
+    context = {
+        "registration": registration,
+        "offering": offering,
+        "upcoming_sessions": upcoming_sessions,
+        "self_serve_url": self_serve_url,
+        "amount_paid_cents": registration.amount_paid_cents,
+        "amount_paid_dollars": f"{registration.amount_paid_cents / 100:.2f}",
+        "footer": settings_obj.confirmation_email_footer,
+    }
+    body = render_to_string("classes/emails/confirmation.txt", context)
+    subject = f"You're confirmed for {offering.title}"
+    send_mail(
+        subject=subject,
+        message=body,
+        from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
+        recipient_list=[registration.email],
+        fail_silently=False,
+    )
 
 
 def send_reminder_email(registration: "Registration", session: "ClassSession") -> None:

--- a/classes/forms.py
+++ b/classes/forms.py
@@ -9,10 +9,19 @@ from django.contrib.auth import get_user_model
 from django.forms import inlineformset_factory
 from django.utils.text import slugify
 
-from classes.models import Category, ClassOffering, ClassSession, ClassSettings, DiscountCode, Instructor
+from classes.models import (
+    Category,
+    ClassOffering,
+    ClassSession,
+    ClassSettings,
+    DiscountCode,
+    Instructor,
+    Registration,
+    Waiver,
+)
 
 if TYPE_CHECKING:
-    pass
+    from membership.models import Member
 
 
 class ClassOfferingForm(forms.ModelForm):
@@ -203,6 +212,136 @@ class DiscountCodeForm(forms.ModelForm):
         if not data.get("discount_pct") and not data.get("discount_fixed_cents"):
             raise forms.ValidationError("Set either a percent OR a fixed-cents discount.")
         return data
+
+
+class RegistrationForm(forms.ModelForm):
+    """Public registration form — collects registrant + waiver signatures.
+
+    Computes the final price (member discount + optional discount code) and,
+    on save, creates the Registration plus signed Waiver records.
+    """
+
+    discount_code = forms.CharField(
+        max_length=40,
+        required=False,
+        label="Discount code (optional)",
+    )
+    liability_signature = forms.CharField(
+        max_length=255,
+        label="Type your full name to sign the liability waiver",
+    )
+    model_release_signature = forms.CharField(
+        max_length=255,
+        required=False,
+        label="Type your full name to sign the model release",
+    )
+    accepts_liability = forms.BooleanField(
+        label="I have read and agree to the liability waiver above.",
+    )
+    accepts_model_release = forms.BooleanField(
+        required=False,
+        label="I have read and agree to the model release above.",
+    )
+
+    class Meta:
+        model = Registration
+        fields = [
+            "first_name",
+            "last_name",
+            "pronouns",
+            "email",
+            "phone",
+            "prior_experience",
+            "looking_for",
+        ]
+        widgets = {
+            "prior_experience": forms.Textarea(attrs={"rows": 3}),
+            "looking_for": forms.Textarea(attrs={"rows": 3}),
+        }
+
+    def __init__(
+        self,
+        *args,
+        offering: ClassOffering,
+        settings_obj: ClassSettings,
+        member: "Member | None" = None,
+        client_ip: str = "",
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.offering = offering
+        self.settings_obj = settings_obj
+        self.member = member
+        self.client_ip = client_ip
+        self._validated_discount: DiscountCode | None = None
+        if not offering.requires_model_release:
+            # Hide model release fields entirely when the class doesn't need them.
+            self.fields.pop("model_release_signature")
+            self.fields.pop("accepts_model_release")
+
+    def clean_discount_code(self) -> DiscountCode | None:
+        raw = (self.cleaned_data.get("discount_code") or "").strip().upper()
+        if not raw:
+            return None
+        try:
+            code = DiscountCode.objects.get(code=raw)
+        except DiscountCode.DoesNotExist:
+            raise forms.ValidationError("That discount code isn't recognized.") from None
+        if not code.is_currently_valid():
+            raise forms.ValidationError("That discount code isn't valid right now.")
+        self._validated_discount = code
+        return code
+
+    def clean(self) -> dict:
+        data = super().clean()
+        if self.offering.spots_remaining <= 0:
+            raise forms.ValidationError("This class is sold out.")
+        if self.offering.requires_model_release and not data.get("accepts_model_release"):
+            self.add_error("accepts_model_release", "Model release acceptance is required for this class.")
+        return data
+
+    @property
+    def member_discount_pct(self) -> int:
+        """Member discount applies only when the registrant matches a verified member."""
+        if self.member is None:
+            return 0
+        return self.offering.member_discount_pct or 0
+
+    def compute_final_price_cents(self) -> int:
+        price = self.offering.price_cents
+        if self.member_discount_pct:
+            price = int(price * (100 - self.member_discount_pct) / 100)
+        code = self._validated_discount
+        if code is not None:
+            price = code.apply_to(price)
+        return max(0, price)
+
+    def save(self, commit: bool = True) -> Registration:
+        registration: Registration = super().save(commit=False)
+        registration.class_offering = self.offering
+        registration.discount_code = self._validated_discount
+        registration.amount_paid_cents = 0  # set on payment success or, for free classes, on confirm
+        if commit:
+            registration.save()
+            self._create_waivers(registration)
+        return registration
+
+    def _create_waivers(self, registration: Registration) -> None:
+        Waiver.objects.create(
+            registration=registration,
+            kind=Waiver.Kind.LIABILITY,
+            waiver_text=self.settings_obj.liability_waiver_text,
+            signature_text=self.cleaned_data["liability_signature"],
+            ip_address=self.client_ip or None,
+        )
+        if self.offering.requires_model_release:
+            Waiver.objects.create(
+                registration=registration,
+                kind=Waiver.Kind.MODEL_RELEASE,
+                waiver_text=self.settings_obj.model_release_waiver_text,
+                signature_text=self.cleaned_data["model_release_signature"],
+                ip_address=self.client_ip or None,
+            )
 
 
 class ClassSettingsForm(forms.ModelForm):

--- a/classes/spec/forms/registration_form_spec.py
+++ b/classes/spec/forms/registration_form_spec.py
@@ -1,0 +1,158 @@
+"""BDD specs for the public RegistrationForm."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from classes.factories import (
+    CategoryFactory,
+    ClassOfferingFactory,
+    DiscountCodeFactory,
+    InstructorFactory,
+    RegistrationFactory,
+)
+from classes.forms import RegistrationForm
+from classes.models import ClassOffering, ClassSettings, Registration, Waiver
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def offering(db):
+    return ClassOfferingFactory(
+        title="Forge Basics",
+        slug="forge-basics",
+        category=CategoryFactory(),
+        instructor=InstructorFactory(),
+        status=ClassOffering.Status.PUBLISHED,
+        price_cents=10000,
+        member_discount_pct=10,
+        capacity=4,
+    )
+
+
+@pytest.fixture
+def settings_obj(db):
+    return ClassSettings.load()
+
+
+def _post_data(**overrides):
+    data = {
+        "first_name": "Sam",
+        "last_name": "Smith",
+        "pronouns": "",
+        "email": "sam@example.com",
+        "phone": "",
+        "prior_experience": "",
+        "looking_for": "",
+        "discount_code": "",
+        "liability_signature": "Sam Smith",
+        "accepts_liability": "on",
+    }
+    data.update(overrides)
+    return data
+
+
+def describe_RegistrationForm():
+    def describe_validation():
+        def it_is_valid_with_minimum_required_fields(offering, settings_obj):
+            form = RegistrationForm(data=_post_data(), offering=offering, settings_obj=settings_obj)
+            assert form.is_valid(), form.errors
+
+        def it_requires_liability_acceptance(offering, settings_obj):
+            data = _post_data()
+            data.pop("accepts_liability")
+            form = RegistrationForm(data=data, offering=offering, settings_obj=settings_obj)
+            assert not form.is_valid()
+            assert "accepts_liability" in form.errors
+
+        def it_rejects_when_class_is_sold_out(offering, settings_obj):
+            for _ in range(offering.capacity):
+                RegistrationFactory(class_offering=offering, status=Registration.Status.CONFIRMED)
+            form = RegistrationForm(data=_post_data(), offering=offering, settings_obj=settings_obj)
+            assert not form.is_valid()
+            assert "sold out" in str(form.errors).lower()
+
+        def it_rejects_unknown_discount_code(offering, settings_obj):
+            form = RegistrationForm(data=_post_data(discount_code="NOPE"), offering=offering, settings_obj=settings_obj)
+            assert not form.is_valid()
+            assert "discount_code" in form.errors
+
+        def it_rejects_expired_discount_code(offering, settings_obj):
+            DiscountCodeFactory(code="OLD", discount_pct=20, valid_until=date.today() - timedelta(days=1))
+            form = RegistrationForm(data=_post_data(discount_code="OLD"), offering=offering, settings_obj=settings_obj)
+            assert not form.is_valid()
+
+        def it_requires_model_release_when_class_demands_it(offering, settings_obj):
+            offering.requires_model_release = True
+            offering.save()
+            data = _post_data()
+            # Don't include accepts_model_release / model_release_signature
+            form = RegistrationForm(data=data, offering=offering, settings_obj=settings_obj)
+            assert not form.is_valid()
+            assert "accepts_model_release" in form.errors
+
+    def describe_compute_final_price_cents():
+        def it_returns_full_price_for_non_member_without_discount(offering, settings_obj):
+            form = RegistrationForm(data=_post_data(), offering=offering, settings_obj=settings_obj)
+            assert form.is_valid()
+            assert form.compute_final_price_cents() == 10000
+
+        def it_applies_member_discount_when_member_is_set(offering, settings_obj):
+            sentinel_member = object()  # we only check truthiness, not identity
+            form = RegistrationForm(
+                data=_post_data(), offering=offering, settings_obj=settings_obj, member=sentinel_member
+            )
+            assert form.is_valid()
+            assert form.compute_final_price_cents() == 9000  # 10% off
+
+        def it_applies_discount_code_on_top_of_member_discount(offering, settings_obj):
+            DiscountCodeFactory(code="SAVE20", discount_pct=20)
+            sentinel_member = object()
+            form = RegistrationForm(
+                data=_post_data(discount_code="save20"),
+                offering=offering,
+                settings_obj=settings_obj,
+                member=sentinel_member,
+            )
+            assert form.is_valid(), form.errors
+            # 10000 -> 9000 (member) -> 7200 (20% off)
+            assert form.compute_final_price_cents() == 7200
+
+        def it_floors_at_zero(offering, settings_obj):
+            DiscountCodeFactory(code="FREE", discount_pct=None, discount_fixed_cents=999_999)
+            form = RegistrationForm(data=_post_data(discount_code="FREE"), offering=offering, settings_obj=settings_obj)
+            assert form.is_valid()
+            assert form.compute_final_price_cents() == 0
+
+    def describe_save():
+        def it_creates_registration_with_offering_attached(offering, settings_obj):
+            form = RegistrationForm(data=_post_data(), offering=offering, settings_obj=settings_obj)
+            assert form.is_valid()
+            registration = form.save()
+            assert registration.class_offering_id == offering.pk
+            assert registration.email == "sam@example.com"
+            assert registration.self_serve_token
+
+        def it_creates_a_liability_waiver_record(offering, settings_obj):
+            form = RegistrationForm(
+                data=_post_data(), offering=offering, settings_obj=settings_obj, client_ip="10.0.0.1"
+            )
+            assert form.is_valid()
+            registration = form.save()
+            waiver = registration.waivers.get(kind=Waiver.Kind.LIABILITY)
+            assert waiver.signature_text == "Sam Smith"
+            assert waiver.ip_address == "10.0.0.1"
+            assert "ASSUMPTION OF RISK" in waiver.waiver_text
+
+        def it_creates_both_waivers_when_model_release_required(offering, settings_obj):
+            offering.requires_model_release = True
+            offering.save()
+            data = _post_data(model_release_signature="Sam Smith", accepts_model_release="on")
+            form = RegistrationForm(data=data, offering=offering, settings_obj=settings_obj)
+            assert form.is_valid(), form.errors
+            registration = form.save()
+            kinds = set(registration.waivers.values_list("kind", flat=True))
+            assert kinds == {Waiver.Kind.LIABILITY, Waiver.Kind.MODEL_RELEASE}

--- a/classes/spec/views/public_spec.py
+++ b/classes/spec/views/public_spec.py
@@ -72,7 +72,21 @@ def describe_public_list():
         response = client.get(reverse("classes:public_list"))
         assert b"Private Lesson" not in response.content
 
-    def it_hides_published_classes_with_no_upcoming_sessions(db, client):
+    def it_shows_published_classes_with_no_upcoming_sessions(db, client):
+        category = CategoryFactory()
+        instructor = InstructorFactory()
+        ClassOfferingFactory(
+            title="Brand New Class",
+            slug="brand-new-class",
+            category=category,
+            instructor=instructor,
+            status=ClassOffering.Status.PUBLISHED,
+        )
+        response = client.get(reverse("classes:public_list"))
+        assert b"Brand New Class" in response.content
+        assert b"Upcoming dates TBA" in response.content
+
+    def it_shows_published_classes_whose_only_sessions_are_past(db, client):
         category = CategoryFactory()
         instructor = InstructorFactory()
         stale = ClassOfferingFactory(
@@ -89,7 +103,7 @@ def describe_public_list():
             ends_at=past_start + timedelta(hours=2),
         )
         response = client.get(reverse("classes:public_list"))
-        assert b"Past Class" not in response.content
+        assert b"Past Class" in response.content
 
     def it_includes_flexible_classes_even_without_sessions(db, client):
         category = CategoryFactory()

--- a/classes/spec/views/register_spec.py
+++ b/classes/spec/views/register_spec.py
@@ -1,0 +1,187 @@
+"""BDD specs for the public registration views."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.core import mail
+from django.urls import reverse
+from django.utils import timezone
+
+from classes.factories import (
+    CategoryFactory,
+    ClassOfferingFactory,
+    ClassSessionFactory,
+    InstructorFactory,
+    RegistrationFactory,
+)
+from classes.models import ClassOffering, Registration
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def paid_offering(db):
+    offering = ClassOfferingFactory(
+        title="Forge Basics",
+        slug="forge-basics",
+        category=CategoryFactory(),
+        instructor=InstructorFactory(),
+        status=ClassOffering.Status.PUBLISHED,
+        price_cents=10000,
+        member_discount_pct=10,
+        capacity=4,
+    )
+    ClassSessionFactory(
+        class_offering=offering,
+        starts_at=timezone.now() + timedelta(days=7),
+        ends_at=timezone.now() + timedelta(days=7, hours=2),
+    )
+    return offering
+
+
+@pytest.fixture
+def free_offering(db):
+    offering = ClassOfferingFactory(
+        title="Free Demo",
+        slug="free-demo",
+        category=CategoryFactory(),
+        instructor=InstructorFactory(),
+        status=ClassOffering.Status.PUBLISHED,
+        price_cents=0,
+        member_discount_pct=0,
+        capacity=4,
+    )
+    ClassSessionFactory(
+        class_offering=offering,
+        starts_at=timezone.now() + timedelta(days=3),
+        ends_at=timezone.now() + timedelta(days=3, hours=2),
+    )
+    return offering
+
+
+def _post_data(**overrides):
+    data = {
+        "first_name": "Sam",
+        "last_name": "Smith",
+        "pronouns": "",
+        "email": "sam@example.com",
+        "phone": "",
+        "prior_experience": "",
+        "looking_for": "",
+        "discount_code": "",
+        "liability_signature": "Sam Smith",
+        "accepts_liability": "on",
+    }
+    data.update(overrides)
+    return data
+
+
+def describe_register_view():
+    def it_renders_the_form(paid_offering, client):
+        response = client.get(reverse("classes:register", kwargs={"slug": paid_offering.slug}))
+        assert response.status_code == 200
+        assert b"Liability Waiver" in response.content
+        assert b"Continue to Payment" in response.content
+
+    def it_404s_for_unpublished_class(db, client):
+        offering = ClassOfferingFactory(status=ClassOffering.Status.DRAFT, slug="hidden")
+        response = client.get(reverse("classes:register", kwargs={"slug": offering.slug}))
+        assert response.status_code == 404
+
+    def it_confirms_immediately_for_a_free_class(free_offering, client):
+        response = client.post(reverse("classes:register", kwargs={"slug": free_offering.slug}), data=_post_data())
+        assert response.status_code == 302
+        assert response.url == reverse("classes:register_success", kwargs={"slug": free_offering.slug})
+        registration = Registration.objects.get(class_offering=free_offering)
+        assert registration.status == Registration.Status.CONFIRMED
+        assert registration.confirmed_at is not None
+        assert registration.amount_paid_cents == 0
+        assert len(mail.outbox) == 1
+        assert "confirmed" in mail.outbox[0].subject.lower()
+
+    @patch("billing.stripe_utils.create_class_checkout_session")
+    def it_kicks_off_stripe_checkout_for_paid_classes(mock_checkout, paid_offering, client):
+        mock_checkout.return_value = {"id": "cs_test_123", "url": "https://checkout.stripe.com/c/pay/cs_test_123"}
+
+        response = client.post(reverse("classes:register", kwargs={"slug": paid_offering.slug}), data=_post_data())
+
+        assert response.status_code == 302
+        assert response.url == "https://checkout.stripe.com/c/pay/cs_test_123"
+        registration = Registration.objects.get(class_offering=paid_offering)
+        assert registration.status == Registration.Status.PENDING
+        assert registration.stripe_session_id == "cs_test_123"
+        assert registration.amount_paid_cents == 10000  # provisional, no member match
+
+        kwargs = mock_checkout.call_args.kwargs
+        assert kwargs["amount_cents"] == 10000
+        assert kwargs["customer_email"] == "sam@example.com"
+        assert kwargs["metadata"]["registration_id"] == str(registration.pk)
+        assert kwargs["metadata"]["kind"] == "class_registration"
+
+    @patch("billing.stripe_utils.create_class_checkout_session")
+    def it_rolls_back_registration_when_stripe_fails(mock_checkout, paid_offering, client):
+        mock_checkout.side_effect = RuntimeError("stripe down")
+        with pytest.raises(RuntimeError):
+            client.post(reverse("classes:register", kwargs={"slug": paid_offering.slug}), data=_post_data())
+        assert not Registration.objects.filter(class_offering=paid_offering).exists()
+
+    def it_blocks_registration_when_sold_out(paid_offering, client):
+        for _ in range(paid_offering.capacity):
+            RegistrationFactory(class_offering=paid_offering, status=Registration.Status.CONFIRMED)
+        response = client.post(reverse("classes:register", kwargs={"slug": paid_offering.slug}), data=_post_data())
+        assert response.status_code == 200
+        assert b"sold out" in response.content.lower()
+
+
+def describe_register_success_view():
+    def it_renders_a_thanks_page(paid_offering, client):
+        response = client.get(reverse("classes:register_success", kwargs={"slug": paid_offering.slug}))
+        assert response.status_code == 200
+        assert b"You're in!" in response.content
+
+
+def describe_register_cancelled_view():
+    def it_deletes_the_pending_registration_when_token_provided(paid_offering, client):
+        registration = RegistrationFactory(class_offering=paid_offering, status=Registration.Status.PENDING)
+        url = reverse("classes:register_cancelled", kwargs={"slug": paid_offering.slug})
+        response = client.get(f"{url}?reg={registration.self_serve_token}")
+        assert response.status_code == 200
+        assert not Registration.objects.filter(pk=registration.pk).exists()
+
+    def it_keeps_confirmed_registrations_intact(paid_offering, client):
+        registration = RegistrationFactory(class_offering=paid_offering, status=Registration.Status.CONFIRMED)
+        url = reverse("classes:register_cancelled", kwargs={"slug": paid_offering.slug})
+        client.get(f"{url}?reg={registration.self_serve_token}")
+        assert Registration.objects.filter(pk=registration.pk).exists()
+
+
+def describe_my_registration_view():
+    def it_renders_via_token(paid_offering, client):
+        registration = RegistrationFactory(class_offering=paid_offering, status=Registration.Status.CONFIRMED)
+        response = client.get(reverse("classes:my_registration", kwargs={"token": registration.self_serve_token}))
+        assert response.status_code == 200
+        assert paid_offering.title.encode() in response.content
+
+    def it_404s_on_unknown_token(db, client):
+        response = client.get(reverse("classes:my_registration", kwargs={"token": "nope"}))
+        assert response.status_code == 404
+
+    def it_self_cancels_via_post(paid_offering, client):
+        registration = RegistrationFactory(class_offering=paid_offering, status=Registration.Status.CONFIRMED)
+        url = reverse("classes:my_registration_cancel", kwargs={"token": registration.self_serve_token})
+        response = client.post(url)
+        assert response.status_code == 302
+        registration.refresh_from_db()
+        assert registration.status == Registration.Status.CANCELLED
+        assert registration.cancelled_at is not None
+
+    def it_redirects_get_on_cancel_endpoint_back_to_self_serve(paid_offering, client):
+        registration = RegistrationFactory(class_offering=paid_offering, status=Registration.Status.CONFIRMED)
+        url = reverse("classes:my_registration_cancel", kwargs={"token": registration.self_serve_token})
+        response = client.get(url)
+        assert response.status_code == 302
+        registration.refresh_from_db()
+        assert registration.status == Registration.Status.CONFIRMED  # unchanged

--- a/classes/spec/views/register_spec.py
+++ b/classes/spec/views/register_spec.py
@@ -86,6 +86,22 @@ def describe_register_view():
         assert b"Liability Waiver" in response.content
         assert b"Continue to Payment" in response.content
 
+    def it_prefills_form_for_a_logged_in_member(paid_offering, client, member_user):
+        member = member_user.member
+        member.full_legal_name = "Robin Hood"
+        member.phone = "503-555-0100"
+        member.pronouns = "they/them"
+        member.save()
+        client.force_login(member_user)
+        response = client.get(reverse("classes:register", kwargs={"slug": paid_offering.slug}))
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert 'value="Robin"' in body
+        assert 'value="Hood"' in body
+        assert 'value="member@example.com"' in body
+        assert 'value="503-555-0100"' in body
+        assert 'value="they/them"' in body
+
     def it_404s_for_unpublished_class(db, client):
         offering = ClassOfferingFactory(status=ClassOffering.Status.DRAFT, slug="hidden")
         response = client.get(reverse("classes:register", kwargs={"slug": offering.slug}))

--- a/classes/spec/webhook_handlers_spec.py
+++ b/classes/spec/webhook_handlers_spec.py
@@ -1,0 +1,97 @@
+"""BDD specs for the classes app's Stripe webhook handler."""
+
+from __future__ import annotations
+
+import pytest
+from django.core import mail
+
+from classes.factories import (
+    ClassOfferingFactory,
+    DiscountCodeFactory,
+    RegistrationFactory,
+)
+from classes.models import ClassOffering, Registration
+from classes.webhook_handlers import handle_checkout_session_completed
+
+pytestmark = pytest.mark.django_db
+
+
+def _event(payment_status="paid", **session_overrides):
+    session = {
+        "id": "cs_test_abc",
+        "payment_status": payment_status,
+        "payment_intent": "pi_test_xyz",
+        "amount_total": 9000,
+        "metadata": {"kind": "class_registration", "registration_id": ""},
+    }
+    session.update(session_overrides)
+    return {"data": {"object": session}}
+
+
+@pytest.fixture
+def pending_registration(db):
+    offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED, price_cents=10000)
+    return RegistrationFactory(
+        class_offering=offering,
+        status=Registration.Status.PENDING,
+        amount_paid_cents=10000,
+        stripe_session_id="cs_test_abc",
+        email="buyer@example.com",
+    )
+
+
+def describe_handle_checkout_session_completed():
+    def it_confirms_the_registration_and_emails_the_registrant(pending_registration):
+        event = _event()
+        event["data"]["object"]["metadata"]["registration_id"] = str(pending_registration.pk)
+
+        handle_checkout_session_completed(event)
+
+        pending_registration.refresh_from_db()
+        assert pending_registration.status == Registration.Status.CONFIRMED
+        assert pending_registration.confirmed_at is not None
+        assert pending_registration.stripe_payment_id == "pi_test_xyz"
+        assert pending_registration.amount_paid_cents == 9000
+        assert len(mail.outbox) == 1
+        assert "confirmed" in mail.outbox[0].subject.lower()
+        assert mail.outbox[0].to == ["buyer@example.com"]
+
+    def it_is_idempotent_on_redelivery(pending_registration):
+        event = _event()
+        event["data"]["object"]["metadata"]["registration_id"] = str(pending_registration.pk)
+        handle_checkout_session_completed(event)
+        handle_checkout_session_completed(event)  # second delivery
+        # Only one email — second call short-circuits before sending.
+        assert len(mail.outbox) == 1
+
+    def it_increments_discount_use_count(pending_registration):
+        code = DiscountCodeFactory(code="SAVE10", discount_pct=10, use_count=0)
+        pending_registration.discount_code = code
+        pending_registration.save(update_fields=["discount_code"])
+        event = _event()
+        event["data"]["object"]["metadata"]["registration_id"] = str(pending_registration.pk)
+
+        handle_checkout_session_completed(event)
+
+        code.refresh_from_db()
+        assert code.use_count == 1
+
+    def it_ignores_events_from_other_checkout_kinds(pending_registration):
+        event = _event()
+        event["data"]["object"]["metadata"] = {"kind": "tab_topup"}
+        handle_checkout_session_completed(event)
+        pending_registration.refresh_from_db()
+        assert pending_registration.status == Registration.Status.PENDING
+        assert mail.outbox == []
+
+    def it_ignores_unpaid_sessions(pending_registration):
+        event = _event(payment_status="unpaid")
+        event["data"]["object"]["metadata"]["registration_id"] = str(pending_registration.pk)
+        handle_checkout_session_completed(event)
+        pending_registration.refresh_from_db()
+        assert pending_registration.status == Registration.Status.PENDING
+
+    def it_skips_when_registration_no_longer_exists(db):
+        event = _event()
+        event["data"]["object"]["metadata"]["registration_id"] = "999999"
+        handle_checkout_session_completed(event)  # should not raise

--- a/classes/urls.py
+++ b/classes/urls.py
@@ -9,6 +9,9 @@ urlpatterns = [
     path("", views.public_list, name="public_list"),
     path("category/<slug:slug>/", views.public_category, name="public_category"),
     path("instructors/<slug:slug>/", views.public_instructor, name="public_instructor"),
+    # Self-serve registration management (token-based, no auth)
+    path("my/<str:token>/", views.my_registration, name="my_registration"),
+    path("my/<str:token>/cancel/", views.my_registration_cancel, name="my_registration_cancel"),
     # Instructor dashboard
     path("instructor/", views.instructor_dashboard, name="instructor_dashboard"),
     path("instructor/classes/new/", views.instructor_class_create, name="instructor_class_create"),
@@ -53,6 +56,10 @@ urlpatterns = [
     path("admin/discount-codes/<int:pk>/edit/", views.admin_discount_code_edit, name="admin_discount_code_edit"),
     path("admin/discount-codes/<int:pk>/delete/", views.admin_discount_code_delete, name="admin_discount_code_delete"),
     path("admin/settings/", views.admin_settings, name="admin_settings"),
-    # Public class detail — keep last so admin/, category/, instructors/ win.
+    # Public registration — must come before the bare slug catch-all below.
+    path("<slug:slug>/register/", views.register, name="register"),
+    path("<slug:slug>/register/success/", views.register_success, name="register_success"),
+    path("<slug:slug>/register/cancelled/", views.register_cancelled, name="register_cancelled"),
+    # Public class detail — keep last so admin/, category/, instructors/, my/ win.
     path("<slug:slug>/", views.public_class_detail, name="public_class_detail"),
 ]

--- a/classes/views.py
+++ b/classes/views.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.db.models import Count, Min, Q
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
+
+if TYPE_CHECKING:
+    from membership.models import Member
 
 from classes.emails import send_registration_confirmation
 from classes.forms import (
@@ -159,7 +163,7 @@ def _client_ip(request: HttpRequest) -> str:
     return request.META.get("REMOTE_ADDR", "")
 
 
-def _member_for_email(email: str):
+def _member_for_email(email: str) -> "Member | None":
     """Verified Member matching this email, or None."""
     from membership.models import Member
 
@@ -173,7 +177,7 @@ def _member_for_email(email: str):
     )
 
 
-def _registration_initial_for_user(user) -> dict[str, str]:
+def _registration_initial_for_user(user: "AbstractBaseUser | AnonymousUser | None") -> dict[str, str]:
     """Pre-fill values pulled from the logged-in user's Member record."""
     if not user or not user.is_authenticated:
         return {}

--- a/classes/views.py
+++ b/classes/views.py
@@ -173,6 +173,24 @@ def _member_for_email(email: str):
     )
 
 
+def _registration_initial_for_user(user) -> dict[str, str]:
+    """Pre-fill values pulled from the logged-in user's Member record."""
+    if not user or not user.is_authenticated:
+        return {}
+    member = getattr(user, "member", None)
+    if member is None:
+        return {"email": user.email or ""}
+    name = (member.preferred_name or member.full_legal_name or user.get_full_name() or "").strip()
+    first_name, _, last_name = name.partition(" ")
+    return {
+        "first_name": first_name or user.first_name or "",
+        "last_name": last_name.strip() or user.last_name or "",
+        "email": member.primary_email or user.email or "",
+        "phone": member.phone or "",
+        "pronouns": member.pronouns or "",
+    }
+
+
 def register(request: HttpRequest, slug: str) -> HttpResponse:
     """Public registration form — collects info, signs waivers, kicks off Stripe Checkout.
 
@@ -188,8 +206,10 @@ def register(request: HttpRequest, slug: str) -> HttpResponse:
 
     # Two-pass form: first POST validates email so we can detect a member
     # before computing price, then re-binds to surface the discounted total.
+    # GET requests pre-fill from the logged-in user's Member record when present.
     bound_email = (request.POST.get("email") or "").strip() if request.method == "POST" else ""
     member = _member_for_email(bound_email) if bound_email else None
+    initial = {} if request.method == "POST" else _registration_initial_for_user(request.user)
 
     form = RegistrationForm(
         request.POST or None,
@@ -197,6 +217,7 @@ def register(request: HttpRequest, slug: str) -> HttpResponse:
         settings_obj=settings_obj,
         member=member,
         client_ip=_client_ip(request),
+        initial=initial,
     )
 
     if request.method == "POST" and form.is_valid():

--- a/classes/views.py
+++ b/classes/views.py
@@ -31,8 +31,11 @@ _ViewFunc = Callable[..., HttpResponse]
 def _browsable_classes() -> Any:
     """Published, non-private classes annotated with first upcoming session date.
 
-    Classes without any upcoming sessions are hidden unless they use flexible
-    scheduling. Ordered by category sort, then soonest upcoming session.
+    Every published, non-private class is shown — the template renders an
+    "Upcoming dates TBA" placeholder when no future sessions exist, so a
+    just-created class is visible immediately whether or not its schedule is
+    finalized. Ordered by category sort, then soonest upcoming session
+    (classes with no upcoming session sort to the bottom of each category).
     """
     now = timezone.now()
     return (
@@ -40,7 +43,6 @@ def _browsable_classes() -> Any:
         .select_related("category", "instructor")
         .prefetch_related("sessions")
         .annotate(first_session_at=Min("sessions__starts_at", filter=Q(sessions__starts_at__gte=now)))
-        .filter(Q(first_session_at__isnull=False) | Q(scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE))
         .order_by("category__sort_order", "category__name", "first_session_at", "title")
     )
 

--- a/classes/views.py
+++ b/classes/views.py
@@ -10,8 +10,10 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Min, Q
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils import timezone
 
+from classes.emails import send_registration_confirmation
 from classes.forms import (
     CategoryForm,
     ClassOfferingForm,
@@ -21,6 +23,7 @@ from classes.forms import (
     InstructorClassOfferingForm,
     InstructorProfileForm,
     PromoteUserToInstructorForm,
+    RegistrationForm,
 )
 from classes.models import Category, ClassOffering, ClassSettings, DiscountCode, Instructor, Registration
 from core.models import SiteConfiguration
@@ -146,6 +149,214 @@ def public_instructor(request: HttpRequest, slug: str) -> HttpResponse:
             "site_config": SiteConfiguration.load(),
         },
     )
+
+
+def _client_ip(request: HttpRequest) -> str:
+    """Best-effort client IP, honoring X-Forwarded-For when behind a proxy."""
+    forwarded = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR", "")
+
+
+def _member_for_email(email: str):
+    """Verified Member matching this email, or None."""
+    from membership.models import Member
+
+    return (
+        Member.objects.filter(
+            user__emailaddress__email__iexact=email,
+            user__emailaddress__verified=True,
+        )
+        .distinct()
+        .first()
+    )
+
+
+def register(request: HttpRequest, slug: str) -> HttpResponse:
+    """Public registration form — collects info, signs waivers, kicks off Stripe Checkout.
+
+    Free classes (price_cents == 0 after discounts) confirm immediately and
+    skip Stripe. Paid classes redirect to a Stripe Checkout Session; the
+    webhook handler flips the registration to CONFIRMED on success.
+    """
+    offering = get_object_or_404(
+        ClassOffering.objects.public().select_related("category", "instructor"),
+        slug=slug,
+    )
+    settings_obj = ClassSettings.load()
+
+    # Two-pass form: first POST validates email so we can detect a member
+    # before computing price, then re-binds to surface the discounted total.
+    bound_email = (request.POST.get("email") or "").strip() if request.method == "POST" else ""
+    member = _member_for_email(bound_email) if bound_email else None
+
+    form = RegistrationForm(
+        request.POST or None,
+        offering=offering,
+        settings_obj=settings_obj,
+        member=member,
+        client_ip=_client_ip(request),
+    )
+
+    if request.method == "POST" and form.is_valid():
+        registration = form.save()
+        final_price = form.compute_final_price_cents()
+
+        if final_price == 0:
+            # Free class — confirm + email immediately, no Stripe round-trip.
+            registration.status = Registration.Status.CONFIRMED
+            registration.confirmed_at = timezone.now()
+            registration.amount_paid_cents = 0
+            registration.save(update_fields=["status", "confirmed_at", "amount_paid_cents"])
+            if registration.discount_code_id:
+                _bump_discount_use_count(registration.discount_code_id)
+            send_registration_confirmation(registration)
+            return redirect("classes:register_success", slug=offering.slug)
+
+        # Paid class — kick off Stripe Checkout.
+        from billing import stripe_utils
+
+        success_url = (
+            request.build_absolute_uri(reverse("classes:register_success", kwargs={"slug": offering.slug}))
+            + f"?reg={registration.self_serve_token}"
+        )
+        cancel_url = (
+            request.build_absolute_uri(reverse("classes:register_cancelled", kwargs={"slug": offering.slug}))
+            + f"?reg={registration.self_serve_token}"
+        )
+
+        try:
+            checkout = stripe_utils.create_class_checkout_session(
+                amount_cents=final_price,
+                product_name=offering.title,
+                customer_email=registration.email,
+                success_url=success_url,
+                cancel_url=cancel_url,
+                metadata={
+                    "registration_id": str(registration.pk),
+                    "class_slug": offering.slug,
+                    "kind": "class_registration",
+                },
+                idempotency_key=f"class-checkout-reg-{registration.pk}",
+            )
+        except Exception:
+            registration.delete()  # roll back the half-created registration
+            raise
+
+        registration.stripe_session_id = checkout["id"]
+        registration.amount_paid_cents = final_price  # provisional; webhook is canonical
+        registration.save(update_fields=["stripe_session_id", "amount_paid_cents"])
+        return redirect(checkout["url"])
+
+    member_price_cents = None
+    if offering.member_discount_pct:
+        member_price_cents = int(offering.price_cents * (100 - offering.member_discount_pct) / 100)
+
+    return render(
+        request,
+        "classes/public/register.html",
+        {
+            "offering": offering,
+            "form": form,
+            "settings_obj": settings_obj,
+            "site_config": SiteConfiguration.load(),
+            "member_price_cents": member_price_cents,
+            "spots_remaining": offering.spots_remaining,
+        },
+    )
+
+
+def register_success(request: HttpRequest, slug: str) -> HttpResponse:
+    """Landing page after successful checkout — webhook does the real work."""
+    offering = get_object_or_404(
+        ClassOffering.objects.public().select_related("category", "instructor"),
+        slug=slug,
+    )
+    return render(
+        request,
+        "classes/public/register_success.html",
+        {
+            "offering": offering,
+            "settings_obj": ClassSettings.load(),
+            "site_config": SiteConfiguration.load(),
+        },
+    )
+
+
+def register_cancelled(request: HttpRequest, slug: str) -> HttpResponse:
+    """User backed out of Stripe Checkout — clean up the unpaid registration."""
+    offering = get_object_or_404(
+        ClassOffering.objects.public().select_related("category", "instructor"),
+        slug=slug,
+    )
+    token = request.GET.get("reg", "").strip()
+    if token:
+        Registration.objects.filter(
+            self_serve_token=token,
+            status=Registration.Status.PENDING,
+            class_offering=offering,
+        ).delete()
+    return render(
+        request,
+        "classes/public/register_cancelled.html",
+        {
+            "offering": offering,
+            "settings_obj": ClassSettings.load(),
+            "site_config": SiteConfiguration.load(),
+        },
+    )
+
+
+def my_registration(request: HttpRequest, token: str) -> HttpResponse:
+    """Self-serve registration page — no auth, identified by the unguessable token."""
+    registration = get_object_or_404(
+        Registration.objects.select_related("class_offering", "class_offering__instructor"),
+        self_serve_token=token,
+    )
+    offering = registration.class_offering
+    upcoming_sessions = list(offering.sessions.filter(starts_at__gte=timezone.now()).order_by("starts_at"))
+    can_self_cancel = registration.status in {
+        Registration.Status.PENDING,
+        Registration.Status.CONFIRMED,
+        Registration.Status.WAITLISTED,
+    } and (not upcoming_sessions or upcoming_sessions[0].starts_at > timezone.now())
+    return render(
+        request,
+        "classes/public/my_registration.html",
+        {
+            "registration": registration,
+            "offering": offering,
+            "upcoming_sessions": upcoming_sessions,
+            "can_self_cancel": can_self_cancel,
+            "settings_obj": ClassSettings.load(),
+            "site_config": SiteConfiguration.load(),
+        },
+    )
+
+
+def my_registration_cancel(request: HttpRequest, token: str) -> HttpResponse:
+    """Self-cancel a registration. Refunds aren't automated — admins handle them."""
+    registration = get_object_or_404(Registration, self_serve_token=token)
+    if request.method != "POST":
+        return redirect("classes:my_registration", token=token)
+    if registration.status not in {
+        Registration.Status.PENDING,
+        Registration.Status.CONFIRMED,
+        Registration.Status.WAITLISTED,
+    }:
+        messages.info(request, "This registration is already cancelled.")
+        return redirect("classes:my_registration", token=token)
+    registration.cancel(reason="self-serve")
+    messages.success(request, "Your registration is cancelled.")
+    return redirect("classes:my_registration", token=token)
+
+
+def _bump_discount_use_count(discount_code_id: int) -> None:
+    """Atomic +1 on use_count — called on confirmed registration."""
+    from django.db.models import F
+
+    DiscountCode.objects.filter(pk=discount_code_id).update(use_count=F("use_count") + 1)
 
 
 def admin_required(view_func: _ViewFunc) -> _ViewFunc:

--- a/classes/webhook_handlers.py
+++ b/classes/webhook_handlers.py
@@ -1,0 +1,77 @@
+"""Stripe webhook handlers for the Classes app.
+
+Registered into the billing app's webhook dispatcher. All handlers must be
+idempotent — Stripe retries failed deliveries and may also fire the same
+event more than once.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.db import transaction
+from django.db.models import F
+from django.utils import timezone
+
+from classes.emails import send_registration_confirmation
+from classes.models import DiscountCode, Registration
+
+logger = logging.getLogger(__name__)
+
+
+def handle_checkout_session_completed(event: dict[str, Any]) -> None:
+    """Confirm a class registration whose Stripe Checkout Session completed.
+
+    We only act on sessions tagged ``kind=class_registration`` in their
+    metadata so we don't collide with future Checkout uses (e.g. Tab top-ups).
+    Idempotent — re-delivery on an already-confirmed registration is a no-op.
+    """
+    session = event["data"]["object"]
+    metadata = session.get("metadata") or {}
+    if metadata.get("kind") != "class_registration":
+        return
+
+    registration_id = metadata.get("registration_id")
+    if not registration_id:
+        logger.warning("checkout.session.completed: missing registration_id in metadata")
+        return
+
+    if session.get("payment_status") != "paid":
+        logger.info(
+            "checkout.session.completed: ignoring session %s with payment_status=%s",
+            session.get("id"),
+            session.get("payment_status"),
+        )
+        return
+
+    with transaction.atomic():
+        try:
+            registration = Registration.objects.select_for_update().get(pk=registration_id)
+        except Registration.DoesNotExist:
+            logger.warning("checkout.session.completed: no registration %s", registration_id)
+            return
+
+        if registration.status == Registration.Status.CONFIRMED:
+            return  # already handled
+
+        registration.status = Registration.Status.CONFIRMED
+        registration.confirmed_at = timezone.now()
+        registration.stripe_session_id = session.get("id", registration.stripe_session_id)
+        registration.stripe_payment_id = session.get("payment_intent", "") or ""
+        amount_total = session.get("amount_total")
+        if isinstance(amount_total, int):
+            registration.amount_paid_cents = amount_total
+        registration.save(
+            update_fields=[
+                "status",
+                "confirmed_at",
+                "stripe_session_id",
+                "stripe_payment_id",
+                "amount_paid_cents",
+            ]
+        )
+        if registration.discount_code_id:
+            DiscountCode.objects.filter(pk=registration.discount_code_id).update(use_count=F("use_count") + 1)
+
+    send_registration_confirmation(registration)

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -8,8 +8,13 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
     {
         "version": "1.7.5",
         "date": "2026-04-25",
-        "title": "One Classes & Workshops page for everyone",
+        "title": "Members can sign up for classes online — plus a unified Classes page",
         "changes": [
+            "You can now register for classes and workshops directly on the website. Click Register on any class page, fill out a short form, sign the liability waiver online, and pay with a card through Stripe — no more email back-and-forth.",
+            "Members get the member discount applied automatically when the email on the form matches a verified member email.",
+            "Free classes skip the payment step and confirm immediately — you'll get a confirmation email right away.",
+            "Discount codes are honored on the registration form, and stack on top of the member discount.",
+            "Every confirmed registrant gets a confirmation email with the schedule, location, and a personal link they can use to view or cancel their spot — no login needed.",
             "There's now a single Classes & Workshops page in the sidebar — the same page everyone sees, members and visitors alike. Admins and instructors get a Manage button right on that page that opens the classes admin (or the Teaching dashboard for instructors), so you don't lose anything, it's just one entry point instead of two.",
             'Fixed: a class you publish now shows up on the Classes & Workshops page right away, even before its sessions are scheduled — it appears with an "Upcoming dates TBA" note until you add dates.',
         ],

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-VERSION = "1.7.4"
+VERSION = "1.7.5"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.7.5",
+        "date": "2026-04-25",
+        "title": "One Classes & Workshops page for everyone",
+        "changes": [
+            "There's now a single Classes & Workshops page in the sidebar — the same page everyone sees, members and visitors alike. Admins and instructors get a Manage button right on that page that opens the classes admin (or the Teaching dashboard for instructors), so you don't lose anything, it's just one entry point instead of two.",
+            'Fixed: a class you publish now shows up on the Classes & Workshops page right away, even before its sessions are scheduled — it appears with an "Upcoming dates TBA" note until you add dates.',
+        ],
+    },
     {
         "version": "1.7.4",
         "date": "2026-04-25",

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -2029,6 +2029,23 @@ a:hover { color: var(--color-yellow-hover); }
     text-decoration: none;
 }
 .pl-public-topbar__login:hover { background: #f5ca6e; text-decoration: none; }
+.pl-public-topbar__exit-preview {
+    background: rgba(238, 180, 75, 0.12);
+    color: var(--color-tuscan-yellow, #EEB44B);
+    border: 1px solid rgba(238, 180, 75, 0.4);
+    padding: 7px 14px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    white-space: nowrap;
+}
+.pl-public-topbar__exit-preview:hover {
+    background: rgba(238, 180, 75, 0.22);
+    text-decoration: none;
+}
 
 /* When no sidebar (anonymous), the wrapper occupies the full viewport. */
 .hub-main-wrapper--public { margin-left: 0; }

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -1972,3 +1972,63 @@ a:hover { color: var(--color-yellow-hover); }
     white-space: nowrap;
     border: 0;
 }
+
+/* ========================================
+   Public Top Bar (anonymous visitors)
+   Used on Classes & Workshops, register, etc. when no user is logged in.
+   ======================================== */
+.pl-public-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    height: var(--topbar-height);
+    background-color: rgba(6, 31, 51, 0.85);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    border-bottom: 1px solid rgba(238, 180, 75, 0.18);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 1.5rem;
+    gap: 1rem;
+}
+.pl-public-topbar__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--color-cream, #f4efdd);
+    font-family: 'Playfair Display', Georgia, serif;
+    font-weight: 800;
+    font-size: 16px;
+    text-decoration: none;
+}
+.pl-public-topbar__brand:hover { text-decoration: none; opacity: 0.9; }
+.pl-public-topbar__nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+}
+.pl-public-topbar__link {
+    color: var(--color-steel, #96acbb);
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.pl-public-topbar__link:hover { color: var(--color-tuscan-yellow, #EEB44B); text-decoration: none; }
+.pl-public-topbar__login {
+    background: var(--color-tuscan-yellow, #EEB44B);
+    color: #061f33;
+    padding: 8px 18px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+}
+.pl-public-topbar__login:hover { background: #f5ca6e; text-decoration: none; }
+
+/* When no sidebar (anonymous), the wrapper occupies the full viewport. */
+.hub-main-wrapper--public { margin-left: 0; }

--- a/templates/classes/admin/base.html
+++ b/templates/classes/admin/base.html
@@ -8,8 +8,8 @@
     <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:0.75rem;">
         <h1 style="margin:0;">Classes</h1>
         <div style="display:flex; gap:0.375rem; flex-wrap:wrap;">
-            <a class="hub-btn hub-btn--sm hub-btn--ghost" href="{% url 'classes:public_list' %}" target="_blank" rel="noopener"
-               title="Opens in a new tab">View public portal ↗</a>
+            <a class="hub-btn hub-btn--sm hub-btn--ghost" href="{% url 'classes:public_list' %}"
+               title="Back to the Classes &amp; Workshops page">← Classes &amp; Workshops</a>
             <a class="hub-btn hub-btn--sm hub-btn--ghost" href="{% url 'classes:admin_settings' %}"
                title="Global class settings: waiver text, member discount, reminder window">⚙ Settings</a>
         </div>

--- a/templates/classes/emails/confirmation.txt
+++ b/templates/classes/emails/confirmation.txt
@@ -1,0 +1,16 @@
+Hi {{ registration.first_name }},
+
+You're confirmed for "{{ offering.title }}" with {{ offering.instructor.display_name }}.
+
+{% if upcoming_sessions %}Schedule:
+{% for session in upcoming_sessions %}- {{ session.starts_at|date:"l, F j, Y" }} at {{ session.starts_at|time:"g:i A" }}
+{% endfor %}{% else %}Schedule: TBA — {{ offering.instructor.display_name }} will be in touch with dates.
+{% endif %}
+Location: Past Lives Makerspace, 2808 SE 9th Ave, Portland, OR 97202
+
+{% if amount_paid_cents %}You paid: ${{ amount_paid_dollars }}
+{% endif %}Manage your registration (or cancel): {{ self_serve_url }}
+{% if footer %}
+{{ footer }}{% endif %}
+See you soon!
+— Past Lives Makerspace

--- a/templates/classes/public/detail.html
+++ b/templates/classes/public/detail.html
@@ -95,8 +95,9 @@
 
         <div class="dc-reg">
           {% if spots_remaining > 0 %}
-            <a class="btn-reg" href="#register">Register — {{ offering.price_cents|cents_as_price }}</a>
-            <div style="margin-top:10px;font-size:11px;color:var(--text3);text-align:center">Online registration coming soon — check back shortly.</div>
+            <a class="btn-reg" href="{% url 'classes:register' slug=offering.slug %}">
+              {% if offering.price_cents == 0 %}Register — Free{% else %}Register — {{ offering.price_cents|cents_as_price }}{% endif %}
+            </a>
           {% else %}
             <div class="btn-sold">Sold Out</div>
           {% endif %}

--- a/templates/classes/public/list.html
+++ b/templates/classes/public/list.html
@@ -14,6 +14,11 @@
   </div>
   <div id="hero-cta">
     <a class="cta-primary" href="#catalog">Browse Classes</a>
+    {% if request.view_as.is_admin %}
+      <a class="cta-secondary" href="{% url 'classes:admin_classes' %}">Manage Classes &amp; Workshops</a>
+    {% elif request.view_as.is_instructor %}
+      <a class="cta-secondary" href="{% url 'classes:instructor_dashboard' %}">Manage My Classes</a>
+    {% endif %}
   </div>
 </div>
 

--- a/templates/classes/public/list.html
+++ b/templates/classes/public/list.html
@@ -19,6 +19,9 @@
     {% elif request.view_as.is_instructor %}
       <a class="cta-secondary" href="{% url 'classes:instructor_dashboard' %}">Manage My Classes</a>
     {% endif %}
+    {% if user.is_authenticated and not request.GET.public %}
+      <a class="cta-secondary" href="?public=1" hx-boost="false" title="Preview the page the way a logged-out visitor sees it">View Publicly</a>
+    {% endif %}
   </div>
 </div>
 

--- a/templates/classes/public/my_registration.html
+++ b/templates/classes/public/my_registration.html
@@ -1,0 +1,70 @@
+{% extends "classes/base_public.html" %}
+{% load classes_tags %}
+
+{% block title %}Your registration — {{ offering.title }}{% endblock %}
+
+{% block portal_content %}
+<div class="view">
+  <div class="cp-container">
+    <div class="detail-card">
+      <div class="detail-head">
+        <div>
+          <div class="dc-cat">{{ registration.get_status_display }}</div>
+          <div class="dc-title">{{ offering.title }}</div>
+          <div class="dc-inst">with {{ offering.instructor.display_name }}</div>
+        </div>
+        <a class="back-link" href="{% url 'classes:public_class_detail' slug=offering.slug %}">Class page →</a>
+      </div>
+      <div class="detail-body">
+        {% if messages %}
+          {% for msg in messages %}
+            <div style="padding:10px 12px;margin-bottom:10px;background:rgba(45,212,160,.08);border:1px solid rgba(45,212,160,.25);border-radius:6px;color:var(--green);font-size:12px">{{ msg }}</div>
+          {% endfor %}
+        {% endif %}
+
+        <div class="dc-igrid">
+          <div class="dc-icard">
+            <div class="dc-lbl">Registrant</div>
+            <div class="dc-txt">{{ registration.first_name }} {{ registration.last_name }}<br>{{ registration.email }}{% if registration.phone %}<br>{{ registration.phone }}{% endif %}</div>
+          </div>
+          <div class="dc-icard">
+            <div class="dc-lbl">Status</div>
+            <div class="dc-txt">{{ registration.get_status_display }}{% if registration.amount_paid_cents %} · paid {{ registration.amount_paid_cents|cents_as_price }}{% endif %}</div>
+          </div>
+        </div>
+
+        {% if upcoming_sessions %}
+          <div class="dc-sec">
+            <div class="dc-lbl">Schedule</div>
+            {% for session in upcoming_sessions %}
+              <div class="dc-srow">
+                {% if upcoming_sessions|length > 1 %}<span class="dc-snum">{{ forloop.counter }}</span>{% endif %}
+                <span class="dc-sdate">{{ session.starts_at|date:"l, F j, Y" }}</span>
+                <span class="dc-stime">{{ session.starts_at|time:"g:i A" }} – {{ session.ends_at|time:"g:i A" }}</span>
+              </div>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="dc-sec">
+            <div class="dc-lbl">Schedule</div>
+            <div class="dc-txt" style="color:var(--text3)">TBA — {{ offering.instructor.display_name }} will be in touch.</div>
+          </div>
+        {% endif %}
+
+        <div class="dc-sec">
+          <div class="dc-lbl">Location</div>
+          <div class="dc-txt">Past Lives Makerspace · 2808 SE 9th Ave, Portland, OR 97202</div>
+        </div>
+
+        {% if can_self_cancel %}
+          <form method="post" action="{% url 'classes:my_registration_cancel' token=registration.self_serve_token %}" style="margin-top:18px" onsubmit="return confirm('Cancel your registration? You can re-register if spots are still available.')">
+            {% csrf_token %}
+            <button type="submit" class="hub-btn hub-btn--sm hub-btn--danger">Cancel my registration</button>
+            <div style="font-size:11px;color:var(--text3);margin-top:6px">Refunds for paid registrations are handled by an admin — email info@pastlives.space.</div>
+          </form>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/classes/public/register.html
+++ b/templates/classes/public/register.html
@@ -1,0 +1,139 @@
+{% extends "classes/base_public.html" %}
+{% load classes_tags %}
+
+{% block title %}Register — {{ offering.title }} — Past Lives Makerspace{% endblock %}
+
+{% block classes_extra_head %}
+<style>
+.cp-page .reg-form{display:flex;flex-direction:column;gap:14px}
+.cp-page .reg-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+@media(max-width:600px){.cp-page .reg-row{grid-template-columns:1fr}}
+.cp-page .reg-field label{display:block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-bottom:5px}
+.cp-page .reg-field input[type=text],.cp-page .reg-field input[type=email],.cp-page .reg-field input[type=tel],.cp-page .reg-field textarea{width:100%;padding:9px 11px;background:rgba(9,46,76,.35);border:1px solid var(--border);border-radius:6px;color:var(--cream);font-family:var(--font);font-size:13px}
+.cp-page .reg-field input:focus,.cp-page .reg-field textarea:focus{outline:none;border-color:var(--gold);background:rgba(14,50,80,.5)}
+.cp-page .reg-field textarea{min-height:70px;resize:vertical}
+.cp-page .reg-errors{color:var(--red);font-size:11px;margin-top:4px;list-style:none;padding:0}
+.cp-page .reg-help{color:var(--text3);font-size:11px;margin-top:4px}
+.cp-page .reg-waiver{margin-top:6px;padding:14px 16px;background:rgba(9,46,76,.3);border:1px solid var(--border);border-radius:var(--r)}
+.cp-page .reg-waiver h3{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--gold);margin-bottom:8px}
+.cp-page .reg-waiver-text{font-size:12px;color:var(--steel);line-height:1.6;max-height:200px;overflow:auto;white-space:pre-wrap;padding:10px 12px;background:rgba(0,0,0,.2);border-radius:6px;margin-bottom:10px}
+.cp-page .reg-check{display:flex;gap:8px;align-items:flex-start;font-size:12px;color:var(--cream);cursor:pointer}
+.cp-page .reg-check input{margin-top:3px;accent-color:var(--gold)}
+.cp-page .reg-summary{padding:14px 16px;background:rgba(238,180,75,.06);border:1px solid rgba(238,180,75,.18);border-radius:var(--r);font-size:13px;color:var(--cream)}
+.cp-page .reg-summary .total{font-size:20px;font-weight:900;color:var(--gold);font-family:var(--heading)}
+.cp-page .reg-error-block{padding:10px 12px;background:rgba(248,113,113,.08);border:1px solid rgba(248,113,113,.25);border-radius:6px;color:var(--red);font-size:12px}
+</style>
+{% endblock %}
+
+{% block portal_content %}
+<div class="view">
+  <div class="cp-container">
+    <div class="detail-card">
+      <div class="detail-head">
+        <div>
+          <div class="dc-cat">Register</div>
+          <div class="dc-title">{{ offering.title }}</div>
+          <div class="dc-inst">with {{ offering.instructor.display_name }}</div>
+        </div>
+        <a class="back-link" href="{% url 'classes:public_class_detail' slug=offering.slug %}">&larr; Class details</a>
+      </div>
+      <div class="detail-body">
+        <div class="reg-summary">
+          <div>{{ offering.title }}</div>
+          <div class="total">{{ offering.price_cents|cents_as_price }}</div>
+          {% if member_price_cents %}<div style="font-size:11px;color:var(--steel-dim);margin-top:2px">Members: {{ member_price_cents|cents_as_price }} (auto-applied if your email matches a verified member)</div>{% endif %}
+          {% if spots_remaining <= 3 %}<div style="font-size:11px;color:var(--red);margin-top:6px">Only {{ spots_remaining }} spot{{ spots_remaining|pluralize }} left</div>{% endif %}
+        </div>
+
+        {% if form.non_field_errors %}
+          <div class="reg-error-block" style="margin-top:12px">
+            {% for err in form.non_field_errors %}{{ err }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+          </div>
+        {% endif %}
+
+        <form method="post" class="reg-form" style="margin-top:14px">
+          {% csrf_token %}
+          <div class="reg-row">
+            <div class="reg-field">
+              <label for="{{ form.first_name.id_for_label }}">First name</label>
+              {{ form.first_name }}
+              {% if form.first_name.errors %}<ul class="reg-errors">{% for e in form.first_name.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+            </div>
+            <div class="reg-field">
+              <label for="{{ form.last_name.id_for_label }}">Last name</label>
+              {{ form.last_name }}
+              {% if form.last_name.errors %}<ul class="reg-errors">{% for e in form.last_name.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+            </div>
+          </div>
+          <div class="reg-row">
+            <div class="reg-field">
+              <label for="{{ form.email.id_for_label }}">Email</label>
+              {{ form.email }}
+              {% if form.email.errors %}<ul class="reg-errors">{% for e in form.email.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+            </div>
+            <div class="reg-field">
+              <label for="{{ form.phone.id_for_label }}">Phone (optional)</label>
+              {{ form.phone }}
+              {% if form.phone.errors %}<ul class="reg-errors">{% for e in form.phone.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+            </div>
+          </div>
+          <div class="reg-field">
+            <label for="{{ form.pronouns.id_for_label }}">Pronouns (optional)</label>
+            {{ form.pronouns }}
+          </div>
+          <div class="reg-field">
+            <label for="{{ form.prior_experience.id_for_label }}">Any prior experience? (optional)</label>
+            {{ form.prior_experience }}
+          </div>
+          <div class="reg-field">
+            <label for="{{ form.looking_for.id_for_label }}">What are you hoping to get out of this class? (optional)</label>
+            {{ form.looking_for }}
+          </div>
+          <div class="reg-field">
+            <label for="{{ form.discount_code.id_for_label }}">Discount code (optional)</label>
+            {{ form.discount_code }}
+            {% if form.discount_code.errors %}<ul class="reg-errors">{% for e in form.discount_code.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+          </div>
+
+          <div class="reg-waiver">
+            <h3>Liability Waiver</h3>
+            <div class="reg-waiver-text">{{ settings_obj.liability_waiver_text }}</div>
+            <div class="reg-field">
+              <label for="{{ form.liability_signature.id_for_label }}">Type your full name to sign</label>
+              {{ form.liability_signature }}
+              {% if form.liability_signature.errors %}<ul class="reg-errors">{% for e in form.liability_signature.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+            </div>
+            <label class="reg-check" style="margin-top:8px">
+              {{ form.accepts_liability }}
+              <span>I have read and agree to the liability waiver above.</span>
+            </label>
+            {% if form.accepts_liability.errors %}<ul class="reg-errors">{% for e in form.accepts_liability.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+          </div>
+
+          {% if offering.requires_model_release %}
+          <div class="reg-waiver">
+            <h3>Model Release</h3>
+            <div class="reg-waiver-text">{{ settings_obj.model_release_waiver_text }}</div>
+            <div class="reg-field">
+              <label for="{{ form.model_release_signature.id_for_label }}">Type your full name to sign</label>
+              {{ form.model_release_signature }}
+              {% if form.model_release_signature.errors %}<ul class="reg-errors">{% for e in form.model_release_signature.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+            </div>
+            <label class="reg-check" style="margin-top:8px">
+              {{ form.accepts_model_release }}
+              <span>I have read and agree to the model release above.</span>
+            </label>
+            {% if form.accepts_model_release.errors %}<ul class="reg-errors">{% for e in form.accepts_model_release.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+          </div>
+          {% endif %}
+
+          <button type="submit" class="btn-reg" style="margin-top:8px">
+            {% if offering.price_cents == 0 %}Confirm Registration{% else %}Continue to Payment — {{ offering.price_cents|cents_as_price }}{% endif %}
+          </button>
+          <div class="reg-help" style="text-align:center">Payment is processed securely by Stripe. We never see your card details.</div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/classes/public/register_cancelled.html
+++ b/templates/classes/public/register_cancelled.html
@@ -1,0 +1,26 @@
+{% extends "classes/base_public.html" %}
+
+{% block title %}Registration cancelled — {{ offering.title }}{% endblock %}
+
+{% block portal_content %}
+<div class="view">
+  <div class="cp-container">
+    <div class="detail-card">
+      <div class="detail-head">
+        <div>
+          <div class="dc-cat">Cancelled</div>
+          <div class="dc-title">Registration not completed</div>
+          <div class="dc-inst">{{ offering.title }}</div>
+        </div>
+        <a class="back-link" href="{% url 'classes:public_class_detail' slug=offering.slug %}">&larr; Class details</a>
+      </div>
+      <div class="detail-body">
+        <p style="color:var(--cream);font-size:14px;line-height:1.7">
+          You backed out of payment, so your spot wasn't reserved. No charge was made.
+        </p>
+        <a class="btn-reg" href="{% url 'classes:register' slug=offering.slug %}" style="margin-top:14px">Try again</a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/classes/public/register_success.html
+++ b/templates/classes/public/register_success.html
@@ -1,0 +1,28 @@
+{% extends "classes/base_public.html" %}
+
+{% block title %}You're confirmed — {{ offering.title }}{% endblock %}
+
+{% block portal_content %}
+<div class="view">
+  <div class="cp-container">
+    <div class="detail-card">
+      <div class="detail-head">
+        <div>
+          <div class="dc-cat">Registered</div>
+          <div class="dc-title">You're in!</div>
+          <div class="dc-inst">{{ offering.title }} with {{ offering.instructor.display_name }}</div>
+        </div>
+        <a class="back-link" href="{% url 'classes:public_list' %}">&larr; All classes</a>
+      </div>
+      <div class="detail-body">
+        <p style="color:var(--cream);font-size:14px;line-height:1.7">
+          Your registration is confirmed. We just sent a confirmation email with the schedule, location, and a link to manage or cancel your spot.
+        </p>
+        <p style="color:var(--steel);font-size:13px;line-height:1.7;margin-top:10px">
+          If you don't see it, check your spam folder.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -40,6 +40,7 @@
 </head>
 <body class="{% block body_class %}{% endblock %}" hx-boost="true" x-data="{ sidebarOpen: window.innerWidth > 768 ? ((localStorage.getItem('hubSidebarOpen') !== null) ? (localStorage.getItem('hubSidebarOpen') === '1') : true) : false }" x-init="$watch('sidebarOpen', v => { if (window.innerWidth > 768) localStorage.setItem('hubSidebarOpen', v ? '1' : '0') })">
 {% block extra_body %}{% endblock %}
+    {% if user.is_authenticated %}
     <div class="hub-sidebar-backdrop" :class="{ 'hub-sidebar-backdrop--visible': sidebarOpen }" @click="sidebarOpen = false"></div>
     <aside class="hub-sidebar" :class="{ 'hub-sidebar--closed': !sidebarOpen }">
         <a href="{% url 'hub_community_calendar' %}" class="pl-brand">
@@ -270,8 +271,10 @@
             </a>
         </div>
     </aside>
+    {% endif %}
 
-    <div class="hub-main-wrapper" :class="{ 'hub-main-wrapper--expanded': !sidebarOpen }">
+    <div class="hub-main-wrapper {% if not user.is_authenticated %}hub-main-wrapper--public hub-main-wrapper--expanded{% endif %}" {% if user.is_authenticated %}:class="{ 'hub-main-wrapper--expanded': !sidebarOpen }"{% endif %}>
+        {% if user.is_authenticated %}
         <header class="pl-topbar">
             <button class="pl-topbar__toggle" @click="sidebarOpen = !sidebarOpen" aria-label="Toggle sidebar">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -348,6 +351,18 @@
             <a href="{% url 'account_login' %}" class="pl-view-switcher" hx-boost="false">Log in</a>
             {% endif %}
         </header>
+        {% else %}
+        <header class="pl-public-topbar">
+            <a href="{% url 'classes:public_list' %}" class="pl-public-topbar__brand">
+                <img src="{% static 'img/favicon.png' %}" alt="" width="22" height="22">
+                <span>Past Lives Makerspace</span>
+            </a>
+            <nav class="pl-public-topbar__nav" aria-label="Public navigation">
+                <a href="{% url 'classes:public_list' %}" class="pl-public-topbar__link">Classes</a>
+                <a href="{% url 'account_login' %}" class="pl-public-topbar__login" hx-boost="false">Log in</a>
+            </nav>
+        </header>
+        {% endif %}
 
         <main class="hub-content">
             {% if messages %}

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -40,7 +40,7 @@
 </head>
 <body class="{% block body_class %}{% endblock %}" hx-boost="true" x-data="{ sidebarOpen: window.innerWidth > 768 ? ((localStorage.getItem('hubSidebarOpen') !== null) ? (localStorage.getItem('hubSidebarOpen') === '1') : true) : false }" x-init="$watch('sidebarOpen', v => { if (window.innerWidth > 768) localStorage.setItem('hubSidebarOpen', v ? '1' : '0') })">
 {% block extra_body %}{% endblock %}
-    {% if user.is_authenticated %}
+    {% if user.is_authenticated and not request.GET.public %}
     <div class="hub-sidebar-backdrop" :class="{ 'hub-sidebar-backdrop--visible': sidebarOpen }" @click="sidebarOpen = false"></div>
     <aside class="hub-sidebar" :class="{ 'hub-sidebar--closed': !sidebarOpen }">
         <a href="{% url 'hub_community_calendar' %}" class="pl-brand">
@@ -273,8 +273,8 @@
     </aside>
     {% endif %}
 
-    <div class="hub-main-wrapper {% if not user.is_authenticated %}hub-main-wrapper--public hub-main-wrapper--expanded{% endif %}" {% if user.is_authenticated %}:class="{ 'hub-main-wrapper--expanded': !sidebarOpen }"{% endif %}>
-        {% if user.is_authenticated %}
+    <div class="hub-main-wrapper {% if not user.is_authenticated or request.GET.public %}hub-main-wrapper--public hub-main-wrapper--expanded{% endif %}" {% if user.is_authenticated and not request.GET.public %}:class="{ 'hub-main-wrapper--expanded': !sidebarOpen }"{% endif %}>
+        {% if user.is_authenticated and not request.GET.public %}
         <header class="pl-topbar">
             <button class="pl-topbar__toggle" @click="sidebarOpen = !sidebarOpen" aria-label="Toggle sidebar">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -359,7 +359,11 @@
             </a>
             <nav class="pl-public-topbar__nav" aria-label="Public navigation">
                 <a href="{% url 'classes:public_list' %}" class="pl-public-topbar__link">Classes</a>
+                {% if user.is_authenticated and request.GET.public %}
+                <a href="{{ request.path }}" class="pl-public-topbar__exit-preview" hx-boost="false" title="Return to the dashboard view">← Exit public view</a>
+                {% else %}
                 <a href="{% url 'account_login' %}" class="pl-public-topbar__login" hx-boost="false">Log in</a>
+                {% endif %}
             </nav>
         </header>
         {% endif %}

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -52,7 +52,7 @@
 
         <nav class="hub-sidebar__nav" aria-label="Hub navigation" hx-boost="false" @click="if ($event.target.closest('a') && window.innerWidth <= 768) sidebarOpen = false">
             {% if request.view_as.is_admin %}
-            <a href="{% url 'classes:public_list' %}" class="hub-sidebar__link {% if request.path|slice:':9' == '/classes/' and request.path|slice:':16' != '/classes/admin/' %}active{% endif %}">
+            <a href="{% url 'classes:public_list' %}" class="hub-sidebar__link {% if request.path|slice:':9' == '/classes/' %}active{% endif %}">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
                     <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
@@ -68,14 +68,6 @@
                     <line x1="3" y1="10" x2="21" y2="10"/>
                 </svg>
                 Community Calendar
-            </a>
-
-            <a href="{% url 'classes:admin_classes' %}" class="hub-sidebar__link {% if request.path|slice:':16' == '/classes/admin/' %}active{% endif %}">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
-                    <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
-                </svg>
-                Manage Classes & Workshops
             </a>
 
             <a href="{% url 'hub_admin_members' %}" class="hub-sidebar__link {% active_nav 'hub_admin_members' %}">
@@ -170,16 +162,6 @@
                     <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
                 </svg>
                 Guild Voting
-            </a>
-            {% endif %}
-
-            {% if request.view_as.is_instructor %}
-            <a href="{% url 'classes:instructor_dashboard' %}" class="hub-sidebar__link {% if request.path|slice:':20' == '/classes/instructor/' %}active{% endif %}">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
-                    <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
-                </svg>
-                Manage Classes & Workshops
             </a>
             {% endif %}
 

--- a/templates/hub/community_calendar.html
+++ b/templates/hub/community_calendar.html
@@ -31,7 +31,7 @@
 {% block content %}
 <link rel="stylesheet" href="{% static 'css/calendar.css' %}">
 
-<div class="hub-page-header" style="display:flex;align-items:center;gap:0.625rem;">
+<div class="hub-page-header" style="display:flex;align-items:center;gap:0.625rem;flex-wrap:wrap;">
     <h1 class="hub-page-title">Community Calendar</h1>
     <span x-data="{ open: false }" style="position:relative;display:inline-flex;align-items:center;">
         <button type="button"
@@ -49,6 +49,9 @@
             Events refresh automatically every 5 minutes — no need to reload the page.
         </div>
     </span>
+    {% if user.is_authenticated and not request.GET.public %}
+    <a href="?public=1" class="hub-btn hub-btn--sm hub-btn--ghost" style="margin-left:auto;" hx-boost="false" title="Preview the calendar the way a logged-out visitor sees it">View Publicly</a>
+    {% endif %}
 </div>
 
 <div


### PR DESCRIPTION
## Summary

This PR rolls together three related improvements to the Classes & Workshops experience plus a new public-preview affordance.

### 1. Public class registration + Stripe Checkout
- Members and visitors can register for any published class directly on the site.
- Verified-member emails get the member discount auto-applied; discount codes stack on top.
- Free classes skip Stripe and confirm immediately; paid classes go through Stripe Checkout.
- Confirmed registrants get a confirmation email with a self-serve link to view or cancel.
- Logged-in members get the form pre-filled from their Member record (name, email, phone, pronouns).

### 2. Unified Classes & Workshops page
- `/classes/` is now the single sidebar entry; admins/instructors see a Manage button on the page.
- Bug fix: published classes now appear on the list immediately, even before sessions are scheduled (previously hidden until at least one upcoming session existed).

### 3. Public-facing chrome
- For anonymous visitors, the hub sidebar + topbar are hidden site-wide. They get a slim public topbar with the Past Lives wordmark, a Classes link, and a Log in CTA.
- Authenticated users get a **"View Publicly"** button on the Classes & Workshops list and the Community Calendar — clicking it loads the same URL with `?public=1`, rendering the public chrome.
- The public topbar swaps the Log in button for an "← Exit public view" pill while previewing.

### 4. Admin polish
- Classes admin header swaps "View public portal ↗" for an in-tab "← Classes & Workshops" back-nav.

## Architecture

- `RegistrationForm` (classes/forms.py) owns validation, price computation, and waiver creation.
- `register` view orchestrates: free path confirms inline; paid path creates a Stripe Checkout Session and rolls back the half-created Registration on Stripe failure.
- `classes.webhook_handlers.handle_checkout_session_completed` is registered into the existing `billing/views.py:_WEBHOOK_HANDLERS` dispatcher; gated by `metadata.kind == "class_registration"` so it can't collide with future Checkout uses. Idempotent on Stripe re-deliveries.
- `DiscountCode.use_count` is incremented atomically with `F("use_count") + 1`.
- Self-serve via `Registration.self_serve_token` (already on the model) — no auth required.
- "View Publicly" is page-local: `?public=1` makes `hub/base.html` render the public chrome. Doesn't touch the session or the "Viewing as" preference.

## Test plan
- [x] `pytest` — 1649 passed (33+ new tests across form/view/webhook/prefill)
- [x] `ruff check` clean
- [ ] `/classes/<slug>/register/` renders + submits as guest
- [ ] Logged-in member sees prefilled form
- [ ] Verified-member email auto-applies member discount
- [ ] Discount code applies on top of member discount
- [ ] Free class skips Stripe → confirmation email arrives immediately
- [ ] Paid class redirects to Stripe Checkout test card → webhook fires → registration goes CONFIRMED → email arrives
- [ ] Stripe Checkout Cancel button cleans up the pending registration
- [ ] `/classes/my/<token>/` shows the right registration + cancels via POST
- [ ] Sold-out class blocks new registration with a friendly error
- [ ] Admin `/classes/admin/` "← Classes & Workshops" link navigates in-tab
- [ ] As anon visitor, hub chrome is hidden site-wide; public topbar shows
- [ ] As logged-in user, "View Publicly" toggles to public chrome with Exit pill