### PR TITLE
[hub] Hide the broken announcement-drafts panel (v0.21.15)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-VERSION = "0.21.14"
+VERSION = "0.21.15"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.21.14",
-        "date": "2026-07-12",
+        "version": "0.21.15",
+        "date": "2026-07-13",
         "title": "Your Guilds, wherever you are",
         "screenshot": "my-guilds",
         "changes": [

--- a/templates/hub/announcement_compose.html
+++ b/templates/hub/announcement_compose.html
@@ -97,8 +97,13 @@
 
       <div class="pl-wizard-actions">
         <button type="button" class="hub-btn hub-btn--ghost" @click="step = 2">&larr; Back</button>
+        {% comment %}
+          Drafts UI hidden 2026-07-13 — the "Save draft" button. The backend (hub_compose_save_draft
+          view + route) is intact and dormant; to re-enable, un-comment this button.
+          See docs/superpowers/plans/2026-07-13-hide-announcement-drafts.md
         <button type="button" class="hub-btn hub-btn--ghost"
                 hx-post="{% url 'hub_compose_save_draft' %}" hx-include="closest form" hx-swap="none">Save draft</button>
+        {% endcomment %}
         <button type="submit" class="hub-btn hub-btn--primary"
                 @click="if (!confirm(`Send to ${recipientCount} member(s)? This can't be undone.`)) $event.preventDefault()">
           Send announcement
@@ -108,5 +113,11 @@
   </form>
 </div>
 
+{% comment %}
+  Drafts UI hidden 2026-07-13 — the "Your drafts" panel. It rendered run-together guild names
+  that wrecked the composer navbar/layout. The model (AnnouncementDraft), its save/list/delete
+  views, and routes are all intact and dormant; to re-enable, un-comment this include.
+  See docs/superpowers/plans/2026-07-13-hide-announcement-drafts.md
 {% include "hub/partials/_compose_drafts_list.html" %}
+{% endcomment %}
 {% endblock %}

--- a/tests/hub/announcement_compose_spec.py
+++ b/tests/hub/announcement_compose_spec.py
@@ -1,9 +1,10 @@
 """The announcement compose wizard views (/announcements/compose/) — page, drafts, send, mention.
 
-Covers: GET renders three steps + drafts list; audience gating (admins see site-wide, leads see
-their guilds, plain members get bounced to propose); resume robustness (foreign/sent pk → 404);
-save-draft upsert + error toast; the recipient-count HTMX endpoint; the direct test-send (never
-the spine); send permission re-checks + the guild materialization; delete via confirm.
+Covers: GET renders the three steps + the send path (the drafts UI is hidden as of 2026-07-13 —
+backend intact); audience gating (admins see site-wide, leads see their guilds, plain members get
+bounced to propose); resume robustness (foreign/sent pk → 404); save-draft upsert + error toast;
+the recipient-count HTMX endpoint; the direct test-send (never the spine); send permission
+re-checks + the guild materialization; delete via confirm.
 """
 
 from __future__ import annotations
@@ -69,15 +70,32 @@ def _valid_send_data(**overrides) -> dict:
 
 
 def describe_hub_compose_page():
-    def it_renders_the_three_steps_and_the_empty_drafts_state_for_an_admin(client: Client):
+    def it_renders_the_three_steps_and_the_send_path_for_an_admin(client: Client):
         _login_admin(client)
         response = client.get(reverse("hub_compose"))
         assert response.status_code == 200
         content = response.content.decode()
+        # All three wizard steps render: audience & message → email → Discord.
         assert 'name="audience"' in content
-        assert "No saved drafts yet" in content
-        assert "+ New announcement" in content
+        assert "Audience &amp; message" in content
+        assert "Email" in content
+        assert "Discord" in content
         assert "Reaches" in content
+        # The send path is intact: one form posting to send, with a Send submit.
+        assert f'action="{reverse("hub_compose_send")}"' in content
+        assert "Send announcement" in content
+
+    def it_hides_the_drafts_panel_and_the_save_draft_button(client: Client):
+        # The drafts UI was hidden on 2026-07-13 (backend intact); neither the "Save draft"
+        # button nor the "Your drafts" panel include should reach the composer any more.
+        _login_admin(client)
+        content = client.get(reverse("hub_compose")).content.decode()
+        assert reverse("hub_compose_save_draft") not in content
+        assert ">Save draft<" not in content
+        assert 'id="compose-drafts"' not in content
+        assert "Your drafts" not in content
+        assert "No saved drafts yet" not in content
+        assert "+ New announcement" not in content
 
     def it_offers_the_site_option_to_an_admin(client: Client):
         _login_admin(client)


### PR DESCRIPTION
Hides the drafts panel + Save-draft button that were wrecking the announcement-composer navbar. Backend (AnnouncementDraft model/views/routes) left intact & dormant — a pure, reversible UI hide. 44 tests pass. Base: v21-hot-fixes (version/changelog reconciled on the release branch).

https://claude.ai/code/session_0129pLhnnoZtmYiSze9jDuRF