### PR TITLE
Optional intro note on funding-results email + headless send command (v0.19.14)

### DIFF
--- a/core/events/copy.py
+++ b/core/events/copy.py
@@ -521,6 +521,9 @@ _CURATED: dict[str, EventCopy] = {
     "voting.results_published": EventCopy(
         placeholders=(
             "member_name",
+            # Optional organizer note shown at the top of the email (blank for a normal
+            # automated send; used for a one-off, e.g. a late "sorry this is overdue").
+            "intro_note",
             "cycle_label",
             "allocation_summary",
             "vote_1st",
@@ -530,6 +533,7 @@ _CURATED: dict[str, EventCopy] = {
         ),
         sample_context={
             "member_name": "Robin Vale",
+            "intro_note": "Heads-up: this one's a little late — going forward results are automated.",
             "cycle_label": "June 2026",
             "allocation_summary": "Metal Guild — $600.00 (45.0%)\nFiber Guild — $400.00 (30.0%)",
             "vote_1st": "Metal Guild",
@@ -546,6 +550,7 @@ _CURATED: dict[str, EventCopy] = {
                 subject="{{ cycle_label }} guild funding results",
                 body_text=(
                     "Hi {{ member_name }},\n\n"
+                    "{{ intro_note }}\n\n"
                     "The votes for {{ cycle_label }} are counted. Here's how the funding pool was split:\n\n"
                     "{{ allocation_summary }}\n\n"
                     "You were recorded as voting — 1st: {{ vote_1st }}, 2nd: {{ vote_2nd }}, 3rd: {{ vote_3rd }}.\n\n"
@@ -553,6 +558,7 @@ _CURATED: dict[str, EventCopy] = {
                 ),
                 body_html=(
                     "<p>Hi {{ member_name }},</p>"
+                    "<p>{{ intro_note }}</p>"
                     "<p>The votes for {{ cycle_label }} are counted. Here's how the funding pool was split:</p>"
                     "<pre>{{ allocation_summary }}</pre>"
                     "<p>You were recorded as voting — 1st: <strong>{{ vote_1st }}</strong>, "

--- a/membership/management/commands/send_funding_results.py
+++ b/membership/management/commands/send_funding_results.py
@@ -1,0 +1,67 @@
+"""Send a funding snapshot's member results email headlessly (with an optional note).
+
+The admin UI (``voting_send_results``) is the normal path; this command exists so a
+results send can run as a one-off job (e.g. a Render job) without an admin session —
+and so a late/overdue send can carry an organizer note at the top of the email.
+
+The note is passed **base64-encoded** (``--note-b64``) on purpose: a one-off job runner
+may split the command on whitespace, which would mangle a plain ``--note "long text"``.
+base64 is a single whitespace-free token, so it survives intact.
+
+    python manage.py send_funding_results --snapshot-id 4
+    python manage.py send_funding_results --snapshot-id 4 --note-b64 "$(printf '%s' 'Sorry this is late!' | base64 -w0)"
+    python manage.py send_funding_results --snapshot-id 4 --resend   # re-send an already-sent snapshot
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+from membership.models import FundingSnapshot, ResultsAlreadySentError
+
+
+class Command(BaseCommand):
+    help = "Send a funding snapshot's personalized results email to its voters (optional intro note)."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--snapshot-id", type=int, required=True, help="FundingSnapshot primary key to send.")
+        parser.add_argument(
+            "--note-b64",
+            type=str,
+            default="",
+            help="Optional intro note, base64-encoded (UTF-8), shown at the top of the email.",
+        )
+        parser.add_argument(
+            "--resend",
+            action="store_true",
+            help="Allow re-sending a snapshot whose results were already sent.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        note = self._decode_note(options["note_b64"])
+
+        try:
+            snapshot = FundingSnapshot.objects.get(pk=options["snapshot_id"])
+        except FundingSnapshot.DoesNotExist:
+            raise CommandError(f"No FundingSnapshot with id {options['snapshot_id']}.")
+
+        try:
+            sent = snapshot.send_results(resend=options["resend"], intro_note=note)
+        except ResultsAlreadySentError as exc:
+            raise CommandError(f"{exc} Pass --resend to send it again.")
+
+        note_label = " (with intro note)" if note else ""
+        self.stdout.write(self.style.SUCCESS(f"Sent {sent} results email(s) for '{snapshot.cycle_label}'{note_label}."))
+
+    def _decode_note(self, raw: str) -> str:
+        """Decode the base64 ``--note-b64`` argument to text; raise on malformed input."""
+        if not raw:
+            return ""
+        try:
+            return base64.b64decode(raw, validate=True).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError) as exc:
+            raise CommandError(f"--note-b64 is not valid base64-encoded UTF-8: {exc}")

--- a/membership/models.py
+++ b/membership/models.py
@@ -2121,7 +2121,7 @@ class FundingSnapshot(models.Model):
         lines = [f"{row['guild_name']} — ${row['funding']} ({row['share_pct']}%)" for row in results]
         return "\n".join(lines)
 
-    def send_results(self, *, actor: Any | None = None, resend: bool = False) -> int:
+    def send_results(self, *, actor: Any | None = None, resend: bool = False, intro_note: str = "") -> int:
         """Email each member who voted their personalized results — the admin-confirmed send.
 
         Loops the snapshot's frozen ``raw_votes`` and emits ``voting.results_published``
@@ -2135,6 +2135,10 @@ class FundingSnapshot(models.Model):
                 symmetry/auditing of the calling view).
             resend: When True, allows re-sending already-sent results (a fresh ``period``
                 re-delivers); when False a second send raises ``ResultsAlreadySentError``.
+            intro_note: Optional organizer note rendered at the top of the results email
+                (blank for a normal automated send; used for a one-off, e.g. explaining a
+                late send). Carried into the ``voting.results_published`` ``intro_note``
+                merge field.
 
         Returns:
             The number of voters who received a fresh delivery this send.
@@ -2170,6 +2174,7 @@ class FundingSnapshot(models.Model):
                 context={
                     "member": member,  # → registrant resolver (drops no-account/no-email; respects opt-out)
                     "member_name": member.display_name,
+                    "intro_note": intro_note,
                     "cycle_label": self.cycle_label,
                     "allocation_summary": allocation,
                     "vote_1st": vote["guild_1st_name"],

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.19.13"
+VERSION = "0.19.14"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.19.13",
+        "version": "0.19.14",
         "date": "2026-06-27",
         "title": "Your notifications and emails, all in one place",
         "changes": [

--- a/tests/membership/funding_snapshot_results_spec.py
+++ b/tests/membership/funding_snapshot_results_spec.py
@@ -217,6 +217,28 @@ def describe_send_results():
         assert kwargs["context"]["voting_url"].startswith(dj_settings.MEMBER_BASE_URL)
         assert kwargs["url"].endswith("/guilds/voting/history/")
 
+    def it_renders_an_intro_note_at_the_top_when_provided():
+        _voter("a@x.com")
+        snap = FundingSnapshot.take()
+        assert snap is not None
+        mail.outbox.clear()
+
+        snap.send_results(intro_note="Sorry this is overdue — results are automated from here.")
+
+        assert "Sorry this is overdue — results are automated from here." in mail.outbox[0].body
+
+    def it_omits_the_note_and_still_renders_when_no_intro_note_is_given():
+        _voter("a@x.com")
+        snap = FundingSnapshot.take()
+        assert snap is not None
+        mail.outbox.clear()
+
+        snap.send_results()  # default intro_note=""
+
+        body = mail.outbox[0].body
+        assert "overdue" not in body
+        assert "The votes for" in body  # the email still renders normally without a note
+
 
 def describe_send_results_audience_safety():
     def it_excludes_former_suspended_and_emailless_and_respects_email_opt_out():

--- a/tests/membership/send_funding_results_command_spec.py
+++ b/tests/membership/send_funding_results_command_spec.py
@@ -1,0 +1,85 @@
+"""BDD specs for the ``send_funding_results`` management command.
+
+Headless send path for a funding snapshot's member results email, with an optional
+base64-encoded intro note (so a whitespace-splitting job runner can't mangle it).
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db.models.signals import post_save
+from factory.django import mute_signals
+
+from membership.models import FundingSnapshot, Member
+from tests.membership.factories import GuildFactory, MemberFactory, VotePreferenceFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _voter(email):
+    """An active paying member with a linked, email-bearing user and a vote."""
+    member = MemberFactory(member_type=Member.MemberType.STANDARD, status=Member.Status.ACTIVE)
+    with mute_signals(post_save):
+        user = User.objects.create_user(username=f"u{member.pk}", email=email)
+    member.user = user
+    member.save(update_fields=["user"])
+    VotePreferenceFactory(
+        member=member, guild_1st=GuildFactory(), guild_2nd=GuildFactory(), guild_3rd=GuildFactory(), signed_up=False
+    )
+    return member
+
+
+def describe_send_funding_results_command():
+    def it_sends_the_snapshot_results_and_stamps_it():
+        _voter("a@x.com")
+        snap = FundingSnapshot.take()
+        assert snap is not None
+        mail.outbox.clear()
+
+        call_command("send_funding_results", snapshot_id=snap.pk)
+
+        snap.refresh_from_db()
+        assert snap.results_sent_at is not None
+        assert len(mail.outbox) == 1
+
+    def it_decodes_a_base64_note_into_the_email():
+        _voter("a@x.com")
+        snap = FundingSnapshot.take()
+        assert snap is not None
+        note = "Heads-up: this one is late — future results are automated."
+        encoded = base64.b64encode(note.encode("utf-8")).decode("ascii")
+        mail.outbox.clear()
+
+        call_command("send_funding_results", snapshot_id=snap.pk, note_b64=encoded)
+
+        assert note in mail.outbox[0].body
+
+    def it_errors_on_an_unknown_snapshot():
+        with pytest.raises(CommandError):
+            call_command("send_funding_results", snapshot_id=999999)
+
+    def it_errors_on_invalid_base64():
+        _voter("a@x.com")
+        snap = FundingSnapshot.take()
+        assert snap is not None
+        with pytest.raises(CommandError):
+            call_command("send_funding_results", snapshot_id=snap.pk, note_b64="@@not base64@@")
+
+    def it_refuses_a_second_send_without_resend_then_allows_it_with_the_flag():
+        _voter("a@x.com")
+        snap = FundingSnapshot.take()
+        assert snap is not None
+        call_command("send_funding_results", snapshot_id=snap.pk)
+
+        with pytest.raises(CommandError):
+            call_command("send_funding_results", snapshot_id=snap.pk)
+
+        call_command("send_funding_results", snapshot_id=snap.pk, resend=True)
+        snap.refresh_from_db()
+        assert snap.results_send_count == 2


### PR DESCRIPTION
Lets a funding-results send carry a one-time organizer note (rendered at the top of the `voting.results_published` email) and adds a `send_funding_results` management command so the send can run headlessly as a one-off job.

**Why now:** the May 2026 results were never sent; this lets them go out with a short 'sorry this is overdue — it's automated going forward' note, without an admin session.

- `{{ intro_note }}` merge field on the results email (blank for normal automated sends).
- `FundingSnapshot.send_results(intro_note=...)`.
- `send_funding_results --snapshot-id N [--note-b64 <b64>] [--resend]` (note base64-encoded to survive job-runner arg splitting).
- Specs for note rendering + the command. Local: ruff + mypy clean, 39 specs green.

Note: the DB results template refreshes to include the new field via the deploy's `seed_notification_templates` step.