### PR TITLE
[calendar] Click +N on a busy day to expand all events (v0.23.6)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.5"
+VERSION = "0.23.6"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.6",
+        "date": "2026-07-21",
+        "title": "See every event on a busy calendar day",
+        "changes": [
+            (
+                "On the Community Calendar, a packed day used to hide extra events behind a small "
+                '"+3" tag. Now you can click that tag to expand the day and see everything on it — '
+                'then click "Show less" to tuck it back. Works in both the week and month views.'
+            ),
+        ],
+    },
     {
         "version": "0.23.5",
         "date": "2026-07-21",

--- a/static/css/calendar.css
+++ b/static/css/calendar.css
@@ -373,6 +373,35 @@
     flex-shrink: 0;
 }
 
+/* "+N" overflow indicator as a clickable toggle — expands the day cell in place
+   to reveal every event, then flips to "Show less". */
+.pl-calendar-grid__more--toggle {
+    border: 0;
+    background: none;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    transition: color 0.15s;
+}
+
+.pl-calendar-grid__more--toggle:hover {
+    color: var(--hub-text);
+}
+
+/* Expanded day: let the cell grow past its fixed height so the revealed chips
+   aren't clipped. The grid row grows with it. Beats the week/month height rules
+   via the doubled class selector. */
+.pl-calendar-grid__day.pl-calendar-grid__day--expanded {
+    height: auto;
+    overflow: visible;
+}
+
+.pl-calendar-grid__day--expanded .pl-calendar-grid__day-chips {
+    overflow: visible;
+}
+
 .pl-calendar-divider {
     height: 1px;
     margin: 1.5rem 0;

--- a/templates/hub/partials/calendar_content.html
+++ b/templates/hub/partials/calendar_content.html
@@ -27,17 +27,19 @@
 {# Week grid #}
 <div class="pl-calendar-grid pl-calendar-grid--week" x-show="calView === 'week'">
     {% for day in week_days %}
-    <div class="pl-calendar-grid__day{% if day.is_today %} pl-calendar-grid__day--today{% endif %}">
+    <div class="pl-calendar-grid__day{% if day.is_today %} pl-calendar-grid__day--today{% endif %}"
+         x-data="{ expanded: false }"
+         :class="{ 'pl-calendar-grid__day--expanded': expanded }">
         <div class="pl-calendar-grid__day-header">
             <span class="pl-calendar-grid__day-name">{{ day.date|date:"D" }}</span>
             <span class="pl-calendar-grid__day-num{% if day.is_today %} pl-calendar-grid__day-num--today{% endif %}">{{ day.date|date:"j" }}</span>
         </div>
         <div class="pl-calendar-grid__day-chips">
-            {% for event in day.events|slice:":3" %}
+            {% for event in day.events %}
             {% with src=event.source_key %}
             <button type="button"
                     class="pl-calendar-grid__chip{% if event.is_in_progress %} pl-calendar-grid__chip--live{% endif %}"
-                    x-show="isActive('{{ src }}')"
+                    x-show="isActive('{{ src }}'){% if forloop.counter > 3 %} && expanded{% endif %}"
                     @click="focusEvent({{ event.pk }})"
                     @mouseenter="hoverEvent({{ event.pk }})" @mouseleave="unhoverEvent({{ event.pk }})"
                     style="--chip-color: {{ source_colors|get_item:src|default:'#888888' }};"
@@ -48,7 +50,11 @@
             {% endwith %}
             {% endfor %}
             {% if day.events|length > 3 %}
-            <span class="pl-calendar-grid__more">+{{ day.events|length|add:"-3" }}</span>
+            <button type="button"
+                    class="pl-calendar-grid__more pl-calendar-grid__more--toggle"
+                    @click="expanded = !expanded"
+                    :aria-expanded="expanded"
+                    x-text="expanded ? 'Show less' : '+{{ day.events|length|add:'-3' }}'">+{{ day.events|length|add:"-3" }}</button>
             {% endif %}
         </div>
     </div>
@@ -80,16 +86,18 @@
     <div class="pl-calendar-grid__week-header">{{ header }}</div>
     {% endfor %}
     {% for day in month_days %}
-    <div class="pl-calendar-grid__day{% if day.is_today %} pl-calendar-grid__day--today{% endif %}{% if not day.in_month %} pl-calendar-grid__day--faded{% endif %}">
+    <div class="pl-calendar-grid__day{% if day.is_today %} pl-calendar-grid__day--today{% endif %}{% if not day.in_month %} pl-calendar-grid__day--faded{% endif %}"
+         x-data="{ expanded: false }"
+         :class="{ 'pl-calendar-grid__day--expanded': expanded }">
         <div class="pl-calendar-grid__day-header">
             <span class="pl-calendar-grid__day-num{% if day.is_today %} pl-calendar-grid__day-num--today{% endif %}">{{ day.date|date:"j" }}</span>
         </div>
         <div class="pl-calendar-grid__day-chips pl-calendar-grid__day-chips--compact">
-            {% for event in day.events|slice:":2" %}
+            {% for event in day.events %}
             {% with src=event.source_key %}
             <button type="button"
                     class="pl-calendar-grid__chip{% if event.is_in_progress %} pl-calendar-grid__chip--live{% endif %}"
-                    x-show="isActive('{{ src }}')"
+                    x-show="isActive('{{ src }}'){% if forloop.counter > 2 %} && expanded{% endif %}"
                     @click="focusEvent({{ event.pk }})"
                     @mouseenter="hoverEvent({{ event.pk }})" @mouseleave="unhoverEvent({{ event.pk }})"
                     style="--chip-color: {{ source_colors|get_item:src|default:'#888888' }};"
@@ -99,7 +107,11 @@
             {% endwith %}
             {% endfor %}
             {% if day.events|length > 2 %}
-            <span class="pl-calendar-grid__more">+{{ day.events|length|add:"-2" }}</span>
+            <button type="button"
+                    class="pl-calendar-grid__more pl-calendar-grid__more--toggle"
+                    @click="expanded = !expanded"
+                    :aria-expanded="expanded"
+                    x-text="expanded ? 'Show less' : '+{{ day.events|length|add:'-2' }}'">+{{ day.events|length|add:"-2" }}</button>
             {% endif %}
         </div>
     </div>

--- a/tests/hub/calendar_day_expand_spec.py
+++ b/tests/hub/calendar_day_expand_spec.py
@@ -1,0 +1,120 @@
+"""BDD specs for the Community Calendar 'expand a busy day' interaction.
+
+Clicking the "+N" overflow indicator on a day cell expands it in place to reveal
+every event for that day, then flips to "Show less" to collapse again. The count
+limit differs per view (2 in the compact month grid, 3 in the week grid), so both
+paths are covered. This is pure template/Alpine markup, so the assertions pin the
+rendered expand control rather than any server-side context.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.template.loader import render_to_string
+from django.utils import timezone
+
+from membership.models import CalendarEvent
+from tests.membership.factories import GuildFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_events(guild, count: int) -> list[CalendarEvent]:
+    """Create ``count`` real (pk-bearing) events tied to ``guild``."""
+    now = timezone.now()
+    events = []
+    for i in range(count):
+        start = now + timedelta(days=1, hours=i)
+        events.append(
+            CalendarEvent.objects.create(
+                guild=guild,
+                uid=f"expand-{guild.pk}-{i}",
+                title=f"Busy Day Event {i}",
+                start_dt=start,
+                end_dt=start + timedelta(hours=1),
+                fetched_at=now,
+            )
+        )
+    return events
+
+
+def _day(events: list[CalendarEvent]) -> dict:
+    return {"date": timezone.now().date(), "is_today": False, "in_month": True, "events": events}
+
+
+def _render(*, week_days=None, month_days=None) -> str:
+    ctx = {
+        "week_offset": 0,
+        "month_offset": 0,
+        "event_page": 1,
+        "event_total_pages": 1,
+        "month_event_pages_json": "{}",
+        "events_url": "/calendar/events/",
+        "week_days": week_days or [],
+        "month_days": month_days or [],
+        "month_headers": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+        "week_events": [],
+        "month_events": [],
+        "source_colors": {},
+    }
+    return render_to_string("hub/partials/calendar_content.html", ctx)
+
+
+def describe_calendar_day_expand():
+    def describe_month_grid():
+        def it_renders_a_clickable_toggle_when_a_day_has_more_than_two_events():
+            guild = GuildFactory()
+            events = _make_events(guild, 3)
+            html = _render(month_days=[_day(events)])
+
+            assert "pl-calendar-grid__more--toggle" in html
+            assert '@click="expanded = !expanded"' in html
+            # Collapse affordance: the same control flips to "Show less".
+            assert "expanded ? 'Show less'" in html
+
+        def it_renders_all_events_and_gates_the_overflow_behind_expanded():
+            guild = GuildFactory()
+            events = _make_events(guild, 3)
+            html = _render(month_days=[_day(events)])
+
+            # Every event is now in the DOM (no longer sliced away)...
+            for event in events:
+                assert f"focusEvent({event.pk})" in html
+            # ...but the 3rd (overflow) chip only shows once expanded.
+            assert "&& expanded" in html
+
+        def it_gives_each_day_cell_its_own_expand_state():
+            guild = GuildFactory()
+            html = _render(month_days=[_day(_make_events(guild, 3))])
+
+            assert 'x-data="{ expanded: false }"' in html
+            assert "'pl-calendar-grid__day--expanded': expanded" in html
+
+        def it_shows_no_toggle_when_two_or_fewer_events():
+            guild = GuildFactory()
+            html = _render(month_days=[_day(_make_events(guild, 2))])
+
+            assert "pl-calendar-grid__more--toggle" not in html
+            # Nothing overflows, so no chip is gated behind expansion.
+            assert "&& expanded" not in html
+
+    def describe_week_grid():
+        def it_renders_a_clickable_toggle_when_a_day_has_more_than_three_events():
+            guild = GuildFactory()
+            events = _make_events(guild, 4)
+            html = _render(week_days=[_day(events)])
+
+            assert "pl-calendar-grid__more--toggle" in html
+            assert "expanded ? 'Show less'" in html
+            for event in events:
+                assert f"focusEvent({event.pk})" in html
+            assert "&& expanded" in html
+
+        def it_shows_no_toggle_when_three_or_fewer_events():
+            guild = GuildFactory()
+            html = _render(week_days=[_day(_make_events(guild, 3))])
+
+            assert "pl-calendar-grid__more--toggle" not in html
+            assert "&& expanded" not in html


### PR DESCRIPTION
## What
On the Community Calendar, a day cell with many events truncates the list and shows a `+N` overflow tag. This makes that tag a real control: clicking it **expands the day cell in place** to reveal every event for that day, and flips the label to **"Show less"** to collapse again.

- Works in **both the week grid** (shows 3, `+N` for the rest) **and the month grid** (shows 2).
- Works on the **Community Calendar** and any **guild-page calendar** — both render the shared `hub/partials/calendar_content.html`.
- Each day cell owns its own `expanded` state (nested Alpine `x-data`), so opening one day doesn't touch its neighbors.
- Respects the existing legend filters: expanding reveals the day's *active* events; overflow chips are gated on `isActive(src) && expanded`.

## Why
Busy days hid their events behind a dead `+N` label with no way to see what was underneath without leaving the calendar. This is a small QoL fix to the already-live calendar.

## How
- `calendar_content.html`: render all of a day's events (instead of slicing), gate the overflow chips behind `expanded`, and turn the `+N` span into a toggle `<button>` (`@click`, `x-text`, `:aria-expanded`).
- `calendar.css`: new `pl-`-prefixed rules — `.pl-calendar-grid__more--toggle` (clickable underline styling, theme-token colors) and `.pl-calendar-grid__day--expanded` (lets the cell grow past its fixed height so revealed chips aren't clipped; the grid row grows with it). Verified against both dark (Obsidian) and light (Slate) themes using existing tokens only — no new colors.

## Tests
`tests/hub/calendar_day_expand_spec.py` — renders the partial and asserts the expand control markup for both grids (toggle appears only past the per-view limit, all events land in the DOM, overflow gated behind `expanded`, collapse affordance present, per-cell state). 54 passed (6 new + existing `community_calendar_spec.py`).