### PR TITLE
[calendar] Suppress feed echoes of pushed events + honor Discord 429 (v0.23.4)

### DIFF
--- a/core/integrations/discord_events.py
+++ b/core/integrations/discord_events.py
@@ -108,32 +108,49 @@ class DiscordScheduledEventsClient:
     def server_id(self) -> str:
         return self._server_id
 
-    def insert_event(self, server_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    def insert_event(
+        self, server_id: str, body: dict[str, Any], *, retry_on_rate_limit: bool = False
+    ) -> dict[str, Any]:
         """Create a Scheduled Event; return the event resource (with ``id``)."""
-        return self._execute("POST", f"/guilds/{server_id}/scheduled-events", json=body)
+        return self._execute(
+            "POST", f"/guilds/{server_id}/scheduled-events", json=body, retry_on_rate_limit=retry_on_rate_limit
+        )
 
-    def update_event(self, server_id: str, event_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    def update_event(
+        self, server_id: str, event_id: str, body: dict[str, Any], *, retry_on_rate_limit: bool = False
+    ) -> dict[str, Any]:
         """Patch an existing Scheduled Event; return the updated event resource."""
-        return self._execute("PATCH", f"/guilds/{server_id}/scheduled-events/{event_id}", json=body)
+        return self._execute(
+            "PATCH",
+            f"/guilds/{server_id}/scheduled-events/{event_id}",
+            json=body,
+            retry_on_rate_limit=retry_on_rate_limit,
+        )
 
-    def delete_event(self, server_id: str, event_id: str) -> None:
+    def delete_event(self, server_id: str, event_id: str, *, retry_on_rate_limit: bool = False) -> None:
         """Delete a Scheduled Event. Wraps API errors (caller catches one type)."""
-        self._execute("DELETE", f"/guilds/{server_id}/scheduled-events/{event_id}")
+        self._execute(
+            "DELETE", f"/guilds/{server_id}/scheduled-events/{event_id}", retry_on_rate_limit=retry_on_rate_limit
+        )
 
     @staticmethod
-    def _execute(method: str, path: str, *, json: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _execute(
+        method: str, path: str, *, json: dict[str, Any] | None = None, retry_on_rate_limit: bool = False
+    ) -> dict[str, Any]:
         """Run a bot-authed REST call, translating any failure into :class:`DiscordEventsError`
         so callers catch one exception type (mirrors ``GoogleCalendarClient._execute``).
 
         Both a transport failure (``httpx.HTTPError``) and a non-2xx status become a
         ``DiscordEventsError``; a 2xx with an empty body (a ``DELETE`` 204) returns ``{}``.
-        A 429 is retried once after Discord's ``Retry-After`` — the scheduled-events
-        bucket is tiny, so the daily mirror's burst of ~a-dozen calls reliably trips it
-        mid-run; waiting the advertised second or two clears it. A 429 with no usable or
-        too-long ``Retry-After`` still raises.
+        With ``retry_on_rate_limit`` a 429 is retried once after Discord's ``Retry-After``
+        — the scheduled-events bucket is tiny, so the daily mirror's burst of ~a-dozen
+        calls reliably trips it mid-run; waiting the advertised second or two clears it.
+        Only batch paths opt in: an interactive FOG save should fail fast into the retry
+        cron, not hang the request sleeping. A 429 without the flag, or with no usable or
+        too-long ``Retry-After``, raises immediately.
         """
         response = DiscordScheduledEventsClient._send(method, path, json=json)
-        if response.status_code == 429:
+        if response.status_code == 429 and retry_on_rate_limit:
             retry_after = _retry_after_seconds(response)
             if retry_after is not None and retry_after <= _RATE_LIMIT_MAX_WAIT_SECONDS:
                 time.sleep(retry_after)

--- a/core/integrations/discord_events.py
+++ b/core/integrations/discord_events.py
@@ -31,6 +31,7 @@ clean — exactly as ``push_to_google`` does.
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -51,6 +52,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_LOCATION = "Past Lives Makerspace"
 
 _TIMEOUT_SECONDS = 5.0
+_RATE_LIMIT_MAX_WAIT_SECONDS = 15.0
 _SYNC_ERROR_MAX = 500
 _NAME_MAX = 100
 _LOCATION_MAX = 100
@@ -125,9 +127,26 @@ class DiscordScheduledEventsClient:
 
         Both a transport failure (``httpx.HTTPError``) and a non-2xx status become a
         ``DiscordEventsError``; a 2xx with an empty body (a ``DELETE`` 204) returns ``{}``.
+        A 429 is retried once after Discord's ``Retry-After`` — the scheduled-events
+        bucket is tiny, so the daily mirror's burst of ~a-dozen calls reliably trips it
+        mid-run; waiting the advertised second or two clears it. A 429 with no usable or
+        too-long ``Retry-After`` still raises.
         """
+        response = DiscordScheduledEventsClient._send(method, path, json=json)
+        if response.status_code == 429:
+            retry_after = _retry_after_seconds(response)
+            if retry_after is not None and retry_after <= _RATE_LIMIT_MAX_WAIT_SECONDS:
+                time.sleep(retry_after)
+                response = DiscordScheduledEventsClient._send(method, path, json=json)
+        if not response.is_success:
+            raise DiscordEventsError(f"Discord API {response.status_code}: {response.text[:300]}")
+        return response.json() if response.content else {}
+
+    @staticmethod
+    def _send(method: str, path: str, *, json: dict[str, Any] | None = None) -> httpx.Response:
+        """One raw REST call; only transport failures raise (as :class:`DiscordEventsError`)."""
         try:
-            response = httpx.request(
+            return httpx.request(
                 method,
                 f"{API_BASE}{path}",
                 json=json,
@@ -136,9 +155,17 @@ class DiscordScheduledEventsClient:
             )
         except httpx.HTTPError as exc:
             raise DiscordEventsError(str(exc)) from exc
-        if not response.is_success:
-            raise DiscordEventsError(f"Discord API {response.status_code}: {response.text[:300]}")
-        return response.json() if response.content else {}
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    """Seconds Discord asks us to wait on a 429, or ``None`` when absent/unparseable."""
+    header = response.headers.get("Retry-After")
+    if not header:
+        return None
+    try:
+        return float(header)
+    except ValueError:
+        return None
 
 
 def _build_description(event: CommunityEvent) -> str:

--- a/hub/calendar_service.py
+++ b/hub/calendar_service.py
@@ -390,12 +390,11 @@ def sync_local_class_events() -> int:
         starts_at__lte=horizon,
     ).select_related("class_offering", "class_offering__category")
 
-    kept_uids: list[str] = []
+    kept_pks: list[int] = []
     for session in qs:
         offering = session.class_offering
         uid = f"local-class-{session.pk}"
-        kept_uids.append(uid)
-        CalendarEvent.objects.update_or_create(
+        event, _created = CalendarEvent.objects.update_or_create(
             guild=offering.category.guild,
             uid=uid,
             defaults={
@@ -410,16 +409,19 @@ def sync_local_class_events() -> int:
                 "fetched_at": now,
             },
         )
+        kept_pks.append(event.pk)
 
-    # Purge every "classes" event not backed by a live local session — stale
-    # local-class rows and any leftover legacy classes-* rows from the retired
-    # Drupal calendar feed.
-    CalendarEvent.objects.filter(source="classes").exclude(uid__in=kept_uids).delete()
+    # Purge every "classes" event row we didn't just touch — stale local-class rows,
+    # leftover legacy classes-* rows from the retired Drupal calendar feed, AND the
+    # old-guild copy of a class whose category moved guilds (guild is part of the
+    # upsert key above, so a re-guilded class lands in a NEW row; matching on uid
+    # alone would keep the old copy and double-list the class).
+    CalendarEvent.objects.filter(source="classes").exclude(pk__in=kept_pks).delete()
 
     config = SiteConfiguration.load()
     config.classes_last_synced_at = now
     config.save(update_fields=["classes_last_synced_at"])
-    return len(kept_uids)
+    return len(kept_pks)
 
 
 def _run_source(label: str, sync: Callable[[], object], errors: list[str]) -> None:

--- a/hub/calendar_service.py
+++ b/hub/calendar_service.py
@@ -140,7 +140,7 @@ def _pushed_event_uids() -> set[str]:
     UID. Importing those copies would double-list every pushed event (and the Discord
     mirror would then duplicate its Scheduled Event too) — they must be skipped.
     """
-    return set(CommunityEvent.objects.exclude(google_ical_uid="").values_list("google_ical_uid", flat=True))
+    return set(CommunityEvent.objects.pushed().values_list("google_ical_uid", flat=True))
 
 
 def _upsert_events(
@@ -268,11 +268,15 @@ def sync_discord_feed_events() -> int:
     from core.integrations.discord_events import DiscordEventsError, DiscordScheduledEventsClient
 
     client = DiscordScheduledEventsClient.from_settings()
-    if not client.enabled:
-        return 0
-
     now = timezone.now()
     echo_uids = _pushed_event_uids()
+    if not client.enabled:
+        # Echo rows with no live future Discord copy need no API call to clean up —
+        # purge them even while Discord sync is off, so they don't linger on the
+        # calendar waiting for the toggle.
+        _purge_echoed_feed_events(echo_uids, now)
+        return 0
+
     push_set = list(
         CalendarEvent.objects.filter(
             source=CalendarEvent.Source.GENERAL,
@@ -319,13 +323,13 @@ def _push_feed_event(client: DiscordScheduledEventsClient, event: CalendarEvent)
     body = _discord_event_body(event)
     if event.discord_event_id:
         try:
-            client.update_event(client.server_id, event.discord_event_id, body)
+            client.update_event(client.server_id, event.discord_event_id, body, retry_on_rate_limit=True)
         except DiscordEventsError as exc:
             if "404" not in str(exc):
                 raise
             event.discord_event_id = ""  # deleted on Discord's side — recreate below
     if not event.discord_event_id:
-        created = client.insert_event(client.server_id, body)
+        created = client.insert_event(client.server_id, body, retry_on_rate_limit=True)
         event.discord_event_id = created["id"]
         event.save(update_fields=["discord_event_id"])
 
@@ -335,7 +339,7 @@ def _delete_feed_event_copy(client: DiscordScheduledEventsClient, event: Calenda
     from core.integrations.discord_events import DiscordEventsError
 
     try:
-        client.delete_event(client.server_id, event.discord_event_id)
+        client.delete_event(client.server_id, event.discord_event_id, retry_on_rate_limit=True)
     except DiscordEventsError as exc:
         if "404" not in str(exc):
             raise

--- a/hub/calendar_service.py
+++ b/hub/calendar_service.py
@@ -10,10 +10,11 @@ from datetime import timezone as dt_timezone
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
+from django.db.models import Q
 from django.utils import timezone
 
 from core.models import CalendarFeed, SiteConfiguration
-from membership.models import CalendarEvent, Guild
+from membership.models import CalendarEvent, CommunityEvent, Guild
 
 if TYPE_CHECKING:
     from core.integrations.discord_events import DiscordScheduledEventsClient
@@ -131,6 +132,17 @@ def _fetch_and_parse(url: str, window_start: datetime, window_end: datetime) -> 
     return _parse_ical_events(raw, window_start, window_end)
 
 
+def _pushed_event_uids() -> set[str]:
+    """iCal UIDs of CommunityEvents we ourselves pushed to Google Calendar.
+
+    The Member/Public calendars we push to are the same calendars the general feeds
+    re-import, so our own events come back in the feed under their Google-assigned
+    UID. Importing those copies would double-list every pushed event (and the Discord
+    mirror would then duplicate its Scheduled Event too) — they must be skipped.
+    """
+    return set(CommunityEvent.objects.exclude(google_ical_uid="").values_list("google_ical_uid", flat=True))
+
+
 def _upsert_events(
     events: list[dict[str, Any]],
     guild: Guild | None,
@@ -141,9 +153,12 @@ def _upsert_events(
 
     Uniqueness is per-``(guild, feed, uid, recurrence_id)`` so each occurrence of a recurring
     series gets its own row, and two ``CalendarFeed`` rows whose upstream calendars happen to
-    share a UID don't clobber each other.
+    share a UID don't clobber each other. Echoes of our own Google-pushed CommunityEvents
+    (see :func:`_pushed_event_uids`) are skipped, not imported.
     """
     now = timezone.now()
+    echo_uids = _pushed_event_uids()
+    events = [evt for evt in events if evt["uid"] not in echo_uids]
     for evt in events:
         CalendarEvent.objects.update_or_create(
             guild=guild,
@@ -241,8 +256,11 @@ def sync_discord_feed_events() -> int:
     without one, updates rows already pushed, and recreates a row whose Discord copy was
     deleted by hand (an update 404). A still-future row that dropped out of the push set
     (date moved, or pushed under an older horizon) has its Discord copy deleted; past
-    events are left to Discord's own lifecycle. Returns the number of events in the push
-    set, or 0 when Discord Events sync is disabled.
+    events are left to Discord's own lifecycle. Echoes of our own Google-pushed
+    CommunityEvents are excluded from the push set — the dropped pass deletes any Discord
+    copies they gained before echo suppression existed, then the rows themselves are
+    purged. Returns the number of events in the push set, or 0 when Discord Events sync
+    is disabled.
 
     Every event is attempted even when one fails; failures are then raised as one
     :class:`DiscordEventsError` so ``sync_all_sources`` records the source as failed.
@@ -254,12 +272,15 @@ def sync_discord_feed_events() -> int:
         return 0
 
     now = timezone.now()
+    echo_uids = _pushed_event_uids()
     push_set = list(
         CalendarEvent.objects.filter(
             source=CalendarEvent.Source.GENERAL,
             start_dt__gte=now,
             start_dt__lte=now + _DISCORD_PUSH_HORIZON,
-        ).order_by("start_dt")[:_DISCORD_PUSH_CAP]
+        )
+        .exclude(uid__in=echo_uids)
+        .order_by("start_dt")[:_DISCORD_PUSH_CAP]
     )
     failures: list[str] = []
 
@@ -279,6 +300,8 @@ def sync_discord_feed_events() -> int:
             _delete_feed_event_copy(client, event)
         except DiscordEventsError as exc:
             failures.append(f"'{event.title}': {exc}")
+
+    _purge_echoed_feed_events(echo_uids, now)
 
     if failures:
         raise DiscordEventsError(f"{len(failures)} Discord event push(es) failed; first: {failures[0]}")
@@ -318,6 +341,18 @@ def _delete_feed_event_copy(client: DiscordScheduledEventsClient, event: Calenda
             raise
     event.discord_event_id = ""
     event.save(update_fields=["discord_event_id"])
+
+
+def _purge_echoed_feed_events(echo_uids: set[str], now: datetime) -> None:
+    """Delete feed rows that are echoes of our own Google-pushed CommunityEvents.
+
+    Only rows with no live future Discord copy are removed: a future row still holding a
+    ``discord_event_id`` means its Discord delete failed this run, so it survives to
+    retry next sweep; a past row's Discord copy is already finished and needs no delete.
+    """
+    CalendarEvent.objects.filter(source=CalendarEvent.Source.GENERAL, uid__in=echo_uids).filter(
+        Q(discord_event_id="") | Q(start_dt__lt=now)
+    ).delete()
 
 
 def sync_local_class_events() -> int:

--- a/hub/views.py
+++ b/hub/views.py
@@ -3505,15 +3505,9 @@ def community_calendar(request: HttpRequest) -> HttpResponse:
     ctx = _get_hub_context(request)
     cal_ctx = _get_calendar_context(request)
 
-    default_filters = ["community"]
-    for feed in cal_ctx["calendar_feeds"]:
-        default_filters.append(f"feed-{feed.pk}")
-    if cal_ctx["has_ungrouped_classes"]:
-        default_filters.append("classes")
-    for g in cal_ctx["legend_guilds"]:
-        default_filters.append(str(g.pk))
-
-    cal_ctx["default_filters_json"] = json.dumps(default_filters).replace('"', '\\"')
+    # No default_filters_json here: the Community Calendar persists *disabled*
+    # filters client-side, so every legend key — including ones added later —
+    # defaults to visible without a seeded enabled-list.
     cal_ctx["events_url"] = reverse("hub_community_calendar_events")
 
     view_as = getattr(request, "view_as", None)

--- a/hub/views.py
+++ b/hub/views.py
@@ -545,15 +545,9 @@ def guild_detail(request: HttpRequest, slug: str) -> HttpResponse:
     upcoming_classes = guild_classes.bookable().select_related("instructor")[:4]
     calendar = _get_calendar_context(request, guild=guild)
     calendar["events_url"] = reverse("hub_guild_calendar_events", args=[guild.pk])
-    # Seed the guild-tab defaults with each legend guild's key (this guild always
-    # earns one — its classes key by str(pk)) plus the "Other classes" fallback only
-    # when a no-guild class shows here, so the guild's own classes are visible + on.
-    guild_cal_filters = ["orientation", "community"]
-    if calendar["has_ungrouped_classes"]:
-        guild_cal_filters.append("classes")
-    for g in calendar["legend_guilds"]:
-        guild_cal_filters.append(str(g.pk))
-    calendar["default_filters_json"] = json.dumps(guild_cal_filters).replace('"', '\\"')
+    # No default_filters_json: the guild calendar persists *disabled* filters
+    # client-side (like the Community Calendar), so every legend key — including
+    # this guild's own classes key — defaults to visible without a seeded list.
     pulse = _guild_pulse(guild)
 
     from membership.models import GuildOrientationSettings

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.3"
+VERSION = "0.23.4"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.23.3",
-        "date": "2026-07-20",
+        "version": "0.23.4",
+        "date": "2026-07-21",
         "title": "Community Calendar events are back — and coming to Discord",
         "changes": [
             (
@@ -21,8 +21,8 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.23.3",
-        "date": "2026-07-20",
+        "version": "0.23.4",
+        "date": "2026-07-21",
         "title": "Classes stay filed under their guilds",
         "changes": [
             (

--- a/templates/hub/community_calendar.html
+++ b/templates/hub/community_calendar.html
@@ -75,42 +75,26 @@
     x-show="tab === 'calendar'"
     x-data="{
         calView: localStorage.getItem('calView') || 'week',
-        activeFilters: JSON.parse(localStorage.getItem('calFilters') || '{{ default_filters_json }}'),
+        disabledFilters: JSON.parse(localStorage.getItem('calFiltersOff') || '[]'),
         init() {
-            // One-time rollout: turn the new 'community' source ON for members who saved
-            // filters before it existed, so guild/community events aren't hidden. The
-            // marker makes it happen once, so a later manual removal of it sticks.
-            if (!localStorage.getItem('calCommunityRollout')) {
-                if (localStorage.getItem('calFilters') && !this.activeFilters.includes('community')) {
-                    this.activeFilters.push('community');
-                    localStorage.setItem('calFilters', JSON.stringify(this.activeFilters));
-                }
-                localStorage.setItem('calCommunityRollout', '1');
-            }
-            // One-time rollout: classes used to share a single 'classes' toggle; they
-            // now group under each guild's key. Migrate a returning member who had
-            // classes visible so their guild-grouped classes stay visible instead of
-            // vanishing under a key that no longer controls them.
-            if (!localStorage.getItem('calGuildClassesRollout')) {
-                if (localStorage.getItem('calFilters') && this.activeFilters.includes('classes')) {
-                    {% for g in legend_guilds %}
-                    if (!this.activeFilters.includes('{{ g.pk }}')) { this.activeFilters.push('{{ g.pk }}'); }
-                    {% endfor %}
-                    localStorage.setItem('calFilters', JSON.stringify(this.activeFilters));
-                }
-                localStorage.setItem('calGuildClassesRollout', '1');
-            }
+            // Filters used to persist as an enabled-list, which silently hid any
+            // guild or feed added to the legend after a member's first visit (each
+            // addition needed its own one-time rollout hack). Storage is now the
+            // disabled-list — every key defaults ON, forever, including future ones.
+            // Drop the legacy keys once; a member who had hidden a source re-hides
+            // it with one click.
+            ['calFilters', 'calCommunityRollout', 'calGuildClassesRollout'].forEach(k => localStorage.removeItem(k));
         },
         setView(v) { this.calView = v; localStorage.setItem('calView', v); },
         toggleFilter(key) {
-            if (this.activeFilters.includes(key)) {
-                this.activeFilters = this.activeFilters.filter(k => k !== key);
+            if (this.disabledFilters.includes(key)) {
+                this.disabledFilters = this.disabledFilters.filter(k => k !== key);
             } else {
-                this.activeFilters.push(key);
+                this.disabledFilters.push(key);
             }
-            localStorage.setItem('calFilters', JSON.stringify(this.activeFilters));
+            localStorage.setItem('calFiltersOff', JSON.stringify(this.disabledFilters));
         },
-        isActive(key) { return this.activeFilters.includes(key); },
+        isActive(key) { return !this.disabledFilters.includes(key); },
         flashTarget(pk) {
             const matches = document.querySelectorAll('.pl-calendar-list__item[data-event-pk=\'' + pk + '\']');
             const target = Array.from(matches).find(el => el.offsetParent !== null) || matches[0];

--- a/templates/hub/partials/guild_calendar_app.html
+++ b/templates/hub/partials/guild_calendar_app.html
@@ -8,40 +8,23 @@ Context: `cal` = the calendar context dict; `guild` = the Guild.
 <div
     x-data="{
         calView: localStorage.getItem('guildCalView') || 'week',
-        activeFilters: JSON.parse(localStorage.getItem('guildCalFilters-{{ guild.pk }}') || '{{ cal.default_filters_json }}'),
+        disabledFilters: JSON.parse(localStorage.getItem('guildCalFiltersOff-{{ guild.pk }}') || '[]'),
         init() {
-            // One-time rollout: turn the new 'community' source ON for members who saved
-            // this guild's filters before it existed. The marker makes it happen once.
-            if (!localStorage.getItem('guildCalCommunityRollout-{{ guild.pk }}')) {
-                if (localStorage.getItem('guildCalFilters-{{ guild.pk }}') && !this.activeFilters.includes('community')) {
-                    this.activeFilters.push('community');
-                    localStorage.setItem('guildCalFilters-{{ guild.pk }}', JSON.stringify(this.activeFilters));
-                }
-                localStorage.setItem('guildCalCommunityRollout-{{ guild.pk }}', '1');
-            }
-            // One-time rollout: this guild's classes used to sit under a single 'classes'
-            // toggle; they now group under the guild's own key. Migrate a returning member
-            // who had classes visible so their classes stay visible on this tab.
-            if (!localStorage.getItem('guildCalClassesRollout-{{ guild.pk }}')) {
-                if (localStorage.getItem('guildCalFilters-{{ guild.pk }}') && this.activeFilters.includes('classes')) {
-                    {% for g in cal.legend_guilds %}
-                    if (!this.activeFilters.includes('{{ g.pk }}')) { this.activeFilters.push('{{ g.pk }}'); }
-                    {% endfor %}
-                    localStorage.setItem('guildCalFilters-{{ guild.pk }}', JSON.stringify(this.activeFilters));
-                }
-                localStorage.setItem('guildCalClassesRollout-{{ guild.pk }}', '1');
-            }
+            // Same inversion as the Community Calendar: persist the *disabled* list so
+            // every legend key — including ones added after a member's first visit —
+            // defaults ON without per-addition rollout hacks. Drop the legacy keys once.
+            ['guildCalFilters-{{ guild.pk }}', 'guildCalCommunityRollout-{{ guild.pk }}', 'guildCalClassesRollout-{{ guild.pk }}'].forEach(k => localStorage.removeItem(k));
         },
         setView(v) { this.calView = v; localStorage.setItem('guildCalView', v); },
         toggleFilter(key) {
-            if (this.activeFilters.includes(key)) {
-                this.activeFilters = this.activeFilters.filter(k => k !== key);
+            if (this.disabledFilters.includes(key)) {
+                this.disabledFilters = this.disabledFilters.filter(k => k !== key);
             } else {
-                this.activeFilters.push(key);
+                this.disabledFilters.push(key);
             }
-            localStorage.setItem('guildCalFilters-{{ guild.pk }}', JSON.stringify(this.activeFilters));
+            localStorage.setItem('guildCalFiltersOff-{{ guild.pk }}', JSON.stringify(this.disabledFilters));
         },
-        isActive(key) { return this.activeFilters.includes(key); },
+        isActive(key) { return !this.disabledFilters.includes(key); },
         flashTarget(pk) {
             const matches = document.querySelectorAll('.pl-calendar-list__item[data-event-pk=\'' + pk + '\']');
             const target = Array.from(matches).find(el => el.offsetParent !== null) || matches[0];

--- a/tests/core/integrations/discord_events_spec.py
+++ b/tests/core/integrations/discord_events_spec.py
@@ -420,9 +420,26 @@ def describe_DiscordScheduledEventsClient():
             )
             client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
             with patch("core.integrations.discord_events.time.sleep") as fake_sleep:
-                assert client.insert_event(SERVER_ID, {"name": "x"}) == {"id": "e1"}
+                assert client.insert_event(SERVER_ID, {"name": "x"}, retry_on_rate_limit=True) == {"id": "e1"}
             fake_sleep.assert_called_once_with(1.5)
             assert route.call_count == 2
+
+        @respx.mock
+        def it_fails_fast_on_a_429_without_the_retry_flag(settings):
+            # Interactive FOG saves must not hang the request sleeping — only the
+            # batch mirror opts into the wait-and-retry.
+            settings.DISCORD_BOT_TOKEN = "tok"
+            route = respx.post(_EVENTS_URL).mock(
+                return_value=httpx.Response(429, json={"retry_after": 1.5}, headers={"Retry-After": "1.5"})
+            )
+            client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
+            with (
+                patch("core.integrations.discord_events.time.sleep") as fake_sleep,
+                pytest.raises(de.DiscordEventsError, match="429"),
+            ):
+                client.insert_event(SERVER_ID, {})
+            fake_sleep.assert_not_called()
+            assert route.call_count == 1
 
         @respx.mock
         def it_raises_when_the_retry_is_also_rate_limited(settings):
@@ -434,7 +451,7 @@ def describe_DiscordScheduledEventsClient():
                 patch("core.integrations.discord_events.time.sleep"),
                 pytest.raises(de.DiscordEventsError, match="429"),
             ):
-                client.insert_event(SERVER_ID, {})
+                client.insert_event(SERVER_ID, {}, retry_on_rate_limit=True)
             assert route.call_count == 2
 
         @respx.mock
@@ -446,7 +463,7 @@ def describe_DiscordScheduledEventsClient():
                 patch("core.integrations.discord_events.time.sleep") as fake_sleep,
                 pytest.raises(de.DiscordEventsError, match="429"),
             ):
-                client.insert_event(SERVER_ID, {})
+                client.insert_event(SERVER_ID, {}, retry_on_rate_limit=True)
             fake_sleep.assert_not_called()
             assert route.call_count == 1
 
@@ -459,7 +476,7 @@ def describe_DiscordScheduledEventsClient():
                 patch("core.integrations.discord_events.time.sleep") as fake_sleep,
                 pytest.raises(de.DiscordEventsError, match="429"),
             ):
-                client.insert_event(SERVER_ID, {})
+                client.insert_event(SERVER_ID, {}, retry_on_rate_limit=True)
             fake_sleep.assert_not_called()
             assert route.call_count == 1
 
@@ -474,6 +491,6 @@ def describe_DiscordScheduledEventsClient():
                 patch("core.integrations.discord_events.time.sleep") as fake_sleep,
                 pytest.raises(de.DiscordEventsError, match="429"),
             ):
-                client.insert_event(SERVER_ID, {})
+                client.insert_event(SERVER_ID, {}, retry_on_rate_limit=True)
             fake_sleep.assert_not_called()
             assert route.call_count == 1

--- a/tests/core/integrations/discord_events_spec.py
+++ b/tests/core/integrations/discord_events_spec.py
@@ -408,3 +408,72 @@ def describe_DiscordScheduledEventsClient():
             client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
             with pytest.raises(de.DiscordEventsError):
                 client.insert_event(SERVER_ID, {})
+
+        @respx.mock
+        def it_retries_once_after_a_rate_limits_advertised_wait(settings):
+            settings.DISCORD_BOT_TOKEN = "tok"
+            route = respx.post(_EVENTS_URL).mock(
+                side_effect=[
+                    httpx.Response(429, json={"retry_after": 1.5}, headers={"Retry-After": "1.5"}),
+                    httpx.Response(200, json={"id": "e1"}),
+                ]
+            )
+            client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
+            with patch("core.integrations.discord_events.time.sleep") as fake_sleep:
+                assert client.insert_event(SERVER_ID, {"name": "x"}) == {"id": "e1"}
+            fake_sleep.assert_called_once_with(1.5)
+            assert route.call_count == 2
+
+        @respx.mock
+        def it_raises_when_the_retry_is_also_rate_limited(settings):
+            settings.DISCORD_BOT_TOKEN = "tok"
+            rate_limited = httpx.Response(429, json={"retry_after": 1.0}, headers={"Retry-After": "1.0"})
+            route = respx.post(_EVENTS_URL).mock(side_effect=[rate_limited, rate_limited])
+            client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
+            with (
+                patch("core.integrations.discord_events.time.sleep"),
+                pytest.raises(de.DiscordEventsError, match="429"),
+            ):
+                client.insert_event(SERVER_ID, {})
+            assert route.call_count == 2
+
+        @respx.mock
+        def it_raises_without_retrying_when_a_429_has_no_usable_retry_after(settings):
+            settings.DISCORD_BOT_TOKEN = "tok"
+            route = respx.post(_EVENTS_URL).mock(return_value=httpx.Response(429, json={"global": True}))
+            client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
+            with (
+                patch("core.integrations.discord_events.time.sleep") as fake_sleep,
+                pytest.raises(de.DiscordEventsError, match="429"),
+            ):
+                client.insert_event(SERVER_ID, {})
+            fake_sleep.assert_not_called()
+            assert route.call_count == 1
+
+        @respx.mock
+        def it_raises_without_retrying_when_the_retry_after_is_malformed(settings):
+            settings.DISCORD_BOT_TOKEN = "tok"
+            route = respx.post(_EVENTS_URL).mock(return_value=httpx.Response(429, headers={"Retry-After": "soon"}))
+            client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
+            with (
+                patch("core.integrations.discord_events.time.sleep") as fake_sleep,
+                pytest.raises(de.DiscordEventsError, match="429"),
+            ):
+                client.insert_event(SERVER_ID, {})
+            fake_sleep.assert_not_called()
+            assert route.call_count == 1
+
+        @respx.mock
+        def it_raises_without_retrying_when_the_wait_is_excessive(settings):
+            settings.DISCORD_BOT_TOKEN = "tok"
+            route = respx.post(_EVENTS_URL).mock(
+                return_value=httpx.Response(429, json={"retry_after": 60.0}, headers={"Retry-After": "60"})
+            )
+            client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
+            with (
+                patch("core.integrations.discord_events.time.sleep") as fake_sleep,
+                pytest.raises(de.DiscordEventsError, match="429"),
+            ):
+                client.insert_event(SERVER_ID, {})
+            fake_sleep.assert_not_called()
+            assert route.call_count == 1

--- a/tests/hub/calendar_service_spec.py
+++ b/tests/hub/calendar_service_spec.py
@@ -409,7 +409,7 @@ def describe_sync_discord_feed_events():
         with _with_client(client):
             sync_discord_feed_events()
 
-        client.delete_event.assert_called_once_with("srv1", "disc-moved")
+        client.delete_event.assert_called_once_with("srv1", "disc-moved", retry_on_rate_limit=True)
         moved.refresh_from_db()
         assert moved.discord_event_id == ""
 
@@ -471,7 +471,19 @@ def describe_sync_discord_feed_events():
             with _with_client(client):
                 sync_discord_feed_events()
 
-            client.delete_event.assert_called_once_with("srv1", "disc-echo")
+            client.delete_event.assert_called_once_with("srv1", "disc-echo", retry_on_rate_limit=True)
+            assert not CalendarEvent.objects.filter(uid="echo-uid@google.com").exists()
+
+        def it_purges_safe_echo_rows_even_while_discord_sync_is_off():
+            from hub.calendar_service import sync_discord_feed_events
+            from tests.membership.factories import CommunityEventFactory
+
+            CommunityEventFactory(google_ical_uid="echo-uid@google.com")
+            _feed_event(uid="echo-uid@google.com")
+            client = _events_client(enabled=False)
+            with _with_client(client):
+                assert sync_discord_feed_events() == 0
+
             assert not CalendarEvent.objects.filter(uid="echo-uid@google.com").exists()
 
         def it_keeps_an_echo_row_whose_discord_delete_failed_for_a_retry_next_sweep():

--- a/tests/hub/calendar_service_spec.py
+++ b/tests/hub/calendar_service_spec.py
@@ -429,3 +429,45 @@ def describe_sync_discord_feed_events():
             errors = sync_all_sources()
 
         assert any("discord events" in e and "discord down" in e for e in errors)
+
+    def describe_echoes_of_our_own_google_pushed_events():
+        def it_never_pushes_an_echo_and_purges_its_row():
+            from hub.calendar_service import sync_discord_feed_events
+            from tests.membership.factories import CommunityEventFactory
+
+            CommunityEventFactory(google_ical_uid="echo-uid@google.com")
+            _feed_event(uid="echo-uid@google.com")
+            client = _events_client()
+            with _with_client(client):
+                assert sync_discord_feed_events() == 0
+
+            client.insert_event.assert_not_called()
+            assert not CalendarEvent.objects.filter(uid="echo-uid@google.com").exists()
+
+        def it_deletes_the_discord_copy_an_echo_gained_before_suppression_existed():
+            from hub.calendar_service import sync_discord_feed_events
+            from tests.membership.factories import CommunityEventFactory
+
+            CommunityEventFactory(google_ical_uid="echo-uid@google.com")
+            _feed_event(uid="echo-uid@google.com", discord_event_id="disc-echo")
+            client = _events_client()
+            with _with_client(client):
+                sync_discord_feed_events()
+
+            client.delete_event.assert_called_once_with("srv1", "disc-echo")
+            assert not CalendarEvent.objects.filter(uid="echo-uid@google.com").exists()
+
+        def it_keeps_an_echo_row_whose_discord_delete_failed_for_a_retry_next_sweep():
+            from core.integrations.discord_events import DiscordEventsError
+            from hub.calendar_service import sync_discord_feed_events
+            from tests.membership.factories import CommunityEventFactory
+
+            CommunityEventFactory(google_ical_uid="echo-uid@google.com")
+            echo = _feed_event(uid="echo-uid@google.com", discord_event_id="disc-echo")
+            client = _events_client()
+            client.delete_event.side_effect = DiscordEventsError("Discord API 500: oops")
+            with _with_client(client), pytest.raises(DiscordEventsError):
+                sync_discord_feed_events()
+
+            echo.refresh_from_db()
+            assert echo.discord_event_id == "disc-echo"

--- a/tests/hub/calendar_service_spec.py
+++ b/tests/hub/calendar_service_spec.py
@@ -56,6 +56,23 @@ def describe_sync_local_class_events():
         assert event.title == "Welding 101"
         assert event.start_dt == session.starts_at
 
+    def it_purges_the_old_guild_copy_when_a_class_moves_guilds():
+        from hub.calendar_service import sync_local_class_events
+        from tests.membership.factories import GuildFactory
+
+        offering = _published_offering()
+        _future_session(offering)
+        sync_local_class_events()
+        assert CalendarEvent.objects.filter(source="classes", guild__isnull=True).count() == 1
+
+        offering.category.guild = GuildFactory()
+        offering.category.save()
+        sync_local_class_events()
+
+        events = CalendarEvent.objects.filter(source="classes")
+        assert events.count() == 1
+        assert events.get().guild == offering.category.guild
+
     def it_strips_cms_date_suffix_from_the_title():
         from hub.calendar_service import sync_local_class_events
 

--- a/tests/hub/community_calendar_spec.py
+++ b/tests/hub/community_calendar_spec.py
@@ -291,6 +291,22 @@ def describe_calendar_service():
             count = sync_general_calendar()
             assert count == 0
 
+        def it_skips_echoes_of_our_own_google_pushed_community_events():
+            from core.models import CalendarFeed
+            from hub.calendar_service import sync_general_calendar
+            from tests.membership.factories import CommunityEventFactory
+
+            CommunityEventFactory(google_ical_uid="event-001@test.com")
+            CalendarFeed.objects.create(
+                name="General", ical_url="https://calendar.google.com/calendar/ical/general.ics", color="#EEB44B"
+            )
+            with patch("hub.calendar_service.urllib.request.urlopen", side_effect=_fake_urlopen):
+                count = sync_general_calendar()
+
+            assert count == 1
+            assert not CalendarEvent.objects.filter(uid="event-001@test.com").exists()
+            assert CalendarEvent.objects.filter(uid="event-002@test.com").exists()
+
         def it_iterates_over_multiple_feeds():
             from core.models import CalendarFeed
             from hub.calendar_service import sync_general_calendar

--- a/tests/hub/community_calendar_spec.py
+++ b/tests/hub/community_calendar_spec.py
@@ -631,18 +631,20 @@ def describe_calendar_export_ics_view():
 
 
 def describe_community_calendar_default_filters():
-    def it_includes_each_calendar_feed_in_default_filters(client: Client):
+    # Filters persist as a *disabled* list client-side, so a legend key is visible by
+    # default simply by being rendered — these specs pin each key's toggle to the page.
+    def it_renders_a_toggle_for_each_calendar_feed(client: Client):
         from core.models import CalendarFeed
 
         _logged_in_user(client, username="caluser_gen")
         feed = CalendarFeed.objects.create(name="General", ical_url="https://example.com/general.ics", color="#EEB44B")
         response = client.get("/calendar/")
         assert response.status_code == 200
-        assert f"feed-{feed.pk}" in response.context["default_filters_json"]
+        assert f"toggleFilter('feed-{feed.pk}')" in response.content.decode()
 
-    def it_seeds_a_class_only_guilds_key_into_default_filters(client: Client):
-        # A guild whose only calendar content is a class (no iCal URL) still seeds its
-        # key into the defaults, or its newly-colored class chips render hidden on load.
+    def it_renders_a_toggle_for_a_class_only_guild(client: Client):
+        # A guild whose only calendar content is a class (no iCal URL) still gets a
+        # legend toggle, or its newly-colored class chips would have no filter chip.
         _logged_in_user(client, username="caluser_guildkey")
         guild = GuildFactory(name="Metalworking", calendar_url="")
         now = timezone.now()
@@ -657,7 +659,13 @@ def describe_community_calendar_default_filters():
             fetched_at=now,
         )
         response = client.get("/calendar/")
-        assert str(guild.pk) in response.context["default_filters_json"]
+        assert f"toggleFilter('{guild.pk}')" in response.content.decode()
+
+    def it_does_not_seed_a_legacy_enabled_list(client: Client):
+        _logged_in_user(client, username="caluser_nolegacy")
+        response = client.get("/calendar/")
+        assert "default_filters_json" not in response.context
+        assert "calFiltersOff" in response.content.decode()
 
 
 def describe_calendar_events_partial_invalid_params():

--- a/tests/hub/community_calendar_spec.py
+++ b/tests/hub/community_calendar_spec.py
@@ -808,10 +808,12 @@ def describe_guild_page_class_colors():
         assert calendar["source_colors"][str(guild.pk)] == "#118844"
         # Legend set: the guild earns a toggle even with no iCal calendar_url.
         assert guild in calendar["legend_guilds"]
-        # Visible by default: the guild key seeds the guild-tab default filters.
-        assert str(guild.pk) in calendar["default_filters_json"]
+        # Visible by default: the guild tab persists a *disabled* list (no seeded
+        # enabled-list), so a rendered legend key is on unless explicitly hidden.
+        assert "default_filters_json" not in calendar
 
         html = response.content.decode()
+        assert f"guildCalFiltersOff-{guild.pk}" in html
         # Toggleable: the legend renders a real toggle for the guild's key (un-gated from
         # calendar_url — this is the fix that would otherwise leave no toggle at all)...
         assert f"toggleFilter('{guild.pk}')" in html

--- a/tests/hub/community_event_calendar_spec.py
+++ b/tests/hub/community_event_calendar_spec.py
@@ -98,7 +98,7 @@ def describe_visibility_wiring():
         )
         resp = client.get(reverse("hub_community_calendar"))
         assert b"Community events" in resp.content  # the filter button (proves color wiring)
-        assert b"community" in resp.content  # present in default_filters_json
+        assert b"community" in resp.content  # the legend renders the community toggle
 
     def it_wires_the_community_source_on_a_guild_calendar(client: Client):
         _login(client, "vis2")


### PR DESCRIPTION
## What

Two prod defects found while verifying the v0.23.3 calendar/Discord go-live:

**1. Feed echo loop.** The Member/Public Google calendars we push CommunityEvents to are the same calendars the general feed sync re-imports. Every pushed event came back as feed `CalendarEvent` rows under its Google-assigned UID — observed live: **'Parallel Play' appeared 5× in Discord** (its own push + 4 mirrored feed echoes) and 26 echo rows landed in the calendar table.
- Feed import now skips UIDs matching any `CommunityEvent.google_ical_uid`
- The Discord mirror excludes echoes from its push set; the existing dropped-pass deletes the Discord copies they already gained
- Echo rows are then purged (rows whose Discord delete failed survive to retry next sweep)
- **Self-healing**: the next daily sweep cleans up the existing prod duplicates — no manual DB surgery

**2. Discord 429s fail every sweep.** The scheduled-events rate bucket is tiny; the mirror's burst of ~a dozen calls tripped it mid-run on both one-off sweeps today (`retry_after` 1–10 s). The client now honors `Retry-After` on a 429 (bounded at 15 s, one retry); a 429 with no usable or excessive wait still raises.

## Tests
- 3 new mirror specs (echo never pushed + row purged; pre-existing Discord copy deleted; failed delete survives for retry)
- 1 new feed-import spec (echo UID skipped, sibling imported)
- 5 new client specs (retry honored + sleep asserted; double-429 raises; missing/malformed/excessive Retry-After don't retry)
- ruff + mypy clean; touched spec files green locally (community_calendar specs require `recurring_ical_events`, present in CI)

## Changelog
No new entry — intra-cycle fix to the unannounced v0.23.3 calendar/Discord feature. Both 0.23.3 entries re-stamped to 0.23.4 so the manual Discord announcement posts them together.