### PR TITLE
Fix Discord release post: chunk under 4096 + fail loudly (v0.19.12)

### DIFF
--- a/.github/scripts/discord_release_notify.py
+++ b/.github/scripts/discord_release_notify.py
@@ -1,0 +1,101 @@
+"""Post the current release's changelog to Discord — chunked under the embed limit.
+
+Aggregates every CHANGELOG entry in the current release line (MAJOR.MINOR) into one
+announcement, newest first, and posts it to the ``DISCORD_WEBHOOK_URL`` webhook. The
+release line can accumulate several patch entries (e.g. 0.19.1 … 0.19.11), so the
+combined notes routinely exceed Discord's 4096-char embed-description limit — this
+splits them across as many embeds/messages as needed and FAILS LOUDLY on a rejected
+post (the old inline ``curl`` had no ``--fail``, so a 400 looked like success and the
+0.19 release silently never posted).
+
+Run from the repo root (so ``plfog.version`` imports). Reads the webhook from the
+``DISCORD_WEBHOOK_URL`` env var; a blank webhook is a no-op (the "disabled when blank"
+idiom), logged so it is never silent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, ".")
+from plfog.version import CHANGELOG, VERSION  # noqa: E402
+
+_EMBED_COLOR = 3066993  # the workflow's original green
+_DESC_LIMIT = 4000  # Discord's hard cap is 4096; leave headroom
+
+
+def _release_entries() -> list[dict[str, object]]:
+    """Every CHANGELOG entry sharing the current MAJOR.MINOR line, newest first."""
+    minor = ".".join(VERSION.split(".")[:2])
+    entries = [e for e in CHANGELOG if ".".join(str(e["version"]).split(".")[:2]) == minor]
+    return entries or [CHANGELOG[0]]
+
+
+def _bullets(entries: list[dict[str, object]]) -> list[str]:
+    """Flatten every entry's changes into ``• line`` bullets."""
+    return [f"• {change}" for entry in entries for change in entry["changes"]]
+
+
+def _chunks(bullets: list[str]) -> list[str]:
+    """Greedily pack bullets into description blocks no longer than ``_DESC_LIMIT``."""
+    chunks: list[str] = []
+    current = ""
+    for bullet in bullets:
+        candidate = f"{current}\n{bullet}" if current else bullet
+        if len(candidate) > _DESC_LIMIT and current:
+            chunks.append(current)
+            current = bullet
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _post(webhook: str, payload: dict[str, object]) -> None:
+    """POST one message to the webhook, raising loudly on any non-2xx response."""
+    request = urllib.request.Request(
+        webhook,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request) as response:  # noqa: S310 - trusted webhook URL
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:500]
+        sys.exit(f"Discord rejected the post: HTTP {exc.code} {body}")
+    except urllib.error.URLError as exc:
+        sys.exit(f"Discord post failed (network error): {exc}")
+    if not 200 <= status < 300:
+        sys.exit(f"Discord post failed: HTTP {status}")
+
+
+def main() -> None:
+    webhook = (os.environ.get("DISCORD_WEBHOOK_URL") or "").strip()
+    if not webhook:
+        print("DISCORD_WEBHOOK_URL is blank — skipping Discord release post.")
+        return
+
+    entries = _release_entries()
+    title = str(entries[0]["title"])
+    chunks = _chunks(_bullets(entries))
+    footer = {"text": f"Past Lives FOG v{VERSION}"}
+
+    for index, description in enumerate(chunks):
+        embed: dict[str, object] = {"description": description, "color": _EMBED_COLOR, "footer": footer}
+        if index == 0:
+            embed["title"] = f"🚀 New update: {title}"
+        elif len(chunks) > 1:
+            embed["title"] = f"…continued ({index + 1}/{len(chunks)})"
+        _post(webhook, {"embeds": [embed]})
+
+    print(f"Posted v{VERSION} release notes to Discord in {len(chunks)} message(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -3,6 +3,7 @@ name: Discord Notifications
 on:
   push:
     branches: [main]
+  workflow_dispatch: # allow manual re-posting (e.g. if a release post failed) without a redeploy
 
 jobs:
   notify:
@@ -19,39 +20,6 @@ jobs:
       - name: Post release announcement to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-        run: |
-          # Aggregate every changelog entry in the current release line (MAJOR.MINOR)
-          # into one announcement, so a release branch (e.g. 0.19.x) that accumulated
-          # several patch entries posts all of its changes at once. Newest patch first.
-          RELEASE_INFO=$(python3 -c "
-          import sys
-          sys.path.insert(0, '.')
-          from plfog.version import VERSION, CHANGELOG
-
-          minor = '.'.join(VERSION.split('.')[:2])
-          entries = [e for e in CHANGELOG if '.'.join(str(e['version']).split('.')[:2]) == minor]
-          if not entries:
-              entries = [CHANGELOG[0]]
-          bullets = '\n'.join(f'• {c}' for e in entries for c in e['changes'])
-          title = entries[0]['title']
-          print(f'VERSION={VERSION}')
-          print(f'TITLE={title}')
-          print(f'BULLETS={bullets}')
-          ")
-
-          VERSION=$(echo "$RELEASE_INFO" | grep '^VERSION=' | cut -d= -f2-)
-          TITLE=$(echo "$RELEASE_INFO" | grep '^TITLE=' | cut -d= -f2-)
-          BULLETS=$(echo "$RELEASE_INFO" | sed -n '/^BULLETS=/,$ p' | cut -d= -f2-)
-
-          curl -H "Content-Type: application/json" \
-            -d "$(jq -n \
-              --arg title "New update: $TITLE" \
-              --arg changes "$BULLETS" \
-              --arg version "v$VERSION" \
-              '{embeds: [{
-                title: ("🚀 " + $title),
-                color: 3066993,
-                description: $changes,
-                footer: {text: ("Past Lives FOG " + $version)}
-              }]}')" \
-            "$DISCORD_WEBHOOK_URL"
+        # Aggregates every changelog entry in the current release line and posts it,
+        # chunked under Discord's 4096-char embed limit, failing loudly on rejection.
+        run: python .github/scripts/discord_release_notify.py

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.19.11"
+VERSION = "0.19.12"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.19.11",
+        "version": "0.19.12",
         "date": "2026-06-27",
         "title": "Your notifications and emails, all in one place",
         "changes": [


### PR DESCRIPTION
[ci] Fix Discord release post: chunk under 4096 + fail loudly (v0.19.12)

The 0.19 release never posted to Discord even though the workflow ran green.
Root cause: the aggregated release-line changelog is ~5170 chars, over Discord's
4096-char embed-description limit, so the webhook rejected the embed with a 400 —
but the inline `curl` had no `--fail`, so the step exited 0 and the failure was
invisible.

- Replace the inline curl/jq with `.github/scripts/discord_release_notify.py`,
  which aggregates the current release line, splits the notes across as many
  embeds/messages as needed (each <= 4096), and exits non-zero on any rejected
  post so a future failure is loud, not silent.
- Add `workflow_dispatch` so a missed release post can be re-triggered manually
  (gh workflow run discord-notify.yml) without forcing a redeploy.
- Bump VERSION 0.19.11 -> 0.19.12; re-stamp the top changelog entry.

The release webhook itself (the DISCORD_WEBHOOK_URL repo secret) was never the
problem and is unchanged.