### PR TITLE
v1.7.6: Free class/workshop checkbox + Register page CSS hotfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,6 @@ jobs:
 
       - name: Mypy
         run: mypy plfog/ core/ membership/ hub/
+
+      - name: No inline <style> in template extra_head blocks
+        run: python scripts/check_no_inline_style_in_extra_head.py

--- a/classes/forms.py
+++ b/classes/forms.py
@@ -24,7 +24,55 @@ if TYPE_CHECKING:
     from membership.models import Member
 
 
-class ClassOfferingForm(forms.ModelForm):
+class _FreeClassMixin:
+    """Adds an `is_free` checkbox that, when checked, forces price/discount to 0.
+
+    Source of truth remains `price_cents` on the model (0 = free). The checkbox
+    is a UX affordance so the instructor/admin doesn't have to know that "type 0
+    in cents" makes a class free — they just tick a box.
+    """
+
+    def add_is_free_field(self) -> None:
+        instance = getattr(self, "instance", None)
+        initial = bool(instance and instance.pk and instance.price_cents == 0)
+        self.fields["is_free"] = forms.BooleanField(  # type: ignore[attr-defined]
+            required=False,
+            initial=initial,
+            label="This is a free class / workshop",
+            help_text="Check this if there's no fee. Members will be able to register without entering payment info.",
+        )
+        # Price and discount aren't required when the class is free — the form's
+        # clean() enforces that price_cents is filled in for non-free classes.
+        self.fields["price_cents"].required = False  # type: ignore[attr-defined]
+        self.fields["member_discount_pct"].required = False  # type: ignore[attr-defined]
+        # Render the checkbox just above price so the visual flow is "Is this free?
+        # → if not, here's the price." Django keeps this order when iterating `form`.
+        ordered: list[str] = []
+        for name in self.fields:  # type: ignore[attr-defined]
+            if name == "price_cents":
+                ordered.append("is_free")
+            if name == "is_free":
+                continue
+            ordered.append(name)
+        self.order_fields(ordered)  # type: ignore[attr-defined]
+
+    def clean_is_free_pricing(self) -> None:
+        """Require price_cents when the class isn't free. Call from `clean()`."""
+        cleaned = self.cleaned_data  # type: ignore[attr-defined]
+        if cleaned.get("is_free"):
+            return
+        if cleaned.get("price_cents") in (None, ""):
+            self.add_error(  # type: ignore[attr-defined]
+                "price_cents", "Set a price (in cents) or check 'This is a free class / workshop'."
+            )
+
+    def apply_is_free_to_instance(self, offering: ClassOffering) -> None:
+        if self.cleaned_data.get("is_free"):  # type: ignore[attr-defined]
+            offering.price_cents = 0
+            offering.member_discount_pct = 0
+
+
+class ClassOfferingForm(_FreeClassMixin, forms.ModelForm):
     class Meta:
         model = ClassOffering
         fields = [
@@ -51,8 +99,25 @@ class ClassOfferingForm(forms.ModelForm):
             "requires_model_release",
         ]
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.add_is_free_field()
 
-class InstructorClassOfferingForm(forms.ModelForm):
+    def clean(self) -> dict:
+        data = super().clean()
+        self.clean_is_free_pricing()
+        return data
+
+    def save(self, commit: bool = True) -> ClassOffering:
+        offering = super().save(commit=False)
+        self.apply_is_free_to_instance(offering)
+        if commit:
+            offering.save()
+            self.save_m2m()
+        return offering
+
+
+class InstructorClassOfferingForm(_FreeClassMixin, forms.ModelForm):
     """Class form for instructors — no `instructor`, no `is_private`, slug auto-generated."""
 
     class Meta:
@@ -80,9 +145,16 @@ class InstructorClassOfferingForm(forms.ModelForm):
     def __init__(self, *args, instructor: Instructor | None = None, **kwargs) -> None:
         self.instructor = instructor
         super().__init__(*args, **kwargs)
+        self.add_is_free_field()
+
+    def clean(self) -> dict:
+        data = super().clean()
+        self.clean_is_free_pricing()
+        return data
 
     def save(self, commit: bool = True) -> ClassOffering:
         offering = super().save(commit=False)
+        self.apply_is_free_to_instance(offering)
         if self.instructor is not None and not offering.instructor_id:
             offering.instructor = self.instructor
             if not offering.created_by_id:

--- a/classes/spec/forms/free_class_spec.py
+++ b/classes/spec/forms/free_class_spec.py
@@ -1,0 +1,120 @@
+"""BDD specs for the `is_free` checkbox on ClassOffering forms."""
+
+from __future__ import annotations
+
+import pytest
+
+from classes.factories import CategoryFactory, ClassOfferingFactory, InstructorFactory
+from classes.forms import ClassOfferingForm, InstructorClassOfferingForm
+from classes.models import ClassOffering
+
+pytestmark = pytest.mark.django_db
+
+
+def _admin_post_data(**overrides) -> dict:
+    data = {
+        "title": "Forge Basics",
+        "slug": "forge-basics",
+        "category": str(CategoryFactory().pk),
+        "instructor": str(InstructorFactory().pk),
+        "description": "Hands-on intro.",
+        "prerequisites": "",
+        "materials_included": "",
+        "materials_to_bring": "",
+        "safety_requirements": "",
+        "age_minimum": "",
+        "age_guardian_note": "",
+        "price_cents": "10000",
+        "member_discount_pct": "10",
+        "capacity": "6",
+        "scheduling_model": ClassOffering.SchedulingModel.FIXED,
+        "flexible_note": "",
+        "is_private": "",
+        "private_for_name": "",
+        "recurring_pattern": "",
+        "image": "",
+        "requires_model_release": "",
+    }
+    data.update(overrides)
+    return data
+
+
+def describe_ClassOfferingForm():
+    def describe_is_free_checkbox():
+        def it_zeroes_price_and_discount_when_checked():
+            form = ClassOfferingForm(
+                data=_admin_post_data(is_free="on", price_cents="", member_discount_pct=""),
+            )
+            assert form.is_valid(), form.errors
+            offering = form.save()
+            assert offering.price_cents == 0
+            assert offering.member_discount_pct == 0
+
+        def it_keeps_paid_pricing_when_unchecked():
+            form = ClassOfferingForm(data=_admin_post_data(price_cents="2500", member_discount_pct="15"))
+            assert form.is_valid(), form.errors
+            offering = form.save()
+            assert offering.price_cents == 2500
+            assert offering.member_discount_pct == 15
+
+        def it_requires_a_price_when_not_free():
+            form = ClassOfferingForm(data=_admin_post_data(price_cents="", member_discount_pct=""))
+            assert not form.is_valid()
+            assert "price_cents" in form.errors
+
+        def it_pre_checks_for_existing_free_class():
+            offering = ClassOfferingFactory(price_cents=0, member_discount_pct=0)
+            form = ClassOfferingForm(instance=offering)
+            assert form.fields["is_free"].initial is True
+
+        def it_pre_unchecks_for_existing_paid_class():
+            offering = ClassOfferingFactory(price_cents=4500)
+            form = ClassOfferingForm(instance=offering)
+            assert form.fields["is_free"].initial is False
+
+
+def _instructor_post_data(**overrides) -> dict:
+    data = {
+        "title": "Free Demo",
+        "category": str(CategoryFactory().pk),
+        "description": "A walkthrough.",
+        "prerequisites": "",
+        "materials_included": "",
+        "materials_to_bring": "",
+        "safety_requirements": "",
+        "age_minimum": "",
+        "age_guardian_note": "",
+        "price_cents": "",
+        "member_discount_pct": "",
+        "capacity": "6",
+        "scheduling_model": ClassOffering.SchedulingModel.FIXED,
+        "flexible_note": "",
+        "recurring_pattern": "",
+        "image": "",
+        "requires_model_release": "",
+    }
+    data.update(overrides)
+    return data
+
+
+def describe_InstructorClassOfferingForm():
+    def describe_is_free_checkbox():
+        def it_zeroes_pricing_when_checked():
+            instructor = InstructorFactory()
+            form = InstructorClassOfferingForm(
+                data=_instructor_post_data(is_free="on"),
+                instructor=instructor,
+            )
+            assert form.is_valid(), form.errors
+            offering = form.save()
+            assert offering.price_cents == 0
+            assert offering.member_discount_pct == 0
+
+        def it_requires_price_for_paid_class():
+            instructor = InstructorFactory()
+            form = InstructorClassOfferingForm(
+                data=_instructor_post_data(),
+                instructor=instructor,
+            )
+            assert not form.is_valid()
+            assert "price_cents" in form.errors

--- a/classes/templatetags/classes_tags.py
+++ b/classes/templatetags/classes_tags.py
@@ -12,10 +12,12 @@ register = template.Library()
 
 @register.filter
 def cents_as_price(value: int | None) -> str:
-    """Format integer cents as a dollar string. Whole dollars drop the decimals."""
+    """Format integer cents as a dollar string. Zero renders as "Free"; whole dollars drop the decimals."""
     if value is None:
         return ""
     cents = int(value)
+    if cents == 0:
+        return "Free"
     dollars, remainder = divmod(cents, 100)
     if remainder == 0:
         return f"${dollars}"

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-VERSION = "1.7.5"
+VERSION = "1.7.5.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.7.5.1",
+        "date": "2026-04-26",
+        "title": "Fixed: Register page styling sometimes broken when navigating from a class",
+        "changes": [
+            "Fixed a bug where the Register page on a class could load with no styling if you clicked through from another page in the same browser tab. The page now keeps its full styling no matter how you arrive at it.",
+        ],
+    },
     {
         "version": "1.7.5",
         "date": "2026-04-25",

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-VERSION = "1.7.5.1"
+VERSION = "1.7.6"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "1.7.5.1",
+        "version": "1.7.6",
         "date": "2026-04-26",
-        "title": "Fixed: Register page styling sometimes broken when navigating from a class",
+        "title": "Free classes & workshops — and a fix for the Register page styling",
         "changes": [
+            'When you create or edit a class, there\'s now a "This is a free class / workshop" checkbox right above the price field. Tick it and the class is free — members and visitors register without entering any payment info, and they get a confirmation email immediately.',
+            'Free classes show as "Free" everywhere on the site (the class card, the detail page, and the registration summary) instead of a $0 price tag.',
             "Fixed a bug where the Register page on a class could load with no styling if you clicked through from another page in the same browser tab. The page now keeps its full styling no matter how you arrive at it.",
         ],
     },

--- a/scripts/check_no_inline_style_in_extra_head.py
+++ b/scripts/check_no_inline_style_in_extra_head.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Fail if a Django template puts an inline <style> block inside an extra_head block.
+
+Why this lint exists: hx-boost swaps <body>, not <head>. Without the head-support
+extension, page-specific <style> tags placed inside `{% block extra_head %}`
+silently disappear when a user navigates via a boosted link — the CSS never
+re-renders. We *do* now load the head-support extension, but the safer pattern
+is to keep page-specific CSS in static files referenced by <link>, so this
+class of bug can't recur even if the extension is ever removed.
+
+Allowed: `<link rel="stylesheet" href="...">` in extra_head blocks.
+Disallowed: `<style>...</style>` blocks in extra_head blocks.
+
+A baseline of pre-existing offenders is grandfathered in BASELINE below — the
+lint only fails when *new* violations appear. As you migrate baseline files to
+external CSS, delete them from BASELINE; the lint will then block regressions.
+
+Run: python scripts/check_no_inline_style_in_extra_head.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BLOCK_RE = re.compile(
+    r"\{%\s*block\s+(\w*extra_head)\s*%\}(?P<body>.*?)\{%\s*endblock\s*(?:\w+)?\s*%\}",
+    re.DOTALL,
+)
+INLINE_STYLE_RE = re.compile(r"<style[\s>]", re.IGNORECASE)
+
+# Templates that contain inline <style> in extra_head and are grandfathered until migrated.
+# DO NOT add to this list. The right fix is to move the styles into static/css/*.css and
+# reference them with a <link> tag — see templates/classes/public/register.html for the pattern.
+BASELINE: frozenset[str] = frozenset(
+    {
+        "templates/classes/base_public.html",
+        "templates/hub/admin/member_edit.html",
+        "templates/hub/admin/members.html",
+        "templates/hub/admin/site_settings.html",
+        "templates/hub/community_calendar.html",
+    }
+)
+
+
+def find_violations(template_root: Path) -> list[tuple[Path, str, int]]:
+    """Return (file, block_name, line) tuples for any inline <style> in extra_head blocks."""
+    violations: list[tuple[Path, str, int]] = []
+    for path in sorted(template_root.rglob("*.html")):
+        text = path.read_text(encoding="utf-8")
+        for match in BLOCK_RE.finditer(text):
+            block_body = match.group("body")
+            style_match = INLINE_STYLE_RE.search(block_body)
+            if style_match is None:
+                continue
+            absolute_offset = match.start("body") + style_match.start()
+            line_number = text.count("\n", 0, absolute_offset) + 1
+            violations.append((path, match.group(1), line_number))
+    return violations
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    template_root = repo_root / "templates"
+    if not template_root.exists():
+        print(f"templates/ not found under {repo_root}", file=sys.stderr)
+        return 2
+
+    all_violations = find_violations(template_root)
+    new_violations: list[tuple[Path, str, int]] = []
+    seen_baseline_files: set[str] = set()
+
+    for path, block_name, line in all_violations:
+        rel = str(path.relative_to(repo_root))
+        if rel in BASELINE:
+            seen_baseline_files.add(rel)
+            continue
+        new_violations.append((path, block_name, line))
+
+    stale_baseline = BASELINE - seen_baseline_files
+
+    failed = False
+
+    if new_violations:
+        failed = True
+        print("New inline <style> blocks inside extra_head blocks (NOT allowed):")
+        print()
+        for path, block_name, line in new_violations:
+            rel = path.relative_to(repo_root)
+            print(f"  {rel}:{line}  inside `{{% block {block_name} %}}`")
+        print()
+        print(
+            "Move these styles into a static .css file and reference them with\n"
+            '  <link rel="stylesheet" href="{% static \'css/your-file.css\' %}">.\n'
+            "See templates/classes/public/register.html for the pattern."
+        )
+
+    if stale_baseline:
+        failed = True
+        print()
+        print("Stale baseline entries (file no longer contains inline styles — please remove from BASELINE):")
+        for entry in sorted(stale_baseline):
+            print(f"  {entry}")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/static/css/classes-register.css
+++ b/static/css/classes-register.css
@@ -1,0 +1,101 @@
+/* Public class registration form — extracted from register.html so the styles
+   travel via <link rel=stylesheet> in the document head. Inline <style> blocks
+   inside template extra_head silently lost styles on hx-boost navigation. */
+.cp-page .reg-form { display: flex; flex-direction: column; gap: 14px; }
+.cp-page .reg-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+@media (max-width: 600px) { .cp-page .reg-row { grid-template-columns: 1fr; } }
+.cp-page .reg-field label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text3);
+    margin-bottom: 5px;
+}
+.cp-page .reg-field input[type=text],
+.cp-page .reg-field input[type=email],
+.cp-page .reg-field input[type=tel],
+.cp-page .reg-field textarea {
+    width: 100%;
+    padding: 9px 11px;
+    background: rgba(9, 46, 76, 0.35);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--cream);
+    font-family: var(--font);
+    font-size: 13px;
+}
+.cp-page .reg-field input:focus,
+.cp-page .reg-field textarea:focus {
+    outline: none;
+    border-color: var(--gold);
+    background: rgba(14, 50, 80, 0.5);
+}
+.cp-page .reg-field textarea { min-height: 70px; resize: vertical; }
+.cp-page .reg-errors {
+    color: var(--red);
+    font-size: 11px;
+    margin-top: 4px;
+    list-style: none;
+    padding: 0;
+}
+.cp-page .reg-help { color: var(--text3); font-size: 11px; margin-top: 4px; }
+.cp-page .reg-waiver {
+    margin-top: 6px;
+    padding: 14px 16px;
+    background: rgba(9, 46, 76, 0.3);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+}
+.cp-page .reg-waiver h3 {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--gold);
+    margin-bottom: 8px;
+}
+.cp-page .reg-waiver-text {
+    font-size: 12px;
+    color: var(--steel);
+    line-height: 1.6;
+    max-height: 200px;
+    overflow: auto;
+    white-space: pre-wrap;
+    padding: 10px 12px;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 6px;
+    margin-bottom: 10px;
+}
+.cp-page .reg-check {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    font-size: 12px;
+    color: var(--cream);
+    cursor: pointer;
+}
+.cp-page .reg-check input { margin-top: 3px; accent-color: var(--gold); }
+.cp-page .reg-summary {
+    padding: 14px 16px;
+    background: rgba(238, 180, 75, 0.06);
+    border: 1px solid rgba(238, 180, 75, 0.18);
+    border-radius: var(--r);
+    font-size: 13px;
+    color: var(--cream);
+}
+.cp-page .reg-summary .total {
+    font-size: 20px;
+    font-weight: 900;
+    color: var(--gold);
+    font-family: var(--heading);
+}
+.cp-page .reg-error-block {
+    padding: 10px 12px;
+    background: rgba(248, 113, 113, 0.08);
+    border: 1px solid rgba(248, 113, 113, 0.25);
+    border-radius: 6px;
+    color: var(--red);
+    font-size: 12px;
+}

--- a/static/js/htmx-ext-head-support.js
+++ b/static/js/htmx-ext-head-support.js
@@ -1,0 +1,144 @@
+//==========================================================
+// head-support.js
+//
+// An extension to add head tag merging.
+//==========================================================
+(function(){
+
+    var api = null;
+
+    function log() {
+        //console.log(arguments);
+    }
+
+    function mergeHead(newContent, defaultMergeStrategy) {
+
+        if (newContent && newContent.indexOf('<head') > -1) {
+            const htmlDoc = document.createElement("html");
+            // remove svgs to avoid conflicts
+            var contentWithSvgsRemoved = newContent.replace(/<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim, '');
+            // extract head tag
+            var headTag = contentWithSvgsRemoved.match(/(<head(\s[^>]*>|>)([\s\S]*?)<\/head>)/im);
+
+            // if the  head tag exists...
+            if (headTag) {
+
+                var added = []
+                var removed = []
+                var preserved = []
+                var nodesToAppend = []
+
+                htmlDoc.innerHTML = headTag;
+                var newHeadTag = htmlDoc.querySelector("head");
+                var currentHead = document.head;
+
+                if (newHeadTag == null) {
+                    return;
+                } else {
+                    // put all new head elements into a Map, by their outerHTML
+                    var srcToNewHeadNodes = new Map();
+                    for (const newHeadChild of newHeadTag.children) {
+                        srcToNewHeadNodes.set(newHeadChild.outerHTML, newHeadChild);
+                    }
+                }
+
+
+
+                // determine merge strategy
+                var mergeStrategy = api.getAttributeValue(newHeadTag, "hx-head") || defaultMergeStrategy;
+
+                // get the current head
+                for (const currentHeadElt of currentHead.children) {
+
+                    // If the current head element is in the map
+                    var inNewContent = srcToNewHeadNodes.has(currentHeadElt.outerHTML);
+                    var isReAppended = currentHeadElt.getAttribute("hx-head") === "re-eval";
+                    var isPreserved = api.getAttributeValue(currentHeadElt, "hx-preserve") === "true";
+                    if (inNewContent || isPreserved) {
+                        if (isReAppended) {
+                            // remove the current version and let the new version replace it and re-execute
+                            removed.push(currentHeadElt);
+                        } else {
+                            // this element already exists and should not be re-appended, so remove it from
+                            // the new content map, preserving it in the DOM
+                            srcToNewHeadNodes.delete(currentHeadElt.outerHTML);
+                            preserved.push(currentHeadElt);
+                        }
+                    } else {
+                        if (mergeStrategy === "append") {
+                            // we are appending and this existing element is not new content
+                            // so if and only if it is marked for re-append do we do anything
+                            if (isReAppended) {
+                                removed.push(currentHeadElt);
+                                nodesToAppend.push(currentHeadElt);
+                            }
+                        } else {
+                            // if this is a merge, we remove this content since it is not in the new head
+                            if (api.triggerEvent(document.body, "htmx:removingHeadElement", {headElement: currentHeadElt}) !== false) {
+                                removed.push(currentHeadElt);
+                            }
+                        }
+                    }
+                }
+
+                // Push the tremaining new head elements in the Map into the
+                // nodes to append to the head tag
+                nodesToAppend.push(...srcToNewHeadNodes.values());
+                log("to append: ", nodesToAppend);
+
+                for (const newNode of nodesToAppend) {
+                    log("adding: ", newNode);
+                    var newElt = document.createRange().createContextualFragment(newNode.outerHTML);
+                    log(newElt);
+                    if (api.triggerEvent(document.body, "htmx:addingHeadElement", {headElement: newElt}) !== false) {
+                        currentHead.appendChild(newElt);
+                        added.push(newElt);
+                    }
+                }
+
+                // remove all removed elements, after we have appended the new elements to avoid
+                // additional network requests for things like style sheets
+                for (const removedElement of removed) {
+                    if (api.triggerEvent(document.body, "htmx:removingHeadElement", {headElement: removedElement}) !== false) {
+                        currentHead.removeChild(removedElement);
+                    }
+                }
+
+                api.triggerEvent(document.body, "htmx:afterHeadMerge", {added: added, kept: preserved, removed: removed});
+            }
+        }
+    }
+
+    htmx.defineExtension("head-support", {
+        init: function(apiRef) {
+            // store a reference to the internal API.
+            api = apiRef;
+
+            htmx.on('htmx:afterSwap', function(evt){
+                let xhr = evt.detail.xhr;
+                if (xhr) {
+                    var serverResponse = xhr.response;
+                    if (api.triggerEvent(document.body, "htmx:beforeHeadMerge", evt.detail)) {
+                        mergeHead(serverResponse, evt.detail.boosted ? "merge" : "append");
+                    }
+                }
+            })
+
+            htmx.on('htmx:historyRestore', function(evt){
+                if (api.triggerEvent(document.body, "htmx:beforeHeadMerge", evt.detail)) {
+                    if (evt.detail.cacheMiss) {
+                        mergeHead(evt.detail.serverResponse, "merge");
+                    } else {
+                        mergeHead(evt.detail.item.head, "merge");
+                    }
+                }
+            })
+
+            htmx.on('htmx:historyItemCreated', function(evt){
+                var historyItem = evt.detail.item;
+                historyItem.head = document.head.outerHTML;
+            })
+        }
+    });
+
+})()

--- a/templates/classes/public/register.html
+++ b/templates/classes/public/register.html
@@ -1,28 +1,11 @@
 {% extends "classes/base_public.html" %}
+{% load static %}
 {% load classes_tags %}
 
 {% block title %}Register — {{ offering.title }} — Past Lives Makerspace{% endblock %}
 
 {% block classes_extra_head %}
-<style>
-.cp-page .reg-form{display:flex;flex-direction:column;gap:14px}
-.cp-page .reg-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
-@media(max-width:600px){.cp-page .reg-row{grid-template-columns:1fr}}
-.cp-page .reg-field label{display:block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);margin-bottom:5px}
-.cp-page .reg-field input[type=text],.cp-page .reg-field input[type=email],.cp-page .reg-field input[type=tel],.cp-page .reg-field textarea{width:100%;padding:9px 11px;background:rgba(9,46,76,.35);border:1px solid var(--border);border-radius:6px;color:var(--cream);font-family:var(--font);font-size:13px}
-.cp-page .reg-field input:focus,.cp-page .reg-field textarea:focus{outline:none;border-color:var(--gold);background:rgba(14,50,80,.5)}
-.cp-page .reg-field textarea{min-height:70px;resize:vertical}
-.cp-page .reg-errors{color:var(--red);font-size:11px;margin-top:4px;list-style:none;padding:0}
-.cp-page .reg-help{color:var(--text3);font-size:11px;margin-top:4px}
-.cp-page .reg-waiver{margin-top:6px;padding:14px 16px;background:rgba(9,46,76,.3);border:1px solid var(--border);border-radius:var(--r)}
-.cp-page .reg-waiver h3{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--gold);margin-bottom:8px}
-.cp-page .reg-waiver-text{font-size:12px;color:var(--steel);line-height:1.6;max-height:200px;overflow:auto;white-space:pre-wrap;padding:10px 12px;background:rgba(0,0,0,.2);border-radius:6px;margin-bottom:10px}
-.cp-page .reg-check{display:flex;gap:8px;align-items:flex-start;font-size:12px;color:var(--cream);cursor:pointer}
-.cp-page .reg-check input{margin-top:3px;accent-color:var(--gold)}
-.cp-page .reg-summary{padding:14px 16px;background:rgba(238,180,75,.06);border:1px solid rgba(238,180,75,.18);border-radius:var(--r);font-size:13px;color:var(--cream)}
-.cp-page .reg-summary .total{font-size:20px;font-weight:900;color:var(--gold);font-family:var(--heading)}
-.cp-page .reg-error-block{padding:10px 12px;background:rgba(248,113,113,.08);border:1px solid rgba(248,113,113,.25);border-radius:6px;color:var(--red);font-size:12px}
-</style>
+<link rel="stylesheet" href="{% static 'css/classes-register.css' %}">
 {% endblock %}
 
 {% block portal_content %}

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -38,7 +38,7 @@
     </script>
     {% block extra_head %}{% endblock %}
 </head>
-<body class="{% block body_class %}{% endblock %}" hx-boost="true" x-data="{ sidebarOpen: window.innerWidth > 768 ? ((localStorage.getItem('hubSidebarOpen') !== null) ? (localStorage.getItem('hubSidebarOpen') === '1') : true) : false }" x-init="$watch('sidebarOpen', v => { if (window.innerWidth > 768) localStorage.setItem('hubSidebarOpen', v ? '1' : '0') })">
+<body class="{% block body_class %}{% endblock %}" hx-boost="true" hx-ext="head-support" x-data="{ sidebarOpen: window.innerWidth > 768 ? ((localStorage.getItem('hubSidebarOpen') !== null) ? (localStorage.getItem('hubSidebarOpen') === '1') : true) : false }" x-init="$watch('sidebarOpen', v => { if (window.innerWidth > 768) localStorage.setItem('hubSidebarOpen', v ? '1' : '0') })">
 {% block extra_body %}{% endblock %}
     {% if user.is_authenticated and not request.GET.public %}
     <div class="hub-sidebar-backdrop" :class="{ 'hub-sidebar-backdrop--visible': sidebarOpen }" @click="sidebarOpen = false"></div>
@@ -383,6 +383,9 @@
     {% include "components/toast.html" %}
     {% include "includes/changelog_modal.html" %}
     <script src="{% static 'js/htmx.min.js' %}"></script>
+    {# head-support: makes hx-boost merge <head> contents (per-page styles, link tags) — without it,
+       page-specific <link>/<style> in extra_head silently disappear on boosted navigations. #}
+    <script src="{% static 'js/htmx-ext-head-support.js' %}"></script>
     <script>
         document.body.addEventListener('htmx:configRequest', function(event) {
             event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';


### PR DESCRIPTION
## Summary

Two changes bundled into one release:

### 1. Free class/workshop option (feature)
- New "This is a free class / workshop" checkbox on both `ClassOfferingForm` (admin) and `InstructorClassOfferingForm` (instructor portal). When checked, `price_cents` and `member_discount_pct` are zeroed on save.
- Pre-checked when editing an existing class with `price_cents == 0`.
- Form `clean()` now requires a price unless the box is checked (clear validation error otherwise).
- `cents_as_price` template filter renders 0 as **"Free"** instead of "$0", so the class card, detail page, and registration summary all use the friendlier label automatically.
- The runtime registration flow already supported `price_cents=0` (no Stripe round-trip, instant confirmation email) — this just gives admins/instructors a clear UX for it.

### 2. Register page CSS hotfix + permanent prevention
The Register page lost its styling when navigated to via hx-boost from a class detail page. We've fixed this same class of bug repeatedly. Three layers of fix so it can't recur:

- **Real fix:** Vendor htmx's [head-support](https://htmx.org/extensions/head-support/) extension and load it on `hub/base.html` with `hx-ext="head-support"`. Boost now merges `<head>` contents on every navigation — retroactively fixes every existing page with per-page styles.
- **Pattern fix:** Move the Register page's inline `<style>` into `static/css/classes-register.css`, referenced via `<link>`. Works whether or not head-support is loaded.
- **Recurrence prevention:** New `scripts/check_no_inline_style_in_extra_head.py` lints templates for `<style>` blocks inside any `extra_head` block. Wired into CI (`.github/workflows/ci.yml`) and the local pre-push hook. A baseline grandfathers 5 pre-existing offenders so the lint is additive — but **any new template that puts inline `<style>` in `extra_head` will fail CI**.

## Test plan
- [x] `pytest classes/` — 183 passed (7 new specs for free-class form behavior)
- [x] `ruff check .` clean
- [x] `python3 scripts/check_no_inline_style_in_extra_head.py` exits 0 (baseline matches)
- [ ] Admin: create a class with the "free" box checked → no price required → "Free" shows on the public list
- [ ] Instructor: same flow via the Teaching dashboard
- [ ] Member registers for a free class → no Stripe redirect → confirmation email arrives
- [ ] Visit a class detail page logged-in → click Register → form is fully styled (no hard refresh needed)
- [ ] Same flow as anonymous visitor

## Why we keep hitting the CSS bug
Every time someone (human or AI) writes a new page and quickly drops a `<style>` block in `{% block extra_head %}`, hx-boost silently breaks the styling on intra-app navigation. There's no runtime error — the page just looks broken. Layer 1 (head-support) makes the symptom impossible at runtime; layer 3 (CI lint) makes the lazy pattern impossible at PR time.