### PR TITLE
v2.5.6 — cron dispatcher, book account light mode, onboarding fixes

### DIFF
--- a/core/management/commands/run_scheduled_tasks.py
+++ b/core/management/commands/run_scheduled_tasks.py
@@ -1,0 +1,50 @@
+"""Single dispatcher for all scheduled background tasks.
+
+Runs every 15 minutes via a Render cron service. Each registered task is
+called in its own try/except so one failure cannot block the rest. Each
+task is responsible for its own idempotency.
+
+Time-gated tasks:
+- sync_all_sources: runs only when UTC hour == 13 (≈ 6 AM Portland).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = "Dispatch all scheduled background tasks. Safe to run every 15 minutes."
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        now = timezone.now()
+        failed: list[str] = []
+
+        # --- Always-run tasks (idempotent, no-op outside their window) ---
+        for task in ("send_voting_reminders", "send_lease_expiry_reminders"):
+            try:
+                call_command(task, stdout=self.stdout, stderr=self.stderr)
+                self.stdout.write(f"  ✓ {task}")
+            except Exception as exc:
+                self.stderr.write(self.style.ERROR(f"  ✗ {task}: {exc}"))
+                failed.append(task)
+
+        # --- Daily task: sync calendar + CMS sources (~6 AM Portland = 13:xx UTC) ---
+        if now.hour == 13:
+            try:
+                call_command("sync_all_sources", stdout=self.stdout, stderr=self.stderr)
+                self.stdout.write("  ✓ sync_all_sources")
+            except Exception as exc:
+                self.stderr.write(self.style.ERROR(f"  ✗ sync_all_sources: {exc}"))
+                failed.append("sync_all_sources")
+        else:
+            self.stdout.write("  – sync_all_sources skipped (not 13:xx UTC)")
+
+        if failed:
+            self.stderr.write(self.style.ERROR(f"Failed: {', '.join(failed)}"))
+        else:
+            self.stdout.write(self.style.SUCCESS("All scheduled tasks completed."))

--- a/core/spec/management/run_scheduled_tasks_spec.py
+++ b/core/spec/management/run_scheduled_tasks_spec.py
@@ -31,9 +31,7 @@ def describe_run_scheduled_tasks_command():
             if cmd == "send_voting_reminders":
                 raise CommandError("boom")
 
-        with patch(
-            "core.management.commands.run_scheduled_tasks.call_command", side_effect=_fake_call
-        ) as mock_cc:
+        with patch("core.management.commands.run_scheduled_tasks.call_command", side_effect=_fake_call) as mock_cc:
             stderr = StringIO()
             call_command("run_scheduled_tasks", stderr=stderr)
 

--- a/core/spec/management/run_scheduled_tasks_spec.py
+++ b/core/spec/management/run_scheduled_tasks_spec.py
@@ -1,0 +1,73 @@
+"""Specs for core/management/commands/run_scheduled_tasks.py."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+pytestmark = pytest.mark.django_db
+
+
+def describe_run_scheduled_tasks_command():
+    def it_calls_all_scheduled_tasks(db):
+        with (
+            patch("core.management.commands.run_scheduled_tasks.call_command") as mock_cc,
+        ):
+            stdout = StringIO()
+            call_command("run_scheduled_tasks", stdout=stdout)
+
+        called_cmds = [c.args[0] for c in mock_cc.call_args_list]
+        assert "send_voting_reminders" in called_cmds
+        assert "send_lease_expiry_reminders" in called_cmds
+
+    def it_continues_after_one_task_raises(db):
+        """A failing task must not prevent later tasks from running."""
+
+        def _fake_call(cmd, *a, **kw):
+            if cmd == "send_voting_reminders":
+                raise CommandError("boom")
+
+        with patch("core.management.commands.run_scheduled_tasks.call_command", side_effect=_fake_call):
+            stderr = StringIO()
+            # Must not raise — dispatcher absorbs the error
+            call_command("run_scheduled_tasks", stderr=stderr)
+
+        assert "send_voting_reminders" in stderr.getvalue()
+
+    def it_logs_each_task_outcome(db):
+        with patch("core.management.commands.run_scheduled_tasks.call_command"):
+            stdout = StringIO()
+            call_command("run_scheduled_tasks", stdout=stdout)
+
+        output = stdout.getvalue()
+        assert output  # something was written
+
+    def it_runs_sync_all_sources_at_13_utc(db):
+        with (
+            patch("core.management.commands.run_scheduled_tasks.call_command") as mock_cc,
+            patch("core.management.commands.run_scheduled_tasks.timezone") as mock_tz,
+        ):
+            mock_now = MagicMock()
+            mock_now.hour = 13
+            mock_tz.now.return_value = mock_now
+            call_command("run_scheduled_tasks")
+
+        called_cmds = [c.args[0] for c in mock_cc.call_args_list]
+        assert "sync_all_sources" in called_cmds
+
+    def it_skips_sync_all_sources_outside_hour_13(db):
+        with (
+            patch("core.management.commands.run_scheduled_tasks.call_command") as mock_cc,
+            patch("core.management.commands.run_scheduled_tasks.timezone") as mock_tz,
+        ):
+            mock_now = MagicMock()
+            mock_now.hour = 9
+            mock_tz.now.return_value = mock_now
+            call_command("run_scheduled_tasks")
+
+        called_cmds = [c.args[0] for c in mock_cc.call_args_list]
+        assert "sync_all_sources" not in called_cmds

--- a/core/spec/management/run_scheduled_tasks_spec.py
+++ b/core/spec/management/run_scheduled_tasks_spec.py
@@ -31,12 +31,15 @@ def describe_run_scheduled_tasks_command():
             if cmd == "send_voting_reminders":
                 raise CommandError("boom")
 
-        with patch("core.management.commands.run_scheduled_tasks.call_command", side_effect=_fake_call):
+        with patch(
+            "core.management.commands.run_scheduled_tasks.call_command", side_effect=_fake_call
+        ) as mock_cc:
             stderr = StringIO()
-            # Must not raise — dispatcher absorbs the error
             call_command("run_scheduled_tasks", stderr=stderr)
 
         assert "send_voting_reminders" in stderr.getvalue()
+        called_cmds = [c.args[0] for c in mock_cc.call_args_list]
+        assert "send_lease_expiry_reminders" in called_cmds
 
     def it_logs_each_task_outcome(db):
         with patch("core.management.commands.run_scheduled_tasks.call_command"):
@@ -44,7 +47,8 @@ def describe_run_scheduled_tasks_command():
             call_command("run_scheduled_tasks", stdout=stdout)
 
         output = stdout.getvalue()
-        assert output  # something was written
+        assert "send_voting_reminders" in output
+        assert "send_lease_expiry_reminders" in output
 
     def it_runs_sync_all_sources_at_13_utc(db):
         with (

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "2.5.5"
+VERSION = "2.5.6"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "2.5.6",
+        "date": "2026-06-11",
+        "title": "Scheduled reminders, account page polish, onboarding fixes",
+        "changes": [
+            "Lease expiry and voting reminders now run automatically — no manual setup needed.",
+            "Your account page on the booking site now looks great in light mode.",
+            "Fixed the onboarding questions not showing which answer you selected.",
+        ],
+    },
     {
         "version": "2.5.5",
         "date": "2026-06-10",

--- a/render.yaml
+++ b/render.yaml
@@ -57,41 +57,17 @@ services:
       - key: PYTHON_VERSION
         value: "3.13.0"
 
-  # Daily morning sync of every calendar feed + the legacy CMS into the database.
-  # The Community Calendar and book/CMS pages read these rows straight from the DB,
-  # so this is the single scheduled refresh for the whole site (replaces the old
-  # page-load trigger). Toggles in Site Settings still gate the classes/legacy sources.
-  # Requires the same env vars as the web service (DATABASE_URL, DJANGO_SECRET_KEY,
-  # EMAIL_*, WEBPUSH_*, SENTRY_DSN) — set them on this cron in the Render dashboard.
+  # Single dispatcher for all scheduled background tasks.
+  # Runs every 15 minutes. Each task is responsible for its own idempotency.
+  # sync_all_sources is time-gated inside the command (runs at 13:xx UTC ≈ 6 AM Portland).
+  # Add new scheduled tasks in core/management/commands/run_scheduled_tasks.py only —
+  # no Render config changes needed.
   - type: cron
-    name: daily-sync
+    name: run-scheduled-tasks
     runtime: python
-    schedule: "0 13 * * *"  # 13:00 UTC ≈ 6 AM Portland
+    schedule: "*/15 * * * *"
     buildCommand: pip install -r requirements.txt
-    command: python manage.py sync_all_sources
-    envVars:
-      - key: PYTHON_VERSION
-        value: "3.13.0"
-
-  # Notify members 3 days before the monthly funding vote closes.
-  # Idempotent — safe to run daily. No action taken outside the window.
-  - type: cron
-    name: send-voting-reminders
-    runtime: python
-    schedule: "0 16 * * *"
-    buildCommand: pip install -r requirements.txt
-    command: python manage.py send_voting_reminders
-    envVars:
-      - key: PYTHON_VERSION
-        value: "3.13.0"
-
-  # Notify tenants whose lease ends in 30 days. Idempotent per lease.
-  - type: cron
-    name: send-lease-expiry-reminders
-    runtime: python
-    schedule: "0 16 * * *"
-    buildCommand: pip install -r requirements.txt
-    command: python manage.py send_lease_expiry_reminders
+    command: python manage.py run_scheduled_tasks
     envVars:
       - key: PYTHON_VERSION
         value: "3.13.0"

--- a/static/css/book-account.css
+++ b/static/css/book-account.css
@@ -103,6 +103,52 @@
 }
 .tb-burger svg { width:18px; height:18px; }
 
+/* ── .bk-page theme tokens ─────────────────────────────────────
+   Light defaults match the FOG slate palette; dark restores the
+   original navy values. Only the account-dashboard layout (.bk-page)
+   uses these — auth/onboarding (.bk-auth) keeps its dark-glass look. */
+.bk-page {
+  --bk-h1:          var(--hub-text);
+  --bk-sub:         var(--hub-text-muted);
+  --bk-section-sep: rgba(9,46,76,.12);
+  --bk-card-bg:     var(--hub-card-bg);
+  --bk-card-border: var(--hub-card-border);
+  --bk-card-hover:  var(--hub-surface);
+  --bk-empty-bg:    rgba(9,46,76,.04);
+  --bk-empty-border:rgba(9,46,76,.12);
+  --bk-form-bg:     var(--hub-card-bg);
+  --bk-form-border: var(--hub-card-border);
+  --bk-input-bg:    var(--hub-input-bg);
+  --bk-input-color: var(--hub-text);
+  --bk-rec-bg:      var(--hub-card-bg);
+  --bk-rec-border:  var(--hub-card-border);
+  --bk-rec-head-bg: var(--hub-surface);
+  --bk-rec-title:   var(--hub-text);
+  --bk-readonly-bg: var(--hub-card-bg);
+  --bk-readonly-border: var(--hub-card-border);
+}
+
+[data-theme="dark"] .bk-page {
+  --bk-h1:          var(--color-cream);
+  --bk-sub:         #96acbb;
+  --bk-section-sep: rgba(238,180,75,.10);
+  --bk-card-bg:     rgba(9,46,76,.32);
+  --bk-card-border: rgba(26,69,104,.32);
+  --bk-card-hover:  rgba(14,50,80,.5);
+  --bk-empty-bg:    rgba(9,46,76,.22);
+  --bk-empty-border:rgba(238,180,75,.2);
+  --bk-form-bg:     rgba(7,30,50,.6);
+  --bk-form-border: rgba(238,180,75,.12);
+  --bk-input-bg:    rgba(13,38,60,.55);
+  --bk-input-color: var(--color-cream);
+  --bk-rec-bg:      rgba(7,30,50,.55);
+  --bk-rec-border:  rgba(26,69,104,.22);
+  --bk-rec-head-bg: rgba(7,20,34,.4);
+  --bk-rec-title:   var(--color-cream);
+  --bk-readonly-bg: rgba(9,46,76,.5);
+  --bk-readonly-border: rgba(238,180,75,.18);
+}
+
 /* ── Page wrapper ──────────────────────────────────────────── */
 .bk-page { padding: 36px 36px 64px; }
 .bk-page.is-mobile { padding: 22px 16px 60px; }
@@ -121,14 +167,14 @@
   font-family: var(--heading);
   font-size: 38px; font-weight: 800;
   letter-spacing: -.01em;
-  color: var(--cream);
+  color: var(--bk-h1);
   margin: 4px 0 0;
   line-height: 1.05;
 }
 .bk-h1 em { color: var(--gold); font-style: normal; }
 .bk-sub {
   margin-top: 10px;
-  color: var(--steel);
+  color: var(--bk-sub);
   font-size: 14px; font-weight: 300;
   max-width: 560px;
   line-height:1.55;
@@ -221,7 +267,7 @@
   display:flex; align-items:baseline; gap:12px;
   margin: 26px 0 12px;
   padding-bottom: 6px;
-  border-bottom: 1px solid rgba(238,180,75,.10);
+  border-bottom: 1px solid var(--bk-section-sep);
 }
 .bk-section-h h2 {
   font-family: var(--heading);
@@ -245,15 +291,15 @@
   gap: 16px;
   align-items: stretch;
   padding: 14px 16px;
-  background: rgba(9,46,76,.32);
-  border: 1px solid rgba(26,69,104,.32);
+  background: var(--bk-card-bg);
+  border: 1px solid var(--bk-card-border);
   border-radius: var(--r);
   margin-bottom: 10px;
   transition: all .2s;
   position:relative;
 }
 .bk-card:hover {
-  background: rgba(14,50,80,.5);
+  background: var(--bk-card-hover);
   border-color: rgba(238,180,75,.3);
   box-shadow: 0 4px 24px rgba(0,0,0,.25), 0 0 40px rgba(238,180,75,.04);
 }
@@ -276,10 +322,10 @@
 .bk-card-body { display:flex; flex-direction:column; gap:3px; min-width:0; }
 .bk-card-title {
   font-family: var(--heading); font-weight:800; font-size: 17px;
-  color: var(--cream); line-height: 1.2;
+  color: var(--bk-h1); line-height: 1.2;
   text-wrap: balance;
 }
-.bk-card-inst { font-size: 12px; color: var(--steel); }
+.bk-card-inst { font-size: 12px; color: var(--bk-sub); }
 .bk-card-inst a { color: var(--gold); text-decoration: none; }
 .bk-card-when {
   font-size: 11px; color: var(--text3); margin-top: 2px;
@@ -322,8 +368,8 @@
 /* Empty state */
 .bk-empty {
   padding: 56px 28px;
-  background: rgba(9,46,76,.22);
-  border: 1px dashed rgba(238,180,75,.2);
+  background: var(--bk-empty-bg);
+  border: 1px dashed var(--bk-empty-border);
   border-radius: var(--r2);
   text-align: center;
 }
@@ -335,7 +381,7 @@
 }
 .bk-empty h3 {
   font-family: var(--heading); font-size: 22px; font-weight: 800;
-  color: var(--cream); margin: 0 0 8px;
+  color: var(--bk-h1); margin: 0 0 8px;
 }
 .bk-empty p {
   font-size: 13px; color: var(--steel);
@@ -353,8 +399,8 @@
 
 /* Receipts table */
 .bk-receipts {
-  background: rgba(7,30,50,.55);
-  border: 1px solid rgba(26,69,104,.32);
+  background: var(--bk-rec-bg);
+  border: 1px solid var(--bk-rec-border);
   border-radius: var(--r2);
   overflow: hidden;
 }
@@ -364,7 +410,7 @@
   gap: 16px;
   align-items: center;
   padding: 13px 20px;
-  border-top: 1px solid rgba(26,69,104,.22);
+  border-top: 1px solid var(--bk-rec-border);
   font-size: 13px;
 }
 .bk-rec-row.is-head {
@@ -372,11 +418,11 @@
   font-size: 10px; font-weight: 700;
   text-transform: uppercase; letter-spacing: .12em;
   color: var(--text3);
-  background: rgba(7,20,34,.4);
+  background: var(--bk-rec-head-bg);
   padding: 12px 20px;
 }
 .bk-rec-date { color: var(--steel); font-variant-numeric: tabular-nums; }
-.bk-rec-title { color: var(--cream); font-weight: 600; }
+.bk-rec-title { color: var(--bk-rec-title); font-weight: 600; }
 .bk-rec-title .sub { color: var(--steel-dim); font-weight:400; font-size:11px; display:block; }
 .bk-rec-method {
   font-size: 11px; color: var(--steel);
@@ -420,8 +466,8 @@
 .bk-form {
   display:grid; grid-template-columns: 1fr 1fr; gap: 18px 22px;
   padding: 26px;
-  background: rgba(7,30,50,.6);
-  border: 1px solid rgba(238,180,75,.12);
+  background: var(--bk-form-bg);
+  border: 1px solid var(--bk-form-border);
   border-radius: var(--r2);
 }
 .bk-page.is-mobile .bk-form { grid-template-columns: 1fr; padding: 18px; }
@@ -433,16 +479,16 @@
 }
 .bk-field input, .bk-field select {
   padding: 11px 14px; border-radius: 6px;
-  background: rgba(13,38,60,.55);
+  background: var(--bk-input-bg);
   border: 1px solid var(--border);
-  color: var(--cream);
+  color: var(--bk-input-color);
   font-family: var(--font); font-size: 14px;
 }
 .bk-field input:focus, .bk-field select:focus {
-  outline:none; border-color: var(--gold); background: rgba(13,38,60,.8);
+  outline:none; border-color: var(--gold); background: var(--bk-input-bg);
 }
 .bk-field.is-locked input {
-  background: rgba(13,38,60,.25);
+  background: var(--bk-input-bg);
   color: var(--steel-dim);
   cursor: not-allowed;
 }
@@ -528,8 +574,8 @@
 .bk-readonly-banner {
   display:flex; gap:14px; align-items:center;
   padding: 14px 18px;
-  background: rgba(9,46,76,.5);
-  border: 1px solid rgba(238,180,75,.18);
+  background: var(--bk-readonly-bg);
+  border: 1px solid var(--bk-readonly-border);
   border-radius: var(--r);
   margin-bottom: 18px;
   font-size: 13px;

--- a/static/css/book-account.css
+++ b/static/css/book-account.css
@@ -126,6 +126,12 @@
   --bk-rec-title:   var(--hub-text);
   --bk-readonly-bg: var(--hub-card-bg);
   --bk-readonly-border: var(--hub-card-border);
+  --bk-emails-bg:      var(--hub-surface);
+  --bk-emails-row-sep: var(--hub-card-border);
+  --bk-email-addr:     var(--hub-text);
+  --bk-email-add-bg:   var(--hub-card-bg);
+  --bk-email-input-bg: var(--hub-input-bg);
+  --bk-email-input-clr: var(--hub-text);
 }
 
 [data-theme="dark"] .bk-page {
@@ -147,6 +153,12 @@
   --bk-rec-title:   var(--color-cream);
   --bk-readonly-bg: rgba(9,46,76,.5);
   --bk-readonly-border: rgba(238,180,75,.18);
+  --bk-emails-bg:      rgba(13,38,60,.4);
+  --bk-emails-row-sep: rgba(26,69,104,.3);
+  --bk-email-addr:     var(--color-cream);
+  --bk-email-add-bg:   rgba(7,20,34,.4);
+  --bk-email-input-bg: rgba(13,38,60,.55);
+  --bk-email-input-clr: var(--color-cream);
 }
 
 /* ── Page wrapper ──────────────────────────────────────────── */
@@ -496,7 +508,7 @@
 
 /* Email list inside profile */
 .bk-emails {
-  background: rgba(13,38,60,.4);
+  background: var(--bk-emails-bg);
   border: 1px solid var(--border);
   border-radius: var(--r);
   overflow: hidden;
@@ -504,11 +516,11 @@
 .bk-email-row {
   display: flex; align-items: center; gap: 12px;
   padding: 12px 16px;
-  border-top: 1px solid rgba(26,69,104,.3);
+  border-top: 1px solid var(--bk-emails-row-sep);
   font-size: 13px;
 }
 .bk-email-row:first-child { border-top: none; }
-.bk-email-addr { flex:1; color: var(--cream); min-width:0; overflow:hidden; text-overflow:ellipsis; }
+.bk-email-addr { flex:1; color: var(--bk-email-addr); min-width:0; overflow:hidden; text-overflow:ellipsis; }
 .bk-email-tag {
   font-size: 9px; font-weight: 800;
   text-transform: uppercase; letter-spacing: .12em;
@@ -525,15 +537,15 @@
 .bk-email-row a.danger:hover { color: var(--red); }
 .bk-email-add {
   display:flex; gap: 8px; padding: 14px 16px;
-  border-top: 1px solid rgba(26,69,104,.3);
-  background: rgba(7,20,34,.4);
+  border-top: 1px solid var(--bk-emails-row-sep);
+  background: var(--bk-email-add-bg);
 }
 .bk-email-add input {
   flex:1;
   padding: 9px 12px; border-radius: 4px;
-  background: rgba(13,38,60,.55);
+  background: var(--bk-email-input-bg);
   border: 1px solid var(--border);
-  color: var(--cream); font-size: 13px;
+  color: var(--bk-email-input-clr); font-size: 13px;
 }
 .bk-email-add button {
   padding: 9px 14px; border-radius:4px;
@@ -581,7 +593,7 @@
   font-size: 13px;
 }
 .bk-readonly-banner svg { color: var(--gold); flex-shrink: 0; }
-.bk-readonly-banner b { color: var(--cream); font-weight: 700; }
+.bk-readonly-banner b { color: var(--bk-h1); font-weight: 700; }
 .bk-readonly-banner a {
   color: var(--gold); text-decoration: none; font-weight: 600;
   margin-left: auto; white-space: nowrap;

--- a/templates/classes/account/onboarding/step1.html
+++ b/templates/classes/account/onboarding/step1.html
@@ -33,6 +33,19 @@
         <div class="spacer"></div>
         <button type="submit" class="bk-btn-primary">Continue →</button>
       </div>
+      <script>
+        document.querySelectorAll('.bk-radio').forEach(function(label) {
+          var input = label.querySelector('input[type="radio"]');
+          if (!input) return;
+          if (input.checked) label.classList.add('is-on');
+          input.addEventListener('change', function() {
+            document.querySelectorAll('.bk-radio').forEach(function(l) {
+              l.classList.remove('is-on');
+            });
+            label.classList.add('is-on');
+          });
+        });
+      </script>
     </form>
   </div>
 </div></div></div>

--- a/templates/classes/account/onboarding/step3.html
+++ b/templates/classes/account/onboarding/step3.html
@@ -34,6 +34,16 @@
         <div class="spacer"></div>
         <button type="submit" class="bk-btn-primary">Take me to classes</button>
       </div>
+      <script>
+        document.querySelectorAll('.bk-chip').forEach(function(label) {
+          var input = label.querySelector('input[type="checkbox"]');
+          if (!input) return;
+          if (input.checked) label.classList.add('is-on');
+          input.addEventListener('change', function() {
+            label.classList.toggle('is-on', input.checked);
+          });
+        });
+      </script>
     </form>
   </div>
 </div></div></div>


### PR DESCRIPTION
## Summary

- **Cron dispatcher:** Replaces the three separate Render cron services (`daily-sync`, `send-voting-reminders`, `send-lease-expiry-reminders`) with a single `run_scheduled_tasks` management command running every 15 minutes. Each task runs in its own try/except so one failure can't block the rest. `sync_all_sources` is time-gated to 13:xx UTC (≈ 6 AM Portland). New notification types are added in code only — no Render config changes ever.
- **Book account light mode:** `book-account.css` now defines CSS custom properties at the `.bk-page` scope (light defaults sourcing `--hub-*` tokens, dark overrides restoring the original navy values). Fixes unreadable cream text and dark-navy card backgrounds on the `/account/` dashboard when using light mode. Auth/onboarding glass surfaces are intentionally unchanged.
- **Onboarding visual feedback:** Step 1 (radio) and step 3 (chips) now show visual selection state via inline JS toggling `.is-on` on labels. Clicking a question now highlights it gold; clicking again on a chip deselects it.

## Test plan

- [ ] `pytest core/spec/management/run_scheduled_tasks_spec.py -v` — 5 passing
- [ ] `pytest --tb=short -q` — no new failures
- [ ] Visit `/account/` on book.* in light mode — white card backgrounds, dark text, gold accents
- [ ] Visit `/account/` on book.* in dark mode — navy cards, cream text, identical to before
- [ ] Visit `/account/onboarding/step/1/` — clicking a radio highlights it gold, previously selected clears
- [ ] Visit `/account/onboarding/step/3/` — clicking chips toggles them gold, multi-select works