### PR TITLE
Hotfix v1.7.7: site layout broken by multi-line {# #} comment in hub/base.html

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-VERSION = "1.7.6"
+VERSION = "1.7.7"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.7.7",
+        "date": "2026-04-27",
+        "title": "Hotfix: site layout broken for everyone",
+        "changes": [
+            "Fixed a bug introduced in the last release where the entire site rendered at half-width with a stray line of text near the top — the page was unusable. Everything looks correct again.",
+        ],
+    },
     {
         "version": "1.7.6",
         "date": "2026-04-26",

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "1.7.7"
+VERSION = "1.7.5.2"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "1.7.7",
+        "version": "1.7.5.2",
         "date": "2026-04-27",
         "title": "Hotfix: site layout broken for everyone",
         "changes": [

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -383,8 +383,10 @@
     {% include "components/toast.html" %}
     {% include "includes/changelog_modal.html" %}
     <script src="{% static 'js/htmx.min.js' %}"></script>
-    {# head-support: makes hx-boost merge <head> contents (per-page styles, link tags) — without it,
-       page-specific <link>/<style> in extra_head silently disappear on boosted navigations. #}
+    {% comment %}
+        head-support: makes hx-boost merge <head> contents (per-page styles, link tags) — without it,
+        page-specific <link>/<style> in extra_head silently disappear on boosted navigations.
+    {% endcomment %}
     <script src="{% static 'js/htmx-ext-head-support.js' %}"></script>
     <script>
         document.body.addEventListener('htmx:configRequest', function(event) {


### PR DESCRIPTION
## Summary
- v1.7.6 added a multi-line `{# ... #}` comment above the head-support `<script>` tag in `templates/hub/base.html`. Django's `{# #}` syntax only matches on a single line — the comment text was rendered into the page body, and the literal `<style>` substring opened a real style block that consumed the rest of the document.
- Symptom: every page on the site rendered at half-width, with a stray fragment of comment text near the top of the body, until the user did a hard refresh on a non-boosted route.
- Fix: switch to `{% comment %}{% endcomment %}`, the only Django syntax that legitimately spans multiple lines. Behavior of the head-support extension itself is unchanged.

## Test plan
- [x] `templates/hub/base.html` renders with no occurrence of `head-support: makes hx-boost` or `silently disappear on boosted` in the output HTML.
- [x] `htmx-ext-head-support.js` `<script>` tag is still present in the rendered head, and `hx-ext="head-support"` is still on `<body>`.
- [x] `scripts/check_no_inline_style_in_extra_head.py` exits 0.
- [ ] Manual: log into the hub, navigate around (Hub → Classes → a class → Register) and confirm full-width layout on every page with no stray text near the top.