### PR TITLE
Headless send_site_announcement command (v0.19.16)

### DIFF
--- a/core/management/commands/send_site_announcement.py
+++ b/core/management/commands/send_site_announcement.py
@@ -1,0 +1,82 @@
+"""Send a site-wide announcement email headlessly — the CLI twin of the Site Settings
+→ Announcements composer (``hub.views._send_site_announcement``).
+
+The web composer needs an admin session; this command sends the same
+``site_announcement`` event from a one-off job (e.g. a Render job) with no login, from
+the same ``noreply@`` Resend sender. It builds the branded rich-HTML email exactly like
+the composer (sanitize → inline-style → branded shell) and hands it to ``emit`` as a
+per-channel EMAIL override, so the rich HTML is NOT autoescaped (the spine escapes
+copy-merge values, but a pre-rendered ``Message.html_body`` is trusted).
+
+Subject and body are base64-encoded (``--subject-b64`` / ``--body-b64``) so a
+whitespace-splitting job runner can't mangle them. The body is simple HTML (the same
+tags the editor allows). Discord is OFF unless ``--discord`` is passed. Recipients are
+the activated-member audience the ``site_announcement`` event already resolves to.
+
+    python manage.py send_site_announcement --subject-b64 <b64> --body-b64 <b64>
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Any
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+from django.utils.html import escape
+
+
+class Command(BaseCommand):
+    help = "Send a site-wide announcement email to activated members (subject/body base64-encoded)."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--subject-b64", type=str, required=True, help="Subject, base64-encoded UTF-8.")
+        parser.add_argument("--body-b64", type=str, required=True, help="Body (simple HTML), base64-encoded UTF-8.")
+        parser.add_argument(
+            "--discord",
+            action="store_true",
+            help="Also post the announcement to Discord (off by default).",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        from core.events.channels import Channel, Message
+        from core.events.emit import emit
+        from core.events.templates import wrap_email_html
+        from core.html_sanitize import render_rich_email_body, rich_html_to_text, sanitize_rich_html
+
+        title = self._decode(options["subject_b64"], "--subject-b64").strip()
+        body_html = sanitize_rich_html(self._decode(options["body_b64"], "--body-b64"))
+        if not title or not body_html:
+            raise CommandError("Subject and body must both be non-empty (body must survive sanitization).")
+
+        body_text = rich_html_to_text(body_html)
+        site_url = settings.MEMBER_BASE_URL
+        email = Message(
+            title=title,
+            body=f"{title}\n\n{body_text}\n\n{site_url}",
+            url=site_url,
+            html_body=wrap_email_html(f"<h2>{escape(title)}</h2>{render_rich_email_body(body_html)}"),
+            trigger_kind="site_announcement",
+        )
+        result = emit(
+            "site_announcement",
+            context={
+                "member_name": "there",
+                "announcement_title": title,
+                "announcement_body": body_text,
+                "site_url": site_url,
+            },
+            url=site_url,
+            period=f"site:{timezone.now():%Y%m%d%H%M%S%f}",
+            messages={Channel.EMAIL: email},
+            suppress_broadcast=not options["discord"],
+        )
+        self.stdout.write(self.style.SUCCESS(f"Announcement sent to {result.recipient_count} member(s)."))
+
+    def _decode(self, raw: str, flag: str) -> str:
+        try:
+            return base64.b64decode(raw, validate=True).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError) as exc:
+            raise CommandError(f"{flag} is not valid base64-encoded UTF-8: {exc}")

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.19.15"
+VERSION = "0.19.16"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.19.15",
+        "version": "0.19.16",
         "date": "2026-06-27",
         "title": "Your notifications and emails, all in one place",
         "changes": [

--- a/tests/core/management/send_site_announcement_command_spec.py
+++ b/tests/core/management/send_site_announcement_command_spec.py
@@ -1,0 +1,80 @@
+"""BDD specs for the ``send_site_announcement`` management command.
+
+Headless twin of the Site Settings → Announcements composer: sends the rich-HTML
+``site_announcement`` email to activated members, subject/body base64-encoded.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db.models.signals import post_save
+from django.utils import timezone
+from factory.django import mute_signals
+
+from membership.models import Member
+from tests.membership.factories import MemberFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _activated(email, n):
+    """An active member linked to a User who has logged in — the ALL_ACTIVE_MEMBERS audience."""
+    member = MemberFactory(status=Member.Status.ACTIVE)
+    with mute_signals(post_save):
+        user = User.objects.create_user(username=f"u{member.pk}", email=email, last_login=timezone.now())
+    member.user = user
+    member.save(update_fields=["user"])
+    return member
+
+
+def _b64(text: str) -> str:
+    return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def _html_part(message) -> str:
+    return next((content for content, mime in message.alternatives if mime == "text/html"), "")
+
+
+def describe_send_site_announcement_command():
+    def it_emails_activated_members_with_rich_html_not_escaped():
+        _activated("a@x.com", 1)
+        _activated("b@x.com", 2)
+        mail.outbox.clear()
+
+        call_command(
+            "send_site_announcement",
+            subject_b64=_b64("Big news"),
+            body_b64=_b64("<h3>Hello</h3><ul><li>one</li></ul>"),
+        )
+
+        assert len(mail.outbox) == 2
+        html = _html_part(mail.outbox[0])
+        assert "one" in html
+        assert "&lt;li&gt;" not in html  # the list tag is real markup, not escaped text
+
+    def it_suppresses_discord_by_default():
+        _activated("a@x.com", 1)
+        with patch("core.events.emit.emit") as mock_emit:
+            call_command("send_site_announcement", subject_b64=_b64("T"), body_b64=_b64("<p>hi</p>"))
+        assert mock_emit.call_args.kwargs["suppress_broadcast"] is True
+
+    def it_posts_to_discord_when_flagged():
+        _activated("a@x.com", 1)
+        with patch("core.events.emit.emit") as mock_emit:
+            call_command("send_site_announcement", subject_b64=_b64("T"), body_b64=_b64("<p>hi</p>"), discord=True)
+        assert mock_emit.call_args.kwargs["suppress_broadcast"] is False
+
+    def it_errors_on_invalid_base64():
+        with pytest.raises(CommandError):
+            call_command("send_site_announcement", subject_b64="@@bad@@", body_b64=_b64("<p>hi</p>"))
+
+    def it_errors_when_the_body_sanitizes_to_empty():
+        with pytest.raises(CommandError):
+            call_command("send_site_announcement", subject_b64=_b64("Title"), body_b64=_b64("   "))


### PR DESCRIPTION
CLI twin of the Site Settings → Announcements composer — sends the rich-HTML `site_announcement` email to activated members from a one-off job, **no admin session** (same `noreply@` Resend sender). This lets the release announcement go out headlessly instead of driving the admin UI through a login.

- Subject/body base64-encoded (survives job-runner whitespace splitting).
- Body is sanitized + inline-styled + wrapped in the branded shell and handed to `emit` as a per-channel EMAIL `Message`, so the HTML is **not autoescaped** (the spine escapes copy-merge values; a pre-rendered `html_body` is trusted) — mirrors `hub.views._send_site_announcement`.
- Discord off by default (`--discord` to also post).
- 5 specs (rich HTML unescaped, discord suppress default/flag, bad base64, empty-after-sanitize). Local: ruff + mypy clean, all green.