### PR TITLE
Discord announce: manual-only trigger, stop duplicate posts (v0.19.15)

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,9 +1,12 @@
 name: Discord Notifications
 
+# Manual-only on purpose. This used to fire on every push to main, which re-posted the
+# WHOLE current release-line changelog on every routine hotfix merge — a duplicate
+# announcement to members each time. A release announcement is a deliberate act, so it is
+# now triggered by hand when a release actually ships:
+#   gh workflow run discord-notify.yml        (or the "Run workflow" button in the Actions UI)
 on:
-  push:
-    branches: [main]
-  workflow_dispatch: # allow manual re-posting (e.g. if a release post failed) without a redeploy
+  workflow_dispatch:
 
 jobs:
   notify:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,11 @@ Every PR bumps `VERSION` in `plfog/version.py`. The `CHANGELOG` is the **member-
 - **A fix to something already live on production IS member-facing** (they lived with the bug) — that gets its own plain-language entry.
 - Always keep one entry whose `version == VERSION` (so `announce_release` resolves) — that's the feature entry you just edited and re-stamped.
 - Entries are **plain, member-friendly language** — no jargon, PR numbers, or commit hashes.
-- The GitHub Actions workflow (`.github/workflows/discord-notify.yml`) aggregates every `CHANGELOG` entry whose version shares the current `MAJOR.MINOR` and posts them as one announcement, newest entry's title as the headline. Git history is the granular per-PR trail; the changelog is the curated highlights.
+- The GitHub Actions workflow (`.github/workflows/discord-notify.yml`) aggregates every `CHANGELOG` entry whose version shares the current `MAJOR.MINOR` and posts them as one announcement, newest entry's title as the headline. It is **manual-only** (`workflow_dispatch`) — trigger it deliberately when a release ships (`gh workflow run discord-notify.yml`, or the Actions "Run workflow" button). Git history is the granular per-PR trail; the changelog is the curated highlights.
 
 ## Discord Notifications
 
-A GitHub Actions workflow posts to the Past Lives Discord channel when code is merged to main. It reads the latest changelog entry from `plfog/version.py` and posts a friendly release announcement. No notifications are sent for PR activity — only merged releases.
+A GitHub Actions workflow posts a release announcement to the Past Lives Discord channel. It reads the `CHANGELOG` from `plfog/version.py` (the current `MAJOR.MINOR` line). It is **triggered manually** (`workflow_dispatch`) when a release is ready — it does NOT fire on every merge to main (that re-posted the whole changelog as a duplicate on every routine hotfix). Run it with `gh workflow run discord-notify.yml` or the Actions "Run workflow" button. The script chunks the post under Discord's 4096-char embed limit and fails loudly on a rejected post.
 
 ---
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.19.14"
+VERSION = "0.19.15"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.19.14",
+        "version": "0.19.15",
         "date": "2026-06-27",
         "title": "Your notifications and emails, all in one place",
         "changes": [


### PR DESCRIPTION
The discord-notify workflow fired on **every push to main** and re-posted the whole current release-line changelog each time — a duplicate member announcement on every routine hotfix merge.

This makes it **`workflow_dispatch`-only**: announce a release deliberately with `gh workflow run discord-notify.yml` (or the Actions 'Run workflow' button). No auto-post on merge ⇒ no duplicates.

Since the merge commit carries the new (push-trigger-less) workflow, **landing this PR does not itself trigger a post**. CLAUDE.md updated to match.