### PR TITLE
[discord] /info guild dropdown (v0.23.1)

### DIFF
--- a/membership/discord_commands.py
+++ b/membership/discord_commands.py
@@ -210,11 +210,36 @@ def _info(interaction: Interaction, member: Member | None) -> dict:
     return reply(f"Here's **{guild.name}** on Past Lives:", ephemeral=False, embeds=[embed])
 
 
+def _info_guild_choices() -> list[dict]:
+    """The ``guild`` option for ``/info`` — a dropdown of active guilds, like ``/join-guild``.
+
+    Mirrors that command's picker (each choice's value is the guild ``slug``, resolved by
+    :func:`resolve_command_guild`), but stays ``required=False`` so a member can still omit it
+    to use the current channel's guild. Built at *serialization* time (inside
+    ``register_discord_commands`` → :meth:`SlashCommand.to_api_dict`), so the DB query is safe;
+    capped at Discord's 25-choice limit; ships without a ``choices`` key when there are no active
+    guilds (an empty-choices option would 400 Discord's bulk command PUT, leaving the free-text
+    field the lenient resolver still accepts).
+    """
+    from membership.models import Guild
+
+    guilds = list(Guild.objects.filter(is_active=True).order_by("name"))[:25]
+    option: dict = {
+        "name": "guild",
+        "description": "Which guild — pick one, or omit to use this channel's guild.",
+        "type": 3,
+        "required": False,
+    }
+    if guilds:
+        option["choices"] = [{"name": g.name, "value": g.slug} for g in guilds]
+    return [option]
+
+
 INFO = SlashCommand(
     name="info",
     description="Show a guild's rules, next meeting, FAQ, links, and staff.",
     handler=_info,
-    options=[_GUILD_OPTION],
+    options_builder=_info_guild_choices,
     requires_link=False,
     ephemeral=False,
     defer=False,

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.0"
+VERSION = "0.23.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.1",
+        "date": "2026-07-18",
+        "title": "Pick a guild from a dropdown for /info",
+        "changes": [
+            (
+                "The /info command in Discord now gives you a dropdown of guilds to choose from — the same as "
+                "/join-guild — instead of typing the name. Leave it blank to use the current channel's guild."
+            ),
+        ],
+    },
     {
         "version": "0.23.0",
         "date": "2026-07-17",

--- a/tests/core/events/info_command_spec.py
+++ b/tests/core/events/info_command_spec.py
@@ -33,10 +33,23 @@ def _field(result: dict, name: str) -> str:
 
 
 def describe_info_command_definition():
-    def it_is_public_ungated_immediate_with_a_guild_option():
+    def it_is_public_ungated_immediate_with_a_guild_dropdown():
+        GuildFactory(name="Ceramics Guild")
+        GuildFactory(name="Textiles Guild")
         assert INFO.name == "info"
         assert (INFO.requires_link, INFO.ephemeral, INFO.defer) == (False, False, False)
-        assert [o["name"] for o in INFO.options] == ["guild"]
+        # The guild option is a dropdown built at registration time (like /join-guild),
+        # each choice's value the guild slug, and still optional (omit → channel's guild).
+        opts = INFO.to_api_dict()["options"]
+        assert [o["name"] for o in opts] == ["guild"]
+        assert opts[0]["required"] is False
+        values = {c["value"] for c in opts[0]["choices"]}
+        assert {"ceramics-guild", "textiles-guild"} <= values
+
+    def it_resolves_a_guild_picked_from_the_dropdown_by_slug():
+        GuildFactory(name="Fibers Guild", slug="fibers-guild", about="Weaving and dyeing.")
+        result = _info({"data": {"options": [{"name": "guild", "value": "fibers-guild"}]}}, None)
+        assert "Fibers Guild" in result["data"]["embeds"][0]["title"]
 
 
 def describe_info():


### PR DESCRIPTION
The `/info` Discord command now offers a **dropdown of guilds** to pick from — the same picker `/join-guild` uses — instead of typing the guild name. Still optional (omit → the current channel's guild).

- New `_info_guild_choices` options_builder in `membership/discord_commands.py` (mirrors `/join-guild`'s `_guild_choices`: choices built at registration time, value = slug, 25-cap, empty-guard). Handler unchanged — `resolve_command_guild` already matches by name/slug.
- `info_command_spec` updated: asserts the dropdown choices + that a slug value resolves.
- VERSION → 0.23.1, one member-facing changelog entry.

Post-merge: re-run `register_discord_commands` so the new `/info` choices register.