### PR TITLE
Release 2.5.7

### DIFF
--- a/classes/models.py
+++ b/classes/models.py
@@ -82,7 +82,7 @@ class Category(HeroCropMixin, models.Model):
         """
         from membership.logos import logo_prefix_for
 
-        if self.guild_id is not None:
+        if self.guild is not None:
             guild_prefix = self.guild.logo_prefix
             if guild_prefix:
                 return guild_prefix

--- a/classes/models.py
+++ b/classes/models.py
@@ -72,6 +72,21 @@ class Category(HeroCropMixin, models.Model):
         related_name="categories",
         help_text="Optional link to the makerspace Guild that owns this category. Used for Mailchimp tagging.",
     )
+    @property
+    def logo_prefix(self) -> str | None:
+        """SVG logo prefix for this category's color logo in static/img/guild_logos/.
+
+        Resolves from the linked guild's name when that maps to a logo, otherwise
+        from the category's own name. Returns None when neither matches a logo file.
+        """
+        from membership.logos import logo_prefix_for
+
+        if self.guild_id is not None:
+            guild_prefix = self.guild.logo_prefix
+            if guild_prefix:
+                return guild_prefix
+        return logo_prefix_for(self.name)
+
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/classes/models.py
+++ b/classes/models.py
@@ -72,6 +72,7 @@ class Category(HeroCropMixin, models.Model):
         related_name="categories",
         help_text="Optional link to the makerspace Guild that owns this category. Used for Mailchimp tagging.",
     )
+
     @property
     def logo_prefix(self) -> str | None:
         """SVG logo prefix for this category's color logo in static/img/guild_logos/.

--- a/classes/spec/models/category_spec.py
+++ b/classes/spec/models/category_spec.py
@@ -24,3 +24,26 @@ def describe_Category():
         CategoryFactory(name="Pottery")
         with pytest.raises(Exception):
             CategoryFactory(name="Pottery")
+
+    def describe_logo_prefix():
+        def it_resolves_from_the_category_name(db):
+            category = CategoryFactory(name="Woodworking")
+            assert category.logo_prefix == "woodworking"
+
+        def it_prefers_the_linked_guild_name_over_its_own(db):
+            from tests.membership.factories import GuildFactory
+
+            guild = GuildFactory(name="Ceramics")
+            category = CategoryFactory(name="Pottery & Clay", guild=guild)
+            assert category.logo_prefix == "ceramics"
+
+        def it_falls_back_to_its_own_name_when_guild_has_no_logo(db):
+            from tests.membership.factories import GuildFactory
+
+            guild = GuildFactory(name="Some Unmapped Guild")
+            category = CategoryFactory(name="Glass", guild=guild)
+            assert category.logo_prefix == "glass"
+
+        def it_returns_none_when_nothing_matches(db):
+            category = CategoryFactory(name="Creative Business")
+            assert category.logo_prefix is None

--- a/classes/spec/views/public_spec.py
+++ b/classes/spec/views/public_spec.py
@@ -543,6 +543,7 @@ def describe_public_topbar_member_chrome():
         response = client.get(reverse("classes:public_list"))
         assert b"cp-topbar__account-item--ext" not in response.content
 
+
 def describe_card_image_fallback():
     def it_shows_the_category_color_logo_when_class_has_no_image(client, db):
         from classes.factories import ClassOfferingFactory
@@ -572,6 +573,7 @@ def describe_card_image_fallback():
         assert resp.status_code == 200
         assert "cls-img-ph--logo" in resp.content.decode()
         assert "img/favicon.png" in resp.content.decode()
+
 
 def describe_detail_hero_fallback():
     def it_shows_the_category_color_logo_when_no_images(client, db):

--- a/classes/spec/views/public_spec.py
+++ b/classes/spec/views/public_spec.py
@@ -548,7 +548,7 @@ def describe_card_image_fallback():
         from classes.factories import ClassOfferingFactory
         from classes.models import ClassOffering
 
-        offering = ClassOfferingFactory(
+        ClassOfferingFactory(
             status=ClassOffering.Status.PUBLISHED,
             scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE,
             image="",

--- a/classes/spec/views/public_spec.py
+++ b/classes/spec/views/public_spec.py
@@ -542,3 +542,61 @@ def describe_public_topbar_member_chrome():
         client.force_login(member_persona_user)
         response = client.get(reverse("classes:public_list"))
         assert b"cp-topbar__account-item--ext" not in response.content
+
+def describe_card_image_fallback():
+    def it_shows_the_category_color_logo_when_class_has_no_image(client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        offering = ClassOfferingFactory(
+            status=ClassOffering.Status.PUBLISHED,
+            scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE,
+            image="",
+            category__name="Woodworking",
+        )
+        resp = client.get(reverse("classes:public_list"))
+        assert resp.status_code == 200
+        assert "img/guild_logos/woodworking_color.svg" in resp.content.decode()
+
+    def it_shows_the_past_lives_mark_when_category_has_no_logo(client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        ClassOfferingFactory(
+            status=ClassOffering.Status.PUBLISHED,
+            scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE,
+            image="",
+            category__name="Creative Business",
+        )
+        resp = client.get(reverse("classes:public_list"))
+        assert resp.status_code == 200
+        assert "cls-img-ph--logo" in resp.content.decode()
+        assert "img/favicon.png" in resp.content.decode()
+
+def describe_detail_hero_fallback():
+    def it_shows_the_category_color_logo_when_no_images(client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        offering = ClassOfferingFactory(
+            status=ClassOffering.Status.PUBLISHED,
+            image="",
+            category__name="Glass",
+        )
+        resp = client.get(reverse("classes:public_class_detail", kwargs={"slug": offering.slug}))
+        assert resp.status_code == 200
+        assert "img/guild_logos/glass_color.svg" in resp.content.decode()
+
+    def it_shows_the_past_lives_mark_when_category_has_no_logo(client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        offering = ClassOfferingFactory(
+            status=ClassOffering.Status.PUBLISHED,
+            image="",
+            category__name="Education",
+        )
+        resp = client.get(reverse("classes:public_class_detail", kwargs={"slug": offering.slug}))
+        assert resp.status_code == 200
+        assert "cp-detail__hero-logo" in resp.content.decode()
+        assert "img/favicon.png" in resp.content.decode()

--- a/membership/logos.py
+++ b/membership/logos.py
@@ -1,0 +1,40 @@
+"""Maps a guild/category name to its SVG logo file prefix in static/img/guild_logos/.
+
+Logos ship as ``<prefix>_color.svg`` and ``<prefix>_bw.svg``. Both guilds and
+class categories resolve a prefix from their name through this single map so
+the same artwork represents the same craft everywhere in the app.
+"""
+
+from __future__ import annotations
+
+# Case-insensitive name substring → logo file prefix.
+_NAME_TO_PREFIX: dict[str, str] = {
+    "art framing": "art_framing",
+    "ceramics": "ceramics",
+    "events": "events",
+    "food independence": "food_independence",
+    "garden": "garden",
+    "glass": "glass",
+    "jewelry": "jewelers",
+    "jeweler": "jewelers",
+    "leather": "leatherwork",
+    "metal": "metalworking",
+    "prison": "prison_outreach",
+    "tech": "tech",
+    "textile": "textiles",
+    "visual": "visual_arts",
+    "wood": "woodworking",
+    "writer": "writers",
+    "writing": "writers",
+}
+
+
+def logo_prefix_for(name: str | None) -> str | None:
+    """Return the guild_logos file prefix matching ``name``, or None if none match."""
+    if not name:
+        return None
+    lowered = name.lower()
+    for key, prefix in _NAME_TO_PREFIX.items():
+        if key in lowered:
+            return prefix
+    return None

--- a/membership/models.py
+++ b/membership/models.py
@@ -599,29 +599,9 @@ class Guild(HeroCropMixin, models.Model):
     @property
     def logo_prefix(self) -> str | None:
         """Map the guild name to its SVG logo prefix in static/img/guild_logos/."""
-        name = self.name.lower()
-        mapping = {
-            "art framing": "art_framing",
-            "ceramics": "ceramics",
-            "events": "events",
-            "food independence": "food_independence",
-            "garden": "garden",
-            "glass": "glass",
-            "jewelry": "jewelers",
-            "jeweler": "jewelers",
-            "leather": "leatherwork",
-            "metal": "metalworking",
-            "prison": "prison_outreach",
-            "tech": "tech",
-            "textile": "textiles",
-            "visual": "visual_arts",
-            "wood": "woodworking",
-            "writer": "writers",
-        }
-        for key, prefix in mapping.items():
-            if key in name:
-                return prefix
-        return None
+        from membership.logos import logo_prefix_for
+
+        return logo_prefix_for(self.name)
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         delete_orphan_on_replace(self, "banner_image")

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "2.5.6"
+VERSION = "2.5.7"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "2.5.7",
+        "date": "2026-06-15",
+        "title": "Guild logos on class pages and FOG hub topbar",
+        "changes": [
+            "Class pages that don't have a hero image now show the guild logo for that category instead of a blank header.",
+            "The category chip on a class page now shows the guild logo alongside the category name.",
+            "The member hub topbar now reads 'Past Lives FOG' and shows the version number in brackets instead of 'BETA'.",
+        ],
+    },
     {
         "version": "2.5.6",
         "date": "2026-06-11",

--- a/static/css/cms-public.css
+++ b/static/css/cms-public.css
@@ -567,6 +567,19 @@ body.classes-portal {
   object-fit: cover;
   display: block;
 }
+.cp-detail__hero-logo {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cp-detail__hero-logo img {
+  width: clamp(120px, 22vw, 200px);
+  height: clamp(120px, 22vw, 200px);
+  object-fit: contain;
+  opacity: .9;
+}
 .cp-detail__hero-overlay {
   position: absolute;
   inset: 0;
@@ -1014,7 +1027,14 @@ a.cp-detail__cta--waitlist:hover {
   opacity: .8;
   stroke-width: 1.5;
 }
-.cp-detail__cat-chip svg {
+.cp-page .cls-img-ph--logo { display: flex; align-items: center; justify-content: center; }
+.cp-page .cls-img-ph--logo img {
+  width: 56%; height: 56%;
+  object-fit: contain;
+  opacity: .9;
+}
+.cp-detail__cat-chip svg,
+.cp-detail__cat-chip img {
   width: 13px; height: 13px;
   vertical-align: -2px;
   margin-right: 5px;

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -438,23 +438,19 @@ a:hover { color: var(--hub-link-hover); }
     background-color: var(--hub-topbar-border);
 }
 
-.pl-badge--beta {
-    font-size: 0.625rem;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    padding: 0.125rem 0.5rem;
-    border-radius: 10px;
-    background-color: rgba(238, 180, 75, 0.15);
-    color: var(--color-tuscan-yellow);
+.pl-badge--version {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    color: var(--hub-text-muted);
     border: none;
     cursor: pointer;
     font-family: var(--font-body);
-    transition: background-color 0.15s ease;
+    transition: color 0.15s ease;
 }
 
-.pl-badge--beta:hover {
-    background-color: rgba(238, 180, 75, 0.3);
+.pl-badge--version:hover {
+    color: var(--hub-text);
 }
 
 /* View switcher — distinct button to switch between admin/hub */

--- a/templates/classes/public/_list_results.html
+++ b/templates/classes/public/_list_results.html
@@ -23,16 +23,20 @@ list.html for the initial full-page response.{% endcomment %}
           <img class="cls-img" src="{% url 'classes:legacy_image' %}?url={{ offering.legacy_image_url|urlencode }}" alt="" loading="lazy">
         {% elif offering.category.hero_image %}
           <img class="cls-img" src="{{ offering.category.hero_image.url }}" alt="" loading="lazy">
-        {% elif offering.category.icon_svg %}
-          <div class="cls-img-ph cls-img-ph--icon">{{ offering.category.icon_svg|safe }}</div>
+        {% elif offering.category.logo_prefix %}
+          <div class="cls-img-ph cls-img-ph--logo">
+            <img src="{% static 'img/guild_logos/'|add:offering.category.logo_prefix|add:'_color.svg' %}" alt="{{ offering.category.name }}" loading="lazy">
+          </div>
         {% else %}
-          <div class="cls-img-ph">{{ offering.category.name|initials }}</div>
+          <div class="cls-img-ph cls-img-ph--logo">
+            <img src="{% static 'img/favicon.png' %}" alt="Past Lives Makerspace" loading="lazy">
+          </div>
         {% endif %}
       </a>
       <div class="cls-body">
         <a class="cls-title" href="{% url 'classes:public_class_detail' slug=offering.slug %}">
-          {% if offering.category.guild and offering.category.guild.logo_prefix %}
-            <img src="{% static 'img/guild_logos/'|add:offering.category.guild.logo_prefix|add:'_color.svg' %}" width="16" height="16" alt="{{ offering.category.guild.name }}" style="vertical-align: middle; margin-right: 0.25rem;">
+          {% if offering.category.logo_prefix %}
+            <img src="{% static 'img/guild_logos/'|add:offering.category.logo_prefix|add:'_color.svg' %}" width="16" height="16" alt="{{ offering.category.name }}" style="vertical-align: middle; margin-right: 0.25rem;">
           {% endif %}
           {{ offering.title|strip_date_suffix }}
           {% if offering.scheduling_model == 'flexible' %}<span class="badge fx">Flex</span>{% endif %}

--- a/templates/classes/public/detail.html
+++ b/templates/classes/public/detail.html
@@ -61,6 +61,14 @@
            {% else %}
            style="object-position: {{ offering.category.hero_object_position }};"
            {% endif %}>
+    {% elif offering.category.logo_prefix %}
+      <div class="cp-detail__hero-logo">
+        <img src="{% static 'img/guild_logos/'|add:offering.category.logo_prefix|add:'_color.svg' %}" alt="{{ offering.category.name }}">
+      </div>
+    {% else %}
+      <div class="cp-detail__hero-logo">
+        <img src="{% static 'img/favicon.png' %}" alt="Past Lives Makerspace">
+      </div>
     {% endif %}
     <div class="cp-detail__hero-overlay"></div>
 
@@ -120,7 +128,7 @@
   {% endwith %}
       <div class="cp-detail__cat-row">
         <a class="cp-detail__cat-chip" href="{% url 'classes:public_category' slug=offering.category.slug %}">
-          {% if offering.category.icon_svg %}{{ offering.category.icon_svg|safe }}{% endif %}{{ offering.category.name }}
+          {% if offering.category.logo_prefix %}<img src="{% static 'img/guild_logos/'|add:offering.category.logo_prefix|add:'_color.svg' %}" alt="">{% endif %}{{ offering.category.name }}
         </a>
         {% if offering.first_upcoming_session_at %}
           <span class="cp-detail__next-pill">Next session {{ offering.first_upcoming_session_at|date:"D, M j" }}</span>
@@ -129,8 +137,8 @@
         {% endif %}
       </div>
       <h1 class="cp-detail__title">
-        {% if offering.category.guild and offering.category.guild.logo_prefix %}
-          <img src="{% static 'img/guild_logos/'|add:offering.category.guild.logo_prefix|add:'_color.svg' %}" width="32" height="32" alt="{{ offering.category.guild.name }}" style="vertical-align: middle; margin-right: 0.5rem;">
+        {% if offering.category.logo_prefix %}
+          <img src="{% static 'img/guild_logos/'|add:offering.category.logo_prefix|add:'_color.svg' %}" width="32" height="32" alt="{{ offering.category.name }}" style="vertical-align: middle; margin-right: 0.5rem;">
         {% endif %}
         {{ offering.title|strip_date_suffix }}
       </h1>

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -51,8 +51,8 @@
         <a href="{% url 'hub_community_calendar' %}" class="pl-brand">
             <img src="{% static 'img/favicon.png' %}" alt="Past Lives" class="pl-brand__icon" width="24" height="24">
             <span class="pl-brand__info">
-                <span class="pl-brand__text">Past Lives</span>
-                <button type="button" class="pl-brand__label pl-badge--beta" style="border:0;cursor:pointer;padding:0;background:none;" onclick="event.preventDefault();event.stopPropagation();document.getElementById('changelog-modal').style.display='flex'">BETA v{{ app_version }}</button>
+                <span class="pl-brand__text">Past Lives FOG</span>
+                <button type="button" class="pl-brand__label pl-badge--version" style="border:0;cursor:pointer;padding:0;background:none;" onclick="event.preventDefault();event.stopPropagation();document.getElementById('changelog-modal').style.display='flex'">[v{{ app_version }}]</button>
             </span>
         </a>
 

--- a/tests/membership/logos_spec.py
+++ b/tests/membership/logos_spec.py
@@ -1,0 +1,33 @@
+"""BDD specs for the guild/category logo-prefix helper."""
+
+from __future__ import annotations
+
+from membership.logos import logo_prefix_for
+
+
+def describe_logo_prefix_for():
+    def it_matches_a_guild_name_substring():
+        assert logo_prefix_for("Woodworking") == "woodworking"
+
+    def it_is_case_insensitive():
+        assert logo_prefix_for("CERAMICS") == "ceramics"
+
+    def it_maps_jewelry_category_to_jewelers_logo():
+        assert logo_prefix_for("Jewelry") == "jewelers"
+
+    def it_maps_writing_category_to_writers_logo():
+        assert logo_prefix_for("Writing") == "writers"
+
+    def it_returns_none_when_unmatched():
+        assert logo_prefix_for("Quantum Computing") is None
+
+    def it_returns_none_when_empty():
+        assert logo_prefix_for(None) is None
+        assert logo_prefix_for("") is None
+
+    def it_returns_none_for_unknown_names():
+        assert logo_prefix_for("Creative Business") is None
+
+    def it_returns_none_for_blank():
+        assert logo_prefix_for("") is None
+        assert logo_prefix_for(None) is None


### PR DESCRIPTION
## Summary

- Class detail pages without a hero image now show the guild/category logo (or the PL favicon as a final fallback) instead of a blank header
- Category chip on class detail pages uses the guild logo SVG instead of the old `icon_svg` field
- Title logo on class detail pages now resolves from `category.logo_prefix` directly, no longer requires a linked guild
- Extracted name→logo-prefix lookup into a shared `membership/logos.py` so guilds and categories use the same mapping (adds `writing` alias); `Guild.logo_prefix` and the new `Category.logo_prefix` both delegate there
- Hub topbar brand text changed from "Past Lives" → "Past Lives FOG"; version badge changed from `BETA v…` → `[v…]`

## Test plan
- [ ] Class with no hero image shows category/guild logo in hero area
- [ ] Category chip shows logo SVG on class detail page
- [ ] Hub topbar shows "Past Lives FOG [v2.5.7]"
- [ ] All existing guild logo lookups still resolve correctly
- [ ] pytest passes