### PR TITLE
Free class/workshop checkbox in the class form (v1.7.6)

### DIFF
--- a/classes/forms.py
+++ b/classes/forms.py
@@ -24,7 +24,55 @@ if TYPE_CHECKING:
     from membership.models import Member
 
 
-class ClassOfferingForm(forms.ModelForm):
+class _FreeClassMixin:
+    """Adds an `is_free` checkbox that, when checked, forces price/discount to 0.
+
+    Source of truth remains `price_cents` on the model (0 = free). The checkbox
+    is a UX affordance so the instructor/admin doesn't have to know that "type 0
+    in cents" makes a class free — they just tick a box.
+    """
+
+    def add_is_free_field(self) -> None:
+        instance = getattr(self, "instance", None)
+        initial = bool(instance and instance.pk and instance.price_cents == 0)
+        self.fields["is_free"] = forms.BooleanField(  # type: ignore[attr-defined]
+            required=False,
+            initial=initial,
+            label="This is a free class / workshop",
+            help_text="Check this if there's no fee. Members will be able to register without entering payment info.",
+        )
+        # Price and discount aren't required when the class is free — the form's
+        # clean() enforces that price_cents is filled in for non-free classes.
+        self.fields["price_cents"].required = False  # type: ignore[attr-defined]
+        self.fields["member_discount_pct"].required = False  # type: ignore[attr-defined]
+        # Render the checkbox just above price so the visual flow is "Is this free?
+        # → if not, here's the price." Django keeps this order when iterating `form`.
+        ordered: list[str] = []
+        for name in self.fields:  # type: ignore[attr-defined]
+            if name == "price_cents":
+                ordered.append("is_free")
+            if name == "is_free":
+                continue
+            ordered.append(name)
+        self.order_fields(ordered)  # type: ignore[attr-defined]
+
+    def clean_is_free_pricing(self) -> None:
+        """Require price_cents when the class isn't free. Call from `clean()`."""
+        cleaned = self.cleaned_data  # type: ignore[attr-defined]
+        if cleaned.get("is_free"):
+            return
+        if cleaned.get("price_cents") in (None, ""):
+            self.add_error(  # type: ignore[attr-defined]
+                "price_cents", "Set a price (in cents) or check 'This is a free class / workshop'."
+            )
+
+    def apply_is_free_to_instance(self, offering: ClassOffering) -> None:
+        if self.cleaned_data.get("is_free"):  # type: ignore[attr-defined]
+            offering.price_cents = 0
+            offering.member_discount_pct = 0
+
+
+class ClassOfferingForm(_FreeClassMixin, forms.ModelForm):
     class Meta:
         model = ClassOffering
         fields = [
@@ -51,8 +99,25 @@ class ClassOfferingForm(forms.ModelForm):
             "requires_model_release",
         ]
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.add_is_free_field()
 
-class InstructorClassOfferingForm(forms.ModelForm):
+    def clean(self) -> dict:
+        data = super().clean()
+        self.clean_is_free_pricing()
+        return data
+
+    def save(self, commit: bool = True) -> ClassOffering:
+        offering = super().save(commit=False)
+        self.apply_is_free_to_instance(offering)
+        if commit:
+            offering.save()
+            self.save_m2m()
+        return offering
+
+
+class InstructorClassOfferingForm(_FreeClassMixin, forms.ModelForm):
     """Class form for instructors — no `instructor`, no `is_private`, slug auto-generated."""
 
     class Meta:
@@ -80,9 +145,16 @@ class InstructorClassOfferingForm(forms.ModelForm):
     def __init__(self, *args, instructor: Instructor | None = None, **kwargs) -> None:
         self.instructor = instructor
         super().__init__(*args, **kwargs)
+        self.add_is_free_field()
+
+    def clean(self) -> dict:
+        data = super().clean()
+        self.clean_is_free_pricing()
+        return data
 
     def save(self, commit: bool = True) -> ClassOffering:
         offering = super().save(commit=False)
+        self.apply_is_free_to_instance(offering)
         if self.instructor is not None and not offering.instructor_id:
             offering.instructor = self.instructor
             if not offering.created_by_id:

--- a/classes/spec/forms/free_class_spec.py
+++ b/classes/spec/forms/free_class_spec.py
@@ -1,0 +1,120 @@
+"""BDD specs for the `is_free` checkbox on ClassOffering forms."""
+
+from __future__ import annotations
+
+import pytest
+
+from classes.factories import CategoryFactory, ClassOfferingFactory, InstructorFactory
+from classes.forms import ClassOfferingForm, InstructorClassOfferingForm
+from classes.models import ClassOffering
+
+pytestmark = pytest.mark.django_db
+
+
+def _admin_post_data(**overrides) -> dict:
+    data = {
+        "title": "Forge Basics",
+        "slug": "forge-basics",
+        "category": str(CategoryFactory().pk),
+        "instructor": str(InstructorFactory().pk),
+        "description": "Hands-on intro.",
+        "prerequisites": "",
+        "materials_included": "",
+        "materials_to_bring": "",
+        "safety_requirements": "",
+        "age_minimum": "",
+        "age_guardian_note": "",
+        "price_cents": "10000",
+        "member_discount_pct": "10",
+        "capacity": "6",
+        "scheduling_model": ClassOffering.SchedulingModel.FIXED,
+        "flexible_note": "",
+        "is_private": "",
+        "private_for_name": "",
+        "recurring_pattern": "",
+        "image": "",
+        "requires_model_release": "",
+    }
+    data.update(overrides)
+    return data
+
+
+def describe_ClassOfferingForm():
+    def describe_is_free_checkbox():
+        def it_zeroes_price_and_discount_when_checked():
+            form = ClassOfferingForm(
+                data=_admin_post_data(is_free="on", price_cents="", member_discount_pct=""),
+            )
+            assert form.is_valid(), form.errors
+            offering = form.save()
+            assert offering.price_cents == 0
+            assert offering.member_discount_pct == 0
+
+        def it_keeps_paid_pricing_when_unchecked():
+            form = ClassOfferingForm(data=_admin_post_data(price_cents="2500", member_discount_pct="15"))
+            assert form.is_valid(), form.errors
+            offering = form.save()
+            assert offering.price_cents == 2500
+            assert offering.member_discount_pct == 15
+
+        def it_requires_a_price_when_not_free():
+            form = ClassOfferingForm(data=_admin_post_data(price_cents="", member_discount_pct=""))
+            assert not form.is_valid()
+            assert "price_cents" in form.errors
+
+        def it_pre_checks_for_existing_free_class():
+            offering = ClassOfferingFactory(price_cents=0, member_discount_pct=0)
+            form = ClassOfferingForm(instance=offering)
+            assert form.fields["is_free"].initial is True
+
+        def it_pre_unchecks_for_existing_paid_class():
+            offering = ClassOfferingFactory(price_cents=4500)
+            form = ClassOfferingForm(instance=offering)
+            assert form.fields["is_free"].initial is False
+
+
+def _instructor_post_data(**overrides) -> dict:
+    data = {
+        "title": "Free Demo",
+        "category": str(CategoryFactory().pk),
+        "description": "A walkthrough.",
+        "prerequisites": "",
+        "materials_included": "",
+        "materials_to_bring": "",
+        "safety_requirements": "",
+        "age_minimum": "",
+        "age_guardian_note": "",
+        "price_cents": "",
+        "member_discount_pct": "",
+        "capacity": "6",
+        "scheduling_model": ClassOffering.SchedulingModel.FIXED,
+        "flexible_note": "",
+        "recurring_pattern": "",
+        "image": "",
+        "requires_model_release": "",
+    }
+    data.update(overrides)
+    return data
+
+
+def describe_InstructorClassOfferingForm():
+    def describe_is_free_checkbox():
+        def it_zeroes_pricing_when_checked():
+            instructor = InstructorFactory()
+            form = InstructorClassOfferingForm(
+                data=_instructor_post_data(is_free="on"),
+                instructor=instructor,
+            )
+            assert form.is_valid(), form.errors
+            offering = form.save()
+            assert offering.price_cents == 0
+            assert offering.member_discount_pct == 0
+
+        def it_requires_price_for_paid_class():
+            instructor = InstructorFactory()
+            form = InstructorClassOfferingForm(
+                data=_instructor_post_data(),
+                instructor=instructor,
+            )
+            assert not form.is_valid()
+            assert "price_cents" in form.errors

--- a/classes/templatetags/classes_tags.py
+++ b/classes/templatetags/classes_tags.py
@@ -12,10 +12,12 @@ register = template.Library()
 
 @register.filter
 def cents_as_price(value: int | None) -> str:
-    """Format integer cents as a dollar string. Whole dollars drop the decimals."""
+    """Format integer cents as a dollar string. Zero renders as "Free"; whole dollars drop the decimals."""
     if value is None:
         return ""
     cents = int(value)
+    if cents == 0:
+        return "Free"
     dollars, remainder = divmod(cents, 100)
     if remainder == 0:
         return f"${dollars}"

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-VERSION = "1.7.5"
+VERSION = "1.7.6"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.7.6",
+        "date": "2026-04-26",
+        "title": "Free classes & workshops — one click to make a class free",
+        "changes": [
+            'When you create or edit a class, there\'s now a "This is a free class / workshop" checkbox right above the price field. Tick it and the class is free — members and visitors register without entering any payment info, and they get a confirmation email immediately.',
+            'Free classes show as "Free" everywhere on the site (the class card, the detail page, and the registration summary) instead of a $0 price tag.',
+        ],
+    },
     {
         "version": "1.7.5",
         "date": "2026-04-25",


### PR DESCRIPTION
## Summary

The registration runtime has supported free classes since v1.7.5 (price_cents=0 → no Stripe round-trip, instant confirmation), but the admin/instructor UX didn't make this obvious — they had to know "type 0 in cents = free." This PR adds a clear affordance.

## What changed

- **\"This is a free class / workshop\" checkbox** on both `ClassOfferingForm` (admin) and `InstructorClassOfferingForm` (instructor portal). Renders just above the price field via `order_fields()`.
- When checked on save: `price_cents` and `member_discount_pct` are zeroed.
- When unchecked on save: `clean()` requires a price (clear error if missing).
- Pre-checked when editing an existing free class (`instance.price_cents == 0`).
- `cents_as_price` template filter now renders `0` as **\"Free\"** instead of `\"$0\"` — so the class card, detail page, and registration summary all show the friendlier label automatically.

## Architecture

- New `_FreeClassMixin` keeps the wiring DRY across the two forms (admin vs instructor).
- No model change — `price_cents=0` is the single source of truth.
- No migration.

## Test plan
- [x] 7 BDD specs in `classes/spec/forms/free_class_spec.py` cover:
    - Checking the box zeros price + discount on save (both forms)
    - Unchecking + leaving price blank fails validation
    - Pre-check state matches existing instance pricing
    - Paid pricing is preserved unchanged when unchecked
- [x] Full `pytest classes/` — 183 passed
- [x] `ruff check classes/` clean
- [ ] Admin: create a class with the box checked → confirms with no price field error → \"Free\" shows on the public list
- [ ] Instructor: same flow via the Teaching dashboard
- [ ] Member registers for a free class → no Stripe redirect → confirmation email arrives