### PR TITLE
Discord post: send a User-Agent so Cloudflare doesn't 403 (v0.19.13)

### DIFF
--- a/.github/scripts/discord_release_notify.py
+++ b/.github/scripts/discord_release_notify.py
@@ -61,7 +61,12 @@ def _post(webhook: str, payload: dict[str, object]) -> None:
     request = urllib.request.Request(
         webhook,
         data=json.dumps(payload).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            # Discord/Cloudflare rejects the default "Python-urllib/x" UA with a 403
+            # (error 1010). A descriptive User-Agent is required — see Discord's API docs.
+            "User-Agent": "PastLivesReleaseBot (https://github.com/Past-Lives-Makerspace/plfog, 1.0)",
+        },
     )
     try:
         with urllib.request.urlopen(request) as response:  # noqa: S310 - trusted webhook URL

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.19.12"
+VERSION = "0.19.13"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.19.12",
+        "version": "0.19.13",
         "date": "2026-06-27",
         "title": "Your notifications and emails, all in one place",
         "changes": [


### PR DESCRIPTION
Follow-up to #112. The chunking fix reached Discord but Cloudflare blocked the default `Python-urllib` User-Agent (HTTP 403 / error 1010), so 0.19 still didn't post. Adds a descriptive `User-Agent` header.

**Verified locally:** with the UA, a POST to a known-bad webhook returns `404 / 10015 Unknown Webhook` instead of `403 / 1010` — the request now reaches Discord's API. The release webhook secret itself is valid. Merging this re-runs the workflow and should finally post the 0.19 notes.