### PR TITLE
[classes] Timeframe filter + fix the misleading class count (v0.21.18)

### DIFF
--- a/classes/spec/views/public_spec.py
+++ b/classes/spec/views/public_spec.py
@@ -38,6 +38,29 @@ def published_class(db):
     return offering
 
 
+@pytest.fixture
+def windowed_classes(db):
+    """Three published, dated classes at now+10d / +60d / +200d for timeframe tests."""
+    category = CategoryFactory(name="Woodshop", slug="woodshop")
+    instructor = InstructorFactory(full_legal_name="Marlo", instructor_slug="marlo")
+
+    def _make(title, slug, days):
+        offering = ClassOfferingFactory(
+            title=title,
+            slug=slug,
+            category=category,
+            instructor=instructor,
+            status=ClassOffering.Status.PUBLISHED,
+        )
+        start = timezone.now() + timedelta(days=days)
+        ClassSessionFactory(class_offering=offering, starts_at=start, ends_at=start + timedelta(hours=2))
+        return offering
+
+    _make("Soon Class", "soon-class", 10)
+    _make("Mid Class", "mid-class", 60)
+    _make("Far Class", "far-class", 200)
+
+
 def describe_coerce_dollars_to_cents():
     def it_returns_zero_for_invalid_string():
         from classes.views import _coerce_dollars_to_cents
@@ -63,14 +86,14 @@ def describe_public_list():
         assert b"Intro to Wheel Throwing" in response.content
         assert b"Deenie" in response.content
 
-    def it_renders_the_upcoming_session_count_in_the_hero(published_class, client):
-        # published_class seeds exactly one future session.
+    def it_renders_the_class_card_count_in_the_hero(published_class, client):
+        # published_class collapses to exactly one bookable card. The hero headline
+        # now counts visible cards (paginator.count), labeled "Class(es)" — the old
+        # "Upcoming Session(s)" tile is gone.
         response = client.get(reverse("classes:public_list"))
         body = response.content.decode()
-        assert "Upcoming Session" in body
-        # The hero tile no longer carries the old "Classes" stat label.
-        assert '<div class="hs-l">Classes</div>' not in body
-        assert '<div class="hs-n">1</div><div class="hs-l">Upcoming Session</div>' in body
+        assert "Upcoming Session" not in body
+        assert '<div class="hs-n">1</div><div class="hs-l">Class</div>' in body
 
     def it_labels_the_grouping_as_guilds_not_categories(published_class, client):
         # The "Categories → Guilds" relabel: hero stat label and filter copy read "Guild(s)".
@@ -81,9 +104,10 @@ def describe_public_list():
         assert '<div class="hs-l">Categories</div>' not in body
         assert "All categories" not in body
 
-    def it_counts_sessions_not_cards(db, client):
-        # One series offered on three future dates collapses to ONE catalog card,
-        # but contributes THREE upcoming sessions.
+    def it_counts_grouped_cards_not_sessions(db, client):
+        # One series offered on three future dates collapses to ONE catalog card.
+        # The hero now counts CARDS, so it reads 1 — and agrees with the summary,
+        # which is the whole point of the reconciliation (was: hero said 3).
         offering = ClassOfferingFactory(
             title="Three Week Forge",
             slug="three-week-forge",
@@ -95,14 +119,15 @@ def describe_public_list():
             ClassSessionFactory(class_offering=offering, starts_at=start, ends_at=start + timedelta(hours=2))
         response = client.get(reverse("classes:public_list"))
         body = response.content.decode()
-        # Hero headline counts sessions: 3.
-        assert '<div class="hs-n">3</div><div class="hs-l">Upcoming Session' in body
-        # Results summary still counts cards: 1 class.
+        # Hero headline and results summary both count cards: 1 class.
+        assert '<div class="hs-n">1</div><div class="hs-l">Class</div>' in body
         assert "of <strong>1</strong> class" in body
 
-    def it_shows_zero_gracefully_when_no_upcoming_sessions(db, client):
-        # A published class whose only session is in the past, plus a flexible
-        # (session-less) class — neither contributes an upcoming session.
+    def it_counts_a_session_less_flexible_class_as_one(db, client):
+        # A published class whose only session is in the past (dropped by bookable),
+        # plus a flexible session-less class (always bookable). Semantic flip from
+        # the old session-count: the flexible class is now ONE card, so the hero
+        # reads "1 Class," not "0."
         past_offering = ClassOfferingFactory(
             title="Yesterday's Class",
             slug="yesterdays-class",
@@ -118,7 +143,149 @@ def describe_public_list():
         )
         response = client.get(reverse("classes:public_list"))
         body = response.content.decode()
-        assert '<div class="hs-n">0</div><div class="hs-l">Upcoming Sessions</div>' in body
+        assert '<div class="hs-n">1</div><div class="hs-l">Class</div>' in body
+
+    def describe_within_timeframe_filter():
+        def it_limits_to_the_next_30_days(windowed_classes, client):
+            response = client.get(reverse("classes:public_list") + "?within=30")
+            assert b"Soon Class" in response.content
+            assert b"Mid Class" not in response.content
+            assert b"Far Class" not in response.content
+
+        def it_widens_to_90_and_180_days(windowed_classes, client):
+            at_90 = client.get(reverse("classes:public_list") + "?within=90")
+            assert b"Soon Class" in at_90.content
+            assert b"Mid Class" in at_90.content
+            assert b"Far Class" not in at_90.content
+
+            at_180 = client.get(reverse("classes:public_list") + "?within=180")
+            assert b"Far Class" not in at_180.content
+
+            all_upcoming = client.get(reverse("classes:public_list") + "?within=all")
+            assert b"Soon Class" in all_upcoming.content
+            assert b"Mid Class" in all_upcoming.content
+            assert b"Far Class" in all_upcoming.content
+
+            no_param = client.get(reverse("classes:public_list"))
+            assert b"Far Class" in no_param.content
+
+        def it_keeps_flexible_classes_in_every_window(db, client):
+            ClassOfferingFactory(
+                title="Anytime Workshop",
+                slug="anytime-workshop",
+                status=ClassOffering.Status.PUBLISHED,
+                scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE,
+            )
+            response = client.get(reverse("classes:public_list") + "?within=30")
+            assert b"Anytime Workshop" in response.content
+
+        def it_ignores_an_unknown_within_value(windowed_classes, client):
+            response = client.get(reverse("classes:public_list") + "?within=abc")
+            assert response.status_code == 200
+            assert b"Soon Class" in response.content
+            assert b"Mid Class" in response.content
+            assert b"Far Class" in response.content
+
+    def describe_hero_count_reconciliation():
+        def it_shows_the_grouped_card_count_as_the_hero_number(windowed_classes, client):
+            response = client.get(reverse("classes:public_list"))
+            body = response.content.decode()
+            # Hero headline, results summary, and rendered cards all agree at 3.
+            assert '<div class="hs-n">3</div><div class="hs-l">Classes</div>' in body
+            assert "of <strong>3</strong> class" in body
+            assert body.count('class="cls-card"') == 3
+
+        def it_returns_an_oob_hero_count_on_htmx_requests(windowed_classes, client):
+            htmx = client.get(reverse("classes:public_list") + "?within=30", HTTP_HX_REQUEST="true")
+            htmx_body = htmx.content.decode()
+            # The partial carries the OOB hero tile so the hero tracks the filtered
+            # count (within=30 → only "Soon Class" → 1 card).
+            assert 'id="hero-classes-stat"' in htmx_body
+            assert 'hx-swap-oob="true"' in htmx_body
+            assert '<div class="hs-n">1</div><div class="hs-l">Class</div>' in htmx_body
+
+            # A full page load carries exactly one hero tile (in the hero, never a
+            # stray duplicate inside the embedded results grid).
+            full = client.get(reverse("classes:public_list"))
+            full_body = full.content.decode()
+            assert full_body.count('id="hero-classes-stat"') == 1
+            assert "hx-swap-oob" not in full_body
+
+        def it_counts_a_grouped_class_once(db, client):
+            category = CategoryFactory(name="Metals", slug="metals")
+            instructor = InstructorFactory(full_legal_name="Reese", instructor_slug="reese")
+            # Same title + category → same grouping_key → one card across two dates.
+            for idx, days in enumerate((5, 12)):
+                offering = ClassOfferingFactory(
+                    title="Repeated Class",
+                    slug=f"repeated-class-{idx}",
+                    category=category,
+                    instructor=instructor,
+                    status=ClassOffering.Status.PUBLISHED,
+                )
+                start = timezone.now() + timedelta(days=days)
+                ClassSessionFactory(class_offering=offering, starts_at=start, ends_at=start + timedelta(hours=2))
+            response = client.get(reverse("classes:public_list") + "?within=30")
+            body = response.content.decode()
+            assert '<div class="hs-n">1</div><div class="hs-l">Class</div>' in body
+            assert "of <strong>1</strong> class" in body
+
+    def describe_empty_timeframe_state():
+        def it_offers_a_wider_range_when_the_timeframe_is_empty(db, client):
+            offering = ClassOfferingFactory(
+                title="Far Off Class",
+                slug="far-off-class",
+                status=ClassOffering.Status.PUBLISHED,
+            )
+            start = timezone.now() + timedelta(days=200)
+            ClassSessionFactory(class_offering=offering, starts_at=start, ends_at=start + timedelta(hours=2))
+            response = client.get(reverse("classes:public_list") + "?within=30")
+            assert response.status_code == 200
+            body = response.content.decode()
+            assert "next 30 days" in body
+            assert "Show all upcoming" in body
+            # The escape link drops 'within' entirely — with no other filters, its
+            # hx-get is the bare catalog URL, and no querystring carries 'within='.
+            assert f'hx-get="{reverse("classes:public_list")}"' in body
+            assert "within=" not in body
+
+        def it_preserves_other_filters_in_show_all_upcoming(db, client):
+            category = CategoryFactory(name="Ceramics", slug="ceramics")
+            offering = ClassOfferingFactory(
+                title="Distant Ceramics",
+                slug="distant-ceramics",
+                category=category,
+                status=ClassOffering.Status.PUBLISHED,
+            )
+            start = timezone.now() + timedelta(days=200)
+            ClassSessionFactory(class_offering=offering, starts_at=start, ends_at=start + timedelta(hours=2))
+            response = client.get(reverse("classes:public_list") + "?within=30&category=ceramics")
+            body = response.content.decode()
+            assert "Show all upcoming" in body
+            # 'within' is dropped from the escape link; 'category' is kept.
+            escape = f'hx-get="{reverse("classes:public_list")}?category=ceramics"'
+            assert escape in body
+            assert "within=" not in body
+
+    def describe_pagination_carry_through():
+        def it_keeps_within_across_pages(db, client):
+            category = CategoryFactory(name="Fibers", slug="fibers")
+            instructor = InstructorFactory(full_legal_name="Sable", instructor_slug="sable")
+            # 26 distinct cards within 90 days → two pages (25/page).
+            for idx in range(26):
+                offering = ClassOfferingFactory(
+                    title=f"Fiber Class {idx}",
+                    slug=f"fiber-class-{idx}",
+                    category=category,
+                    instructor=instructor,
+                    status=ClassOffering.Status.PUBLISHED,
+                )
+                start = timezone.now() + timedelta(days=20)
+                ClassSessionFactory(class_offering=offering, starts_at=start, ends_at=start + timedelta(hours=2))
+            response = client.get(reverse("classes:public_list") + "?within=90")
+            # The next-page link carries the timeframe forward.
+            assert b"within=90" in response.content
+            assert b"page=2" in response.content
 
     def it_hides_draft_and_pending_classes(published_class, client):
         ClassOfferingFactory(

--- a/classes/views.py
+++ b/classes/views.py
@@ -63,7 +63,6 @@ from classes.models import (
     ClassApproval,
     ClassImage,
     ClassOffering,
-    ClassSession,
     ClassSettings,
     CmsActivity,
     DiscountCode,
@@ -73,6 +72,12 @@ from classes.models import (
 from core.models import SiteConfiguration
 
 _ViewFunc = Callable[..., HttpResponse]
+
+# Timeframe windows for the public catalog's "When" filter. Keys are the raw
+# GET values; values are the horizon in days. "all"/absent/unknown → no upper
+# bound (all upcoming). Kept in one named place so the three magic numbers
+# don't scatter across the view and templates.
+WITHIN_DAYS = {"30": 30, "90": 90, "180": 180}
 
 
 def _browsable_classes() -> Any:
@@ -176,6 +181,15 @@ def _apply_browse_filters(qs: Any, request: HttpRequest) -> Any:
     if request.GET.get("upcoming") == "1":
         qs = qs.exclude(first_session_at__isnull=True)
 
+    within = request.GET.get("within", "").strip()
+    if within in WITHIN_DAYS:
+        horizon = timezone.now() + timedelta(days=WITHIN_DAYS[within])
+        # Keep flexible/undated classes in every window — they mirror bookable()'s
+        # own rule that a flexible class always qualifies (it has no fixed date to
+        # fall outside the window). A bare `first_session_at__lte` would silently
+        # drop them, since bookable() annotates first_session_at as NULL for them.
+        qs = qs.filter(Q(first_session_at__lte=horizon) | Q(scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE))
+
     return qs
 
 
@@ -194,6 +208,8 @@ def public_list(request: HttpRequest) -> HttpResponse:
     members_only = request.GET.get("members_only") == "1"
     free_only = request.GET.get("free") == "1"
     upcoming_only = request.GET.get("upcoming") == "1"
+    selected_within = request.GET.get("within", "all")
+    selected_within_days = WITHIN_DAYS.get(selected_within)
 
     classes_qs = _apply_browse_filters(_browsable_classes(), request)
     catalog_groups = _grouped_catalog(classes_qs)
@@ -236,6 +252,12 @@ def public_list(request: HttpRequest) -> HttpResponse:
     filter_qs.pop("page", None)
     filter_querystring = filter_qs.urlencode()
 
+    # Same querystring minus 'within' — powers the empty-state "Show all upcoming"
+    # escape, which widens the timeframe while preserving every other filter.
+    no_within = filter_qs.copy()
+    no_within.pop("within", None)
+    filter_querystring_no_within = no_within.urlencode()
+
     active_filter_count = sum(
         1
         for v in (
@@ -249,6 +271,12 @@ def public_list(request: HttpRequest) -> HttpResponse:
         if v
     )
 
+    # HTMX partial: return just the results grid so the filter form can swap
+    # in place without rerendering hero + filter chrome. Computed once so the
+    # OOB hero-count block renders only on HTMX responses (never as a stray
+    # duplicate inside the embedded include on a full page load).
+    is_htmx = bool(request.headers.get("HX-Request") and not request.headers.get("HX-Boosted"))
+
     context = {
         "settings_obj": settings_obj,
         "site_config": SiteConfiguration.load(),
@@ -261,18 +289,22 @@ def public_list(request: HttpRequest) -> HttpResponse:
         "members_only": members_only,
         "free_only": free_only,
         "upcoming_only": upcoming_only,
+        "selected_within": selected_within,
+        "selected_within_days": selected_within_days,
         "active_filter_count": active_filter_count,
         "page_obj": page_obj,
         "paginator": paginator,
         "filter_querystring": filter_querystring,
-        "upcoming_session_count": ClassSession.objects.upcoming_public_count(),
-        "total_instructors": classes_qs.values("instructor_id").exclude(instructor_id__isnull=True).distinct().count(),
+        "filter_querystring_no_within": filter_querystring_no_within,
+        "is_htmx": is_htmx,
+        # The hero "Classes" tile is driven by paginator.count (see the template);
+        # Guilds and Instructors both reflect the full browsable universe so they
+        # stay stable while the live "Classes" count tracks the current filter.
+        "total_instructors": len(instructors_for_filter),
         "total_categories": len(categories),
     }
 
-    # HTMX partial: return just the results grid so the filter form can swap
-    # in place without rerendering hero + filter chrome.
-    if request.headers.get("HX-Request") and not request.headers.get("HX-Boosted"):
+    if is_htmx:
         return render(request, "classes/public/_list_results.html", context)
     return render(request, "classes/public/list.html", context)
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,28 @@
 
 from __future__ import annotations
 
-VERSION = "0.21.14"
+VERSION = "0.21.18"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.21.18",
+        "date": "2026-07-13",
+        "title": "Pick your timeframe on the class catalog",
+        "changes": [
+            (
+                "The class catalog now has a “When” menu — see everything upcoming, or narrow to the next 30, 90, "
+                "or 180 days. It starts on “All upcoming,” so nothing is hidden until you choose to focus."
+            ),
+            (
+                "The big number at the top now matches the classes you actually see below — no more “32 upcoming” "
+                "up top while only a handful of classes show."
+            ),
+            (
+                "Narrowing to a short window that has nothing in it now tells you so and offers a one-tap “Show all "
+                "upcoming” to widen back out."
+            ),
+        ],
+    },
     {
         "version": "0.21.14",
         "date": "2026-07-12",

--- a/static/css/cms-public.css
+++ b/static/css/cms-public.css
@@ -1137,10 +1137,23 @@ a.cp-detail__cta--waitlist:hover {
   padding-right: 12px;
   min-width: 0;
 }
+/* Native option popups don't inherit the select's colors (FRONTEND.md rule 13) —
+   theme them explicitly so the dropdown isn't a white box on the dark theme. */
+.cp-filter__select option {
+  background: var(--bg2);
+  color: var(--text);
+}
 .cp-filter__select:focus,
 .cp-filter__price input:focus {
   outline: none;
   border-color: var(--gold);
+}
+/* Loading state: dim the results grid while an HTMX filter/timeframe request is
+   in flight (the filter form points hx-indicator at #cls-results). Opacity is
+   theme-independent, so this reads correctly on both Obsidian and Slate. */
+.cp-page #cls-results.htmx-request {
+  opacity: 0.55;
+  transition: opacity 0.15s ease;
 }
 .cp-filter__toggle {
   display: inline-flex;

--- a/templates/classes/public/_hero_classes_stat.html
+++ b/templates/classes/public/_hero_classes_stat.html
@@ -1,0 +1,3 @@
+{% comment %}The "N Classes" hero tile body — the count of visible bookable class cards
+for the current filter (paginator.count). Shared by list.html's hero and the
+OOB block in _list_results.html so the two renderings never drift.{% endcomment %}<div class="hs-n">{{ paginator.count }}</div><div class="hs-l">Class{{ paginator.count|pluralize:"es" }}</div>

--- a/templates/classes/public/_list_results.html
+++ b/templates/classes/public/_list_results.html
@@ -1,10 +1,22 @@
 {% load classes_tags static %}
 {% comment %}Results grid — rendered standalone for HTMX swaps and embedded into
 list.html for the initial full-page response.{% endcomment %}
+{% if is_htmx %}
+  {% comment %}Keep the hero "Classes" tile in sync with the filtered card count.
+  Rendered ONLY on HTMX responses (is_htmx) so it never appears as a stray
+  duplicate inside #cls-results on a full page load; HTMX matches it by id and
+  swaps the real tile up in the hero.{% endcomment %}
+  <div id="hero-classes-stat" hx-swap-oob="true">{% include "classes/public/_hero_classes_stat.html" %}</div>
+{% endif %}
 <div class="cp-results__summary">
   {% if paginator.count %}
     Showing <strong>{{ page_obj.start_index }}–{{ page_obj.end_index }}</strong> of <strong>{{ paginator.count }}</strong> class{{ paginator.count|pluralize:"es" }}
     {% if paginator.num_pages > 1 %}&mdash; page {{ page_obj.number }} of {{ paginator.num_pages }}{% endif %}
+  {% elif selected_within_days %}
+    <em>No classes scheduled in the next {{ selected_within_days }} days.</em>
+    <a class="cp-results__reset-inline"
+       hx-get="{% url 'classes:public_list' %}{% if filter_querystring_no_within %}?{{ filter_querystring_no_within }}{% endif %}"
+       hx-target="#cls-results" hx-swap="innerHTML" hx-push-url="true">Show all upcoming</a>
   {% else %}
     <em>No classes match your filters.</em>
     <a href="{% url 'classes:public_list' %}" class="cp-results__reset-inline">Reset all filters</a>

--- a/templates/classes/public/list.html
+++ b/templates/classes/public/list.html
@@ -8,7 +8,7 @@
   <h1>Classes <span>&amp;</span> Workshops Catalog</h1>
   <p>Learn blacksmithing, lampworking, ceramics, framing, and more from working artists in Portland's largest makerspace.</p>
   <div id="hero-stats">
-    <div><div class="hs-n">{{ upcoming_session_count }}</div><div class="hs-l">Upcoming Session{{ upcoming_session_count|pluralize }}</div></div>
+    <div id="hero-classes-stat">{% include "classes/public/_hero_classes_stat.html" %}</div>
     <div><div class="hs-n">{{ total_categories }}</div><div class="hs-l">Guilds</div></div>
     <div><div class="hs-n">{{ total_instructors }}</div><div class="hs-l">Instructors</div></div>
   </div>
@@ -35,6 +35,7 @@
       hx-swap="innerHTML"
       hx-push-url="true"
       hx-trigger="change, submit"
+      hx-indicator="#cls-results"
       x-data="{ open: false }">
   <div class="cp-filter__row">
     <label class="cp-filter__field cp-filter__field--select">
@@ -44,6 +45,16 @@
         {% for cat in categories %}
           <option value="{{ cat.slug }}" {% if selected_category_slug == cat.slug %}selected{% endif %}>{{ cat.name }} ({{ cat.class_count }})</option>
         {% endfor %}
+      </select>
+    </label>
+
+    <label class="cp-filter__field cp-filter__field--select">
+      <span class="cp-filter__field-label">When</span>
+      <select name="within" class="cp-filter__select">
+        <option value="all" {% if selected_within == "all" %}selected{% endif %}>All upcoming</option>
+        <option value="30" {% if selected_within == "30" %}selected{% endif %}>Next 30 days</option>
+        <option value="90" {% if selected_within == "90" %}selected{% endif %}>Next 90 days</option>
+        <option value="180" {% if selected_within == "180" %}selected{% endif %}>Next 180 days</option>
       </select>
     </label>
 


### PR DESCRIPTION
Adds a visible 30/90/180/all timeframe selector to /classes/ and fixes the confusing "32 upcoming vs ~5 shown" — the headline now counts the same grouped cards you see (kept in sync across HTMX filters), and flexible/undated classes aren't dropped by a window. 57 tests pass. A v21 hot-fix.

https://claude.ai/code/session_0129pLhnnoZtmYiSze9jDuRF