### PR TITLE
v2.2.2: Image uploads work on the New Class form

### DIFF
--- a/classes/models.py
+++ b/classes/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import secrets
 from datetime import date as date_type
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.db import models
@@ -13,6 +14,9 @@ from django.utils import timezone
 from core.files import delete_orphan_on_replace
 from core.images import normalize_field_if_uploaded
 from core.validators import validate_image_size
+
+if TYPE_CHECKING:
+    from django.core.files.uploadedfile import UploadedFile
 
 DEFAULT_LIABILITY_TEXT = """ASSUMPTION OF RISK AND WAIVER OF LIABILITY
 
@@ -247,6 +251,11 @@ class ClassOffering(models.Model):
     def archive(self) -> None:
         self.status = self.Status.ARCHIVED
         self.save(update_fields=["status", "updated_at"])
+
+    def add_gallery_images(self, files: list[UploadedFile]) -> None:
+        """Create ClassImage rows from uploaded files."""
+        for i, img_file in enumerate(files):
+            ClassImage.objects.create(class_offering=self, image=img_file, sort_order=i)
 
     @property
     def spots_remaining(self) -> int:

--- a/classes/spec/models/class_offering_spec.py
+++ b/classes/spec/models/class_offering_spec.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from io import BytesIO
+
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from classes.factories import ClassOfferingFactory, InstructorFactory
 from classes.models import ClassOffering
+
+
+def _image_file(name: str = "shot.png") -> SimpleUploadedFile:
+    buf = BytesIO(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    return SimpleUploadedFile(name, buf.getvalue(), content_type="image/png")
 
 
 def describe_ClassOffering():
@@ -60,3 +68,17 @@ def describe_ClassOffering():
             ClassOfferingFactory(instructor=instructor)
             ClassOfferingFactory()
             assert ClassOffering.objects.for_instructor(instructor).count() == 1
+
+    def describe_add_gallery_images():
+        def it_creates_class_images_with_sort_order(db):
+            offering = ClassOfferingFactory()
+            files = [_image_file("a.png"), _image_file("b.png"), _image_file("c.png")]
+            offering.add_gallery_images(files)
+            images = list(offering.gallery_images.all())
+            assert len(images) == 3
+            assert [img.sort_order for img in images] == [0, 1, 2]
+
+        def it_handles_empty_list(db):
+            offering = ClassOfferingFactory()
+            offering.add_gallery_images([])
+            assert offering.gallery_images.count() == 0

--- a/classes/spec/views/admin_classes_spec.py
+++ b/classes/spec/views/admin_classes_spec.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+from io import BytesIO
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
+
+
+def _image_file(name: str = "shot.png") -> SimpleUploadedFile:
+    buf = BytesIO(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    return SimpleUploadedFile(name, buf.getvalue(), content_type="image/png")
 
 
 def describe_status_filter():
@@ -158,6 +166,48 @@ def describe_create_class():
 
         created = ClassOffering.objects.get(slug="new-class")
         assert created.status == ClassOffering.Status.PUBLISHED
+
+    def it_saves_gallery_images_on_create(admin_user, client, db):
+        from classes.factories import CategoryFactory, InstructorFactory
+        from classes.models import ClassImage, ClassOffering
+
+        client.force_login(admin_user)
+        cat = CategoryFactory()
+        inst = InstructorFactory()
+        response = client.post(
+            reverse("classes:admin_class_create"),
+            {
+                "title": "Gallery Class",
+                "slug": "gallery-class",
+                "category": cat.pk,
+                "instructor": inst.pk,
+                "price_cents": "50.00",
+                "member_discount_pct": 10,
+                "capacity": 6,
+                "scheduling_model": "fixed",
+                "description": "d",
+                "prerequisites": "",
+                "materials_included": "",
+                "materials_to_bring": "",
+                "safety_requirements": "",
+                "age_guardian_note": "",
+                "flexible_note": "",
+                "private_for_name": "",
+                "recurring_pattern": "",
+                "sessions-TOTAL_FORMS": "0",
+                "sessions-INITIAL_FORMS": "0",
+                "sessions-MIN_NUM_FORMS": "0",
+                "sessions-MAX_NUM_FORMS": "1000",
+                "images-TOTAL_FORMS": "0",
+                "images-INITIAL_FORMS": "0",
+                "images-MIN_NUM_FORMS": "0",
+                "images-MAX_NUM_FORMS": "1000",
+                "gallery_images": [_image_file("a.png"), _image_file("b.png")],
+            },
+        )
+        assert response.status_code == 302
+        offering = ClassOffering.objects.get(slug="gallery-class")
+        assert ClassImage.objects.filter(class_offering=offering).count() == 2
 
 
 def describe_edit_class():

--- a/classes/spec/views/instructor_dashboard_spec.py
+++ b/classes/spec/views/instructor_dashboard_spec.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from io import BytesIO
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.utils import timezone
 
@@ -15,7 +17,12 @@ from classes.factories import (
     RegistrationFactory,
     UserFactory,
 )
-from classes.models import ClassOffering
+from classes.models import ClassImage, ClassOffering
+
+
+def _image_file(name: str = "shot.png") -> SimpleUploadedFile:
+    buf = BytesIO(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    return SimpleUploadedFile(name, buf.getvalue(), content_type="image/png")
 
 
 @pytest.fixture
@@ -146,6 +153,42 @@ def describe_instructor_create_class():
         assert response.status_code == 302
         offering = ClassOffering.objects.get(title="Submit-Me")
         assert offering.status == ClassOffering.Status.PENDING
+
+    def it_saves_gallery_images_on_create(instructor_fixture, client):
+        cat = CategoryFactory()
+        client.force_login(instructor_fixture.user)
+        response = client.post(
+            reverse("classes:instructor_class_create"),
+            {
+                "title": "Gallery Class",
+                "category": cat.pk,
+                "description": "d",
+                "prerequisites": "",
+                "materials_included": "",
+                "materials_to_bring": "",
+                "safety_requirements": "",
+                "age_guardian_note": "",
+                "price_cents": 5000,
+                "member_discount_pct": 10,
+                "capacity": 6,
+                "scheduling_model": "fixed",
+                "flexible_note": "",
+                "recurring_pattern": "",
+                "sessions-TOTAL_FORMS": "0",
+                "sessions-INITIAL_FORMS": "0",
+                "sessions-MIN_NUM_FORMS": "0",
+                "sessions-MAX_NUM_FORMS": "1000",
+                "images-TOTAL_FORMS": "0",
+                "images-INITIAL_FORMS": "0",
+                "images-MIN_NUM_FORMS": "0",
+                "images-MAX_NUM_FORMS": "1000",
+                "action": "save",
+                "gallery_images": [_image_file("x.png"), _image_file("y.png")],
+            },
+        )
+        assert response.status_code == 302
+        offering = ClassOffering.objects.get(title="Gallery Class")
+        assert ClassImage.objects.filter(class_offering=offering).count() == 2
 
 
 def describe_instructor_edit_class():

--- a/classes/views.py
+++ b/classes/views.py
@@ -542,8 +542,7 @@ def instructor_class_create(request: HttpRequest) -> HttpResponse:
         offering = form.save()
         formset.instance = offering
         formset.save()
-        for i, img_file in enumerate(request.FILES.getlist("gallery_images")):
-            ClassImage.objects.create(class_offering=offering, image=img_file, sort_order=i)
+        offering.add_gallery_images(request.FILES.getlist("gallery_images"))
         submit_now = request.POST.get("action") == "submit"
         if submit_now:
             offering.submit_for_review()
@@ -818,8 +817,7 @@ def admin_class_create(request: HttpRequest) -> HttpResponse:
         offering.save()
         session_formset.instance = offering
         session_formset.save()
-        for i, img_file in enumerate(request.FILES.getlist("gallery_images")):
-            ClassImage.objects.create(class_offering=offering, image=img_file, sort_order=i)
+        offering.add_gallery_images(request.FILES.getlist("gallery_images"))
         messages.success(request, f"{offering.title} is published.")
         return redirect("classes:admin_class_edit", pk=offering.pk)
 

--- a/classes/views.py
+++ b/classes/views.py
@@ -542,6 +542,8 @@ def instructor_class_create(request: HttpRequest) -> HttpResponse:
         offering = form.save()
         formset.instance = offering
         formset.save()
+        for i, img_file in enumerate(request.FILES.getlist("gallery_images")):
+            ClassImage.objects.create(class_offering=offering, image=img_file, sort_order=i)
         submit_now = request.POST.get("action") == "submit"
         if submit_now:
             offering.submit_for_review()
@@ -816,7 +818,9 @@ def admin_class_create(request: HttpRequest) -> HttpResponse:
         offering.save()
         session_formset.instance = offering
         session_formset.save()
-        messages.success(request, f"{offering.title} is published. You can now add gallery images.")
+        for i, img_file in enumerate(request.FILES.getlist("gallery_images")):
+            ClassImage.objects.create(class_offering=offering, image=img_file, sort_order=i)
+        messages.success(request, f"{offering.title} is published.")
         return redirect("classes:admin_class_edit", pk=offering.pk)
 
     sessions_data: list[dict] = []

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-VERSION = "2.2.1"
+VERSION = "2.2.2"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "2.2.2",
+        "date": "2026-05-26",
+        "title": "Image uploads work on the New Class form",
+        "changes": [
+            "The 'New Class' form now has the same hero image and gallery image upload experience as the edit form — drag-and-drop zone with instant preview instead of a plain file picker. Gallery images are uploaded when you hit Save.",
+        ],
+    },
     {
         "version": "2.2.1",
         "date": "2026-05-26",

--- a/templates/classes/_components/hero_image_field.html
+++ b/templates/classes/_components/hero_image_field.html
@@ -86,15 +86,47 @@ Params:
     })();
     </script>
     {% else %}
-    {# Not yet saved — fall back to normal file input #}
-    {% if current_image %}
-    <img src="{{ current_image.url }}"
-         alt="Current hero image"
-         data-hero-cropper-preview
-         style="max-width:100%;max-height:320px;border-radius:6px;border:1px solid var(--hub-border,#1a4568);margin-bottom:0.5rem;display:block;">
-    {% endif %}
-    {{ field }}
+    {# Create mode — same styled zone, file submits with the form #}
+    <div id="hero-preview" style="margin-bottom:0.5rem;"></div>
+    <label class="cls-image-upload-zone" id="hero-upload-zone" style="margin-bottom:0.5rem;">
+        {{ field }}
+        <span class="cls-image-upload-label">+ Upload hero image</span>
+        <span class="cls-image-upload-hint">Click or drag a file here</span>
+    </label>
     {% if crop_field %}{{ crop_field }}{% endif %}
+    <script>
+    (function() {
+        const zone = document.getElementById('hero-upload-zone');
+        if (!zone) return;
+        const input = zone.querySelector('input[type="file"]');
+        const preview = document.getElementById('hero-preview');
+        if (!input) return;
+        input.style.display = 'none';
+        input.addEventListener('change', function() {
+            if (!this.files.length) return;
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                preview.innerHTML = '<img src="' + e.target.result + '" alt="Hero image preview" data-hero-cropper-preview style="max-width:100%;max-height:320px;object-fit:contain;border-radius:6px;border:1px solid var(--hub-border,#1a4568);display:block;">';
+                zone.querySelector('.cls-image-upload-label').textContent = 'Replace image';
+                if (window.initHeroCropper) window.initHeroCropper();
+            };
+            reader.readAsDataURL(this.files[0]);
+        });
+        zone.addEventListener('dragover', function(e) { e.preventDefault(); zone.classList.add('drag-hover'); });
+        zone.addEventListener('dragleave', function() { zone.classList.remove('drag-hover'); });
+        zone.addEventListener('drop', function(e) {
+            e.preventDefault();
+            zone.classList.remove('drag-hover');
+            const f = e.dataTransfer.files[0];
+            if (f && f.type.startsWith('image/')) {
+                const dt = new DataTransfer();
+                dt.items.add(f);
+                input.files = dt.files;
+                input.dispatchEvent(new Event('change'));
+            }
+        });
+    })();
+    </script>
     {% endif %}
 
     {% if field.errors %}

--- a/templates/classes/_components/image_formset.html
+++ b/templates/classes/_components/image_formset.html
@@ -269,9 +269,10 @@ On create (no pk): multi-file input that submits with the form, with local previ
                 card.innerHTML = `
                     <div class="cls-image-thumb"><img src="${e.target.result}" alt=""></div>
                     <div class="cls-image-fields">
-                        <span class="cls-image-alt" style="flex:1;font-size:0.8rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${file.name}</span>
+                        <span class="cls-image-alt" style="flex:1;font-size:0.8rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></span>
                         <button type="button" class="cls-image-remove" title="Remove image">&times;</button>
                     </div>`;
+                card.querySelector('.cls-image-alt').textContent = file.name;
                 card.querySelector('.cls-image-remove').addEventListener('click', function() {
                     card.remove();
                     rebuildFileList();

--- a/templates/classes/_components/image_formset.html
+++ b/templates/classes/_components/image_formset.html
@@ -1,35 +1,8 @@
 {% comment %}
-AJAX-driven gallery image manager. Uploads immediately without page save.
-Supports drag-and-drop reordering, inline alt-text editing, and delete.
-Works for both admin and instructor class forms.
+Gallery image manager for class forms.
+On edit (has pk): AJAX uploads with instant save, drag-to-reorder, inline alt-text.
+On create (no pk): multi-file input that submits with the form, with local previews.
 {% endcomment %}
-{% if offering and offering.pk %}
-<div id="gallery-manager"
-     data-upload-url="{% url 'classes:admin_class_image_upload' pk=offering.pk %}"
-     data-reorder-url="{% url 'classes:admin_class_image_reorder' pk=offering.pk %}"
-     data-csrf="{{ csrf_token }}">
-
-    <div id="gallery-grid" class="cls-image-grid">
-        {% for img in offering.gallery_images.all %}
-        <div class="cls-image-cell has-image" draggable="true" data-id="{{ img.pk }}">
-            <div class="cls-image-thumb">
-                <img src="{{ img.image.url }}" alt="{{ img.alt_text|default:'' }}">
-            </div>
-            <div class="cls-image-fields">
-                <input type="text" class="cls-image-alt" value="{{ img.alt_text }}" placeholder="Alt text (optional)" data-id="{{ img.pk }}">
-                <button type="button" class="cls-image-remove" data-id="{{ img.pk }}" title="Remove image">&times;</button>
-            </div>
-            <div class="cls-image-drag-handle" title="Drag to reorder">⠿</div>
-        </div>
-        {% endfor %}
-    </div>
-
-    <label class="cls-image-upload-zone" id="gallery-upload-zone">
-        <input type="file" accept="image/*" id="gallery-file-input" style="display:none;">
-        <span class="cls-image-upload-label">+ Add image</span>
-        <span class="cls-image-upload-hint">Click or drag a file here</span>
-    </label>
-</div>
 
 <style>
 .cls-image-grid {
@@ -125,6 +98,34 @@ Works for both admin and instructor class forms.
 }
 </style>
 
+{% if offering and offering.pk %}
+<div id="gallery-manager"
+     data-upload-url="{% url 'classes:admin_class_image_upload' pk=offering.pk %}"
+     data-reorder-url="{% url 'classes:admin_class_image_reorder' pk=offering.pk %}"
+     data-csrf="{{ csrf_token }}">
+
+    <div id="gallery-grid" class="cls-image-grid">
+        {% for img in offering.gallery_images.all %}
+        <div class="cls-image-cell has-image" draggable="true" data-id="{{ img.pk }}">
+            <div class="cls-image-thumb">
+                <img src="{{ img.image.url }}" alt="{{ img.alt_text|default:'' }}">
+            </div>
+            <div class="cls-image-fields">
+                <input type="text" class="cls-image-alt" value="{{ img.alt_text }}" placeholder="Alt text (optional)" data-id="{{ img.pk }}">
+                <button type="button" class="cls-image-remove" data-id="{{ img.pk }}" title="Remove image">&times;</button>
+            </div>
+            <div class="cls-image-drag-handle" title="Drag to reorder">&#x2807;</div>
+        </div>
+        {% endfor %}
+    </div>
+
+    <label class="cls-image-upload-zone" id="gallery-upload-zone">
+        <input type="file" accept="image/*" id="gallery-file-input" style="display:none;">
+        <span class="cls-image-upload-label">+ Add image</span>
+        <span class="cls-image-upload-hint">Click or drag a file here</span>
+    </label>
+</div>
+
 <script>
 (function() {
     const manager = document.getElementById('gallery-manager');
@@ -179,7 +180,7 @@ Works for both admin and instructor class forms.
                 <input type="text" class="cls-image-alt" value="" placeholder="Alt text (optional)" data-id="${data.id}">
                 <button type="button" class="cls-image-remove" data-id="${data.id}" title="Remove image">&times;</button>
             </div>
-            <div class="cls-image-drag-handle" title="Drag to reorder">⠿</div>`;
+            <div class="cls-image-drag-handle" title="Drag to reorder">&#x2807;</div>`;
         grid.appendChild(card);
         bindCard(card);
     }
@@ -236,5 +237,77 @@ Works for both admin and instructor class forms.
 })();
 </script>
 {% else %}
-<p style="color:var(--hub-text-muted); font-size:0.85rem;">Save the class first, then you can add gallery images.</p>
+{# Create mode — multi-file input, previews shown locally, uploaded with form #}
+<div id="gallery-create">
+    <div id="gallery-preview-grid" class="cls-image-grid"></div>
+    <label class="cls-image-upload-zone" id="gallery-upload-zone">
+        <input type="file" name="gallery_images" accept="image/*" multiple id="gallery-file-input" style="display:none;">
+        <span class="cls-image-upload-label">+ Add images</span>
+        <span class="cls-image-upload-hint">Click or drag files here &mdash; uploaded when you save</span>
+    </label>
+</div>
+<script>
+(function() {
+    const zone = document.getElementById('gallery-upload-zone');
+    const fileInput = document.getElementById('gallery-file-input');
+    const grid = document.getElementById('gallery-preview-grid');
+    if (!zone || !fileInput || !grid) return;
+
+    // Accumulate files in a DataTransfer so the input carries all of them on submit
+    const dt = new DataTransfer();
+
+    function addFiles(files) {
+        for (const file of files) {
+            if (!file.type.startsWith('image/')) continue;
+            dt.items.add(file);
+            const idx = dt.files.length - 1;
+            const card = document.createElement('div');
+            card.className = 'cls-image-cell has-image';
+            card.dataset.idx = idx;
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                card.innerHTML = `
+                    <div class="cls-image-thumb"><img src="${e.target.result}" alt=""></div>
+                    <div class="cls-image-fields">
+                        <span class="cls-image-alt" style="flex:1;font-size:0.8rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${file.name}</span>
+                        <button type="button" class="cls-image-remove" title="Remove image">&times;</button>
+                    </div>`;
+                card.querySelector('.cls-image-remove').addEventListener('click', function() {
+                    card.remove();
+                    rebuildFileList();
+                });
+            };
+            reader.readAsDataURL(file);
+            grid.appendChild(card);
+        }
+        fileInput.files = dt.files;
+    }
+
+    function rebuildFileList() {
+        const newDt = new DataTransfer();
+        grid.querySelectorAll('.cls-image-cell').forEach((card, i) => {
+            const idx = parseInt(card.dataset.idx);
+            if (idx < dt.files.length) {
+                newDt.items.add(dt.files[idx]);
+                card.dataset.idx = i;
+            }
+        });
+        dt.items.clear();
+        for (const f of newDt.files) dt.items.add(f);
+        fileInput.files = dt.files;
+    }
+
+    fileInput.addEventListener('change', () => {
+        if (fileInput.files.length) addFiles([...fileInput.files]);
+    });
+    zone.addEventListener('dragover', e => { e.preventDefault(); zone.classList.add('drag-hover'); });
+    zone.addEventListener('dragleave', () => zone.classList.remove('drag-hover'));
+    zone.addEventListener('drop', e => {
+        e.preventDefault();
+        zone.classList.remove('drag-hover');
+        const files = [...e.dataTransfer.files].filter(f => f.type.startsWith('image/'));
+        if (files.length) addFiles(files);
+    });
+})();
+</script>
 {% endif %}


### PR DESCRIPTION
## Summary
- Hero image on `/classes/admin/new/` now shows the same styled drag-and-drop upload zone with instant preview as the edit form (was a bare file input)
- Gallery images on `/classes/admin/new/` now have a multi-file upload with preview thumbnails (was just text saying "Save the class first")
- Gallery files submit with the form and are saved as ClassImage rows on create
- Styles moved out of the conditional block so both create and edit forms share them

## Test plan
- [ ] Go to `/classes/admin/new/` — hero image should show styled upload zone, not a plain file input
- [ ] Drag or click to select a hero image — instant preview should appear
- [ ] Gallery section should show "+ Add images" upload zone instead of "Save the class first" text
- [ ] Select multiple gallery images — thumbnails should preview with filenames and remove buttons
- [ ] Remove a gallery preview image before saving — it should disappear
- [ ] Fill out form and Save — class should be created with hero + gallery images
- [ ] Go to `/classes/admin/4/edit/` — existing AJAX upload behavior should be unchanged
- [ ] Instructor create form at `/classes/instructor/new/` — same improvements should apply