### PR TITLE
[release-email] v22 feature screenshots for the release email (v0.22.10)

### DIFF
--- a/core/release_email.py
+++ b/core/release_email.py
@@ -75,6 +75,7 @@ FEATURE_PAGES: list[FeaturePage] = [
     FeaturePage(slug="guild-directory", label="Guilds directory", url_name="hub_guild_directory"),
     FeaturePage(slug="notifications", label="Notifications page", url_name="notification_list"),
     FeaturePage(slug="community-calendar", label="Community Calendar", url_name="hub_community_calendar"),
+    FeaturePage(slug="profile-settings", label="Profile settings", url_name="hub_user_settings", query="?tab=profile"),
 ]
 
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.22.9"
+VERSION = "0.22.10"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "Events in Discord",
         "changes": [
@@ -18,9 +18,10 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "Studio Hours on guild pages",
+        "screenshot": "guild-pages",
         "changes": [
             (
                 "Guild leads can now set their weekly studio hours and meetings right in the app, and "
@@ -31,7 +32,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "Slash commands in Discord",
         "changes": [
@@ -48,7 +49,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "A warm welcome when you finish orientation",
         "changes": [
@@ -60,7 +61,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "Know your reach before you post",
         "changes": [
@@ -72,7 +73,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "Jump straight to a guild's classes",
         "changes": [
@@ -84,7 +85,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "Class reminder emails read cleanly again",
         "changes": [
@@ -95,9 +96,10 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "A cleaner profile, with your own contact links",
+        "screenshot": "profile-settings",
         "changes": [
             (
                 "Your profile settings now split into a Member tab and an Instructor tab, so your teaching "
@@ -114,7 +116,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.22.9",
+        "version": "0.22.10",
         "date": "2026-07-16",
         "title": "Easier-to-read class confirmation screens",
         "changes": [

--- a/tests/e2e/screenshots_spec.py
+++ b/tests/e2e/screenshots_spec.py
@@ -193,6 +193,7 @@ def _seed_member_hub(member: Member) -> None:
         GuildFactory,
         GuildFAQItemFactory,
         GuildMembershipFactory,
+        MemberContactFactory,
         MemberFactory,
         OrgInfoPageFactory,
     )
@@ -249,6 +250,51 @@ def _seed_member_hub(member: Member) -> None:
         title="Open Studio Night",
         starts_at=timezone.now() + timedelta(days=5),
     )
+    # Studio Hours card + weekly meeting on the guild page (0.22): two standing weekly
+    # blocks and a repeating meeting, so the "guild pages" shot shows the new cards.
+    local_now = timezone.localtime()
+    tue = (local_now + timedelta(days=(1 - local_now.weekday()) % 7 or 7)).replace(
+        hour=18, minute=0, second=0, microsecond=0
+    )
+    sat = (local_now + timedelta(days=(5 - local_now.weekday()) % 7 or 7)).replace(
+        hour=10, minute=0, second=0, microsecond=0
+    )
+    CommunityEventFactory(
+        guild=guilds[0],
+        studio_hours=True,
+        title="Ceramics studio hours",
+        starts_at=tue,
+        ends_at=tue + timedelta(hours=3),
+        location="Ceramics studio",
+        description="Drop in — a lead is around to chat.",
+    )
+    CommunityEventFactory(
+        guild=guilds[0],
+        studio_hours=True,
+        title="Ceramics studio hours",
+        starts_at=sat,
+        ends_at=sat + timedelta(hours=2),
+        location="Ceramics studio",
+    )
+    CommunityEventFactory(
+        guild=guilds[0],
+        title="Ceramics Guild meeting",
+        recurrence="weekly",
+        starts_at=tue + timedelta(days=1),
+        ends_at=tue + timedelta(days=1, hours=1),
+        location="Community room",
+    )
+    # Profile settings (0.22): instructor bio + labeled contact links for the split
+    # Member/Instructor profile tabs.
+    member.instructor_bio = (
+        "I've cast bronze and silver for fifteen years and taught studio classes for eight. "
+        "My classes are hands-on from the first hour — expect to leave with something you made."
+    )
+    member.save(update_fields=["instructor_bio"])
+    MemberContactFactory(
+        member=member, label="Website", value="https://robinmaker.example.com", show_on_instructor_page=True
+    )
+    MemberContactFactory(member=member, label="Instagram", value="@robin.makes", show_on_instructor_page=True)
     MemberFactory.create_batch(4)
 
 
@@ -451,6 +497,12 @@ def describe_feature_screenshots():
         targets: list[tuple[str, str, str, bool]] = [(s, lbl, p, False) for s, lbl, p in _feature_pages()]
         targets.append(("guild-pages", "Guild page", reverse("hub_guild_detail", kwargs={"slug": guild.slug}), False))
         targets.append(("qr-codes", "Guild QR flyer", reverse("hub_guild_flyer", kwargs={"pk": guild.pk}), True))
+
+        # Optional narrowing: CAPTURE_SLUGS=guild-pages,profile-settings re-shoots only
+        # those pages, leaving every other slug's R2 asset untouched.
+        only = {s.strip() for s in os.environ.get("CAPTURE_SLUGS", "").split(",") if s.strip()}
+        if only:
+            targets = [t for t in targets if t[0] in only]
 
         results: list[dict[str, object]] = []
         for slug, label, path, full_page in targets:


### PR DESCRIPTION
## What

Wires screenshots into the v22 member release email so the blast (and the Discord announce) go out with visuals:

- **New `profile-settings` FeaturePage** (User Settings → Profile tab) in the release-email registry.
- **Capture-harness seeds for the 0.22 features**: studio hours blocks + a weekly meeting on the Ceramics Guild (so the `guild-pages` shot shows the new Studio Hours card and Next Meeting chip), and instructor bio + labeled contact links (so the `profile-settings` shot shows the split Member/Instructor tabs).
- **`CAPTURE_SLUGS` env filter** for the capture run — re-shoot selected slugs without touching the other R2 assets.
- **Changelog**: `screenshot` slugs on the two 0.22 entries; batch re-stamped at **0.22.10** (the Discord announce for the line hasn't been dispatched yet, so it still posts as one release).

Both shots are already captured and live on R2 at their stable keys — merging this makes the prod `send_release_email --lines 0.22` render them.

## Test plan

- `release_email_spec`, `send_release_email_command_spec`, `release_announcement_spec`, `context_processors_spec` — 75 passed.
- ruff format/check + mypy clean on changed app files.
- Test email rendered and sent end-to-end (2 cards with screenshots, links resolve to members.pastlives.space).