### PR TITLE
[ops] Release email: screenshot slugs + test-send command

### DIFF
--- a/core/management/commands/send_release_email_test.py
+++ b/core/management/commands/send_release_email_test.py
@@ -1,0 +1,52 @@
+"""Send the current release email as a one-off test to a single address.
+
+Renders the release email exactly as the admin composer would (using the same
+``build_release_cards`` / ``render_release_email`` pipeline, with screenshots
+from R2), then delivers it directly via ``core.email.send`` — NOT through the
+notification spine — so the real send's dedup period is never consumed.
+
+Usage (Render one-off job):
+    python manage.py send_release_email_test --to plazajosue2@gmail.com
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Send the current release email as a test to one address (skips the notification spine)."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--to", type=str, required=True, help="Recipient email address.")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        from core.email import send
+        from core.release_email import build_release_cards, render_release_email
+        from plfog.version import VERSION
+
+        to_addr: str = options["to"].strip()
+        if not to_addr or "@" not in to_addr:
+            raise CommandError(f"--to must be a valid email address, got: {to_addr!r}")
+
+        cards = build_release_cards(VERSION)
+        subject = f"What's new at Past Lives: {cards[0].title}" if cards else "What's new at Past Lives"
+        html, text = render_release_email(
+            VERSION,
+            subject=subject,
+            preheader=cards[0].title if cards else "See what's new.",
+            intro="<p>We've just shipped a big update — here's what's new.</p>",
+            cards=cards,
+        )
+
+        send(
+            to=to_addr,
+            subject=subject,
+            trigger_kind="release_email.test",
+            text_body=text,
+            html_body=html,
+            best_effort=True,
+        )
+        self.stdout.write(self.style.SUCCESS(f"Release test email sent to {to_addr}."))

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -9,6 +9,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         "version": "0.20.5",
         "date": "2026-07-04",
         "title": "A “Get started” checklist to help you settle in",
+        "screenshot": "home",
         "changes": [
             (
                 "New members now get a friendly “Get started” card on the home page that walks you through the "
@@ -34,6 +35,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         "version": "0.20.3",
         "date": "2026-07-04",
         "title": "Choose which guilds you're in — right from Settings",
+        "screenshot": "my-guilds",
         "changes": [
             (
                 "There's a new Guilds tab in Settings with a simple on/off switch for every guild. Flip one on to "
@@ -47,6 +49,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         "version": "0.20.2",
         "date": "2026-07-04",
         "title": "Suggest an announcement for your guild",
+        "screenshot": "guild-directory",
         "changes": [
             (
                 "Anyone can now suggest an announcement for a guild — a guild lead (or an admin) reviews it before it "
@@ -82,6 +85,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         "version": "0.20.1",
         "date": "2026-07-03",
         "title": "One place for how our space works",
+        "screenshot": "org-info",
         "changes": [
             (
                 "New Space & Org Info page in the sidebar — one spot for how the space and the organization work: a "
@@ -120,6 +124,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         "version": "0.20.1",
         "date": "2026-07-03",
         "title": "Your profile is safer to edit — and you're listed by default",
+        "screenshot": "member-directory",
         "changes": [
             (
                 "Editing your profile is safer: if a photo you upload is too large, we now keep the rest of your "


### PR DESCRIPTION
Enables the v0.20 release email to send with screenshots.

## What

- Adds `screenshot` slugs to 5 CHANGELOG 0.20.x entries (home, my-guilds, guild-directory, org-info, member-directory) — R2 captures were taken this session, so `resolve_feature_shot_url` will now return real URLs
- New `send_release_email_test --to <email>` management command for one-off test sends without touching the notification spine's dedup period

## Next

Once merged and deployed, run the Render one-off job:
```
python manage.py send_release_email_test --to plazajosue2@gmail.com
```
Then if it looks good, fire the real blast from Site Settings → Announcements → Draft from latest release → Send.