### PR TITLE
[calendar] Events tab lists every calendar event + compact Google-sync badge (v0.23.7)

### DIFF
--- a/hub/calendar_entries.py
+++ b/hub/calendar_entries.py
@@ -12,13 +12,13 @@ location, description, guild, feed``.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
-from typing import TYPE_CHECKING
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Any
 
 from django.utils import timezone
 
 if TYPE_CHECKING:
-    from membership.models import Guild
+    from membership.models import CommunityEvent, Guild
 
 # Offsets keep synthetic pks clear of real CalendarEvent pks so the shared
 # focusEvent() JS and the month_event_pages map keep working untouched.
@@ -26,6 +26,11 @@ CLASS_PK_OFFSET = 1_000_000_000
 ORIENTATION_PK_OFFSET = 2_000_000_000
 EVENT_PK_OFFSET = 3_000_000_000
 _OCC_STRIDE = 100  # max occurrences per event per window (a few months of monthly « 100)
+
+# How far ahead the Events tab looks for a recurring series' next occurrence. A
+# year comfortably contains the next hit for any monthly/weekly cadence, so each
+# recurring event resolves to one upcoming row instead of its stale anchor date.
+_EVENTS_TAB_HORIZON_DAYS = 365
 
 
 @dataclass
@@ -43,6 +48,10 @@ class CalendarEntry:
     all_day: bool = False
     guild: Guild | None = None
     feed: None = None
+    # The backing FOG-native event for a "community" entry, so the templates can draw
+    # its Google-sync flag and (on the Events tab) its admin Edit/Delete controls.
+    # Always None for feed / class / orientation entries.
+    community_event: CommunityEvent | None = None
 
     @property
     def source_key(self) -> str:
@@ -143,6 +152,55 @@ def community_event_entries(fetch_from: date, fetch_to: date, guild: Guild | Non
                     description=ev.description,
                     all_day=False,
                     guild=ev.guild,
+                    community_event=ev,
                 )
             )
     return entries
+
+
+def upcoming_calendar_events() -> list[Any]:
+    """Every upcoming event on the shared Community Calendar as one sorted list.
+
+    This is the source for the Community Calendar's **Events tab**, built so the tab
+    lists nothing narrower than the grid: the read-through feed / general / class
+    ``CalendarEvent`` rows (echo-deduped exactly like the grid) *plus* one entry per
+    published ``CommunityEvent`` at its next occurrence. A recurring series collapses
+    to a single upcoming row (its next hit), so admins get one Edit/Delete affordance
+    per event rather than one per occurrence.
+    """
+    from membership.models import CalendarEvent, CommunityEvent
+
+    now = timezone.now()
+    today = now.date()
+    horizon = today + timedelta(days=_EVENTS_TAB_HORIZON_DAYS)
+
+    # Feed / general / class iCal rows still upcoming, minus the iCal echo of any event
+    # FOG itself pushed to Google (matched by the stored google_ical_uid) — the same
+    # de-dup the grid applies, so a FOG event is never listed twice.
+    pushed_uids = CommunityEvent.objects.pushed().values_list("google_ical_uid", flat=True)
+    entries: list[Any] = list(
+        CalendarEvent.objects.upcoming().exclude(uid__in=pushed_uids).select_related("guild", "feed")
+    )
+
+    # One entry per published CommunityEvent, anchored on its next (or in-progress) occurrence.
+    for ev in CommunityEvent.objects.published().upcoming().select_related("guild"):
+        duration = ev.ends_at - ev.starts_at
+        upcoming_occ = [occ for occ in ev.occurrences_in(today, horizon) if occ + duration >= now]
+        # No in-window occurrence → a still-running non-recurring event (started before
+        # today) or one starting past the horizon: fall back to its own start.
+        start = upcoming_occ[0] if upcoming_occ else ev.starts_at
+        entries.append(
+            CalendarEntry(
+                pk=EVENT_PK_OFFSET + ev.pk * _OCC_STRIDE,
+                title=ev.title,
+                start_dt=start,
+                end_dt=start + duration,
+                source="community",
+                url=ev.absolute_url,
+                location=ev.location,
+                description=ev.description,
+                guild=ev.guild,
+                community_event=ev,
+            )
+        )
+    return sorted(entries, key=lambda e: e.start_dt)

--- a/hub/views.py
+++ b/hub/views.py
@@ -3448,8 +3448,7 @@ def _get_calendar_context(
     # The Google-sync flag stays admin-only and gated by both sync switches (the same
     # contract as the wordy badge), so it renders on the calendar list only for a
     # manager when sync is on — never for a plain member.
-    is_admin = bool(getattr(request, "view_as", None) and request.view_as.is_admin)
-    sync_flag_visible = _google_sync_enabled() and is_admin
+    sync_flag_visible = _google_sync_enabled() and _viewing_as_admin(request)
 
     return {
         "week_events": week_events,

--- a/hub/views.py
+++ b/hub/views.py
@@ -3445,11 +3445,18 @@ def _get_calendar_context(
         d = window_start + timedelta(days=i)
         month_days.append({"date": d, "is_today": d == today, "in_month": True, "events": events_by_date.get(d, [])})
 
+    # The Google-sync flag stays admin-only and gated by both sync switches (the same
+    # contract as the wordy badge), so it renders on the calendar list only for a
+    # manager when sync is on — never for a plain member.
+    is_admin = bool(getattr(request, "view_as", None) and request.view_as.is_admin)
+    sync_flag_visible = _google_sync_enabled() and is_admin
+
     return {
         "week_events": week_events,
         "month_events": month_events,
         "event_page": event_page,
         "event_total_pages": total_pages,
+        "sync_flag_visible": sync_flag_visible,
         "guilds_with_calendars": guilds_with_calendars,
         "legend_guilds": legend_guilds,
         "has_ungrouped_classes": has_ungrouped_classes,
@@ -3494,6 +3501,9 @@ def community_calendar(request: HttpRequest) -> HttpResponse:
     The Events tab is a member-readable upcoming-events list; admins additionally get
     ``+ Add`` / Edit / Delete controls (gated by ``events_can_manage``).
     """
+    from django.core.paginator import Paginator
+
+    from hub.calendar_entries import upcoming_calendar_events
     from membership.models import CommunityEvent
 
     ctx = _get_hub_context(request)
@@ -3506,8 +3516,11 @@ def community_calendar(request: HttpRequest) -> HttpResponse:
 
     view_as = getattr(request, "view_as", None)
     is_admin = bool(view_as is not None and view_as.is_admin)
-    # Only PUBLISHED events reach the public list (pending/declined proposals never leak).
-    cal_ctx["upcoming_events"] = CommunityEvent.objects.published().upcoming().select_related("guild")
+    # The Events tab lists exactly what the grid shows — every feed / general / class
+    # event plus every published community event — not just the FOG-native ones (that
+    # was the "missing events" bug). Paginated with the hub's standard Paginator.
+    events_paginator = Paginator(upcoming_calendar_events(), _CALENDAR_PAGE_SIZE)
+    cal_ctx["events_page_obj"] = events_paginator.get_page(request.GET.get("events_page", 1))
     cal_ctx["events_can_manage"] = is_admin
     # Admin-only: site-wide events parked in SCHEDULED are invisible on the public list and
     # aren't in my_proposals (admin direct-creates set created_by, not submitted_by), so an

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,25 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.6"
+VERSION = "0.23.7"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.7",
+        "date": "2026-07-21",
+        "title": "The Events tab now lists everything on the calendar",
+        "changes": [
+            (
+                "The Community Calendar's Events tab used to show only community events, so guild meetings, "
+                "classes, and subscribed-calendar events were missing. It now lists every event on the calendar, "
+                "in order, with easy paging through the full list."
+            ),
+            (
+                'Each event\'s title is now a link straight to its page — tap it (or the new "More Info" link) '
+                "to see the details and register."
+            ),
+        ],
+    },
     {
         "version": "0.23.6",
         "date": "2026-07-21",

--- a/static/css/calendar.css
+++ b/static/css/calendar.css
@@ -584,6 +584,39 @@ a.pl-calendar-list__title--link:hover {
     background: color-mix(in srgb, var(--color-tuscan-yellow) 28%, transparent);
 }
 
+/* Events-tab management row: sync flag/diagnostics on the left, Edit/Delete on the right. */
+.pl-calendar-list__manage {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+    margin-top: 0.6rem;
+}
+
+.pl-calendar-list__manage-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-left: auto;
+}
+
+/* The compact "on Google" flag when there are no management controls (grid list +
+   non-admin Events tab). */
+.pl-calendar-list__flag {
+    margin-top: 0.4rem;
+}
+
+/* Events-tab pagination — mirrors the hub's standard Prev/Next control. */
+.pl-events-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+}
+
 .pl-calendar-list-note {
     margin: 0 0 0.75rem;
     font-size: 0.75rem;

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -419,6 +419,16 @@ a:hover { color: var(--hub-link-hover); }
 .pl-sync-badge--synced { color: var(--pl-sync-synced); }
 .pl-sync-badge--pending { color: var(--pl-sync-pending); }
 .pl-sync-badge--failed { color: var(--pl-sync-failed); }
+
+/* Compact "synced to the shared Google Calendar" flag — a small green calendar-check
+   glyph that replaces the wordy pill wherever a synced event is listed. */
+.pl-sync-flag {
+    display: inline-flex;
+    align-items: center;
+    color: var(--pl-sync-synced);
+    line-height: 1;
+}
+.pl-sync-flag svg { display: block; }
 /* The failure/config-gap reason, on its own line beneath the badge — visible
    inline text, never a title-tooltip (dead on touch, FRONTEND Screen C). */
 .pl-sync-badge__reason {

--- a/templates/hub/community_calendar.html
+++ b/templates/hub/community_calendar.html
@@ -172,7 +172,7 @@
                         Subscribe via webcal
                     </a>
                     <p class="pl-calendar-export__note">
-                        Exports the full community calendar — all guild, general, and class events. To register for a specific class, use the Register button on that event instead.
+                        Exports the full community calendar — all guild, general, and class events. To register for a specific class, use the More Info link on that event instead.
                     </p>
                 </div>
             </div>
@@ -286,35 +286,20 @@
     {% endif %}
 
     <div class="hub-card" style="padding:1.5rem;">
-        {% if upcoming_events %}
-        <div style="display:flex; flex-direction:column; gap:1rem;">
-            {% for event in upcoming_events %}
-            {% with confirm_id=event.pk|stringformat:"s"|add:"-event-delete" %}
-            <div class="hub-card" style="padding:1rem; background:var(--hub-surface); display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap;">
-                <div style="flex:1; min-width:220px;">
-                    <div style="font-weight:600;">{{ event.title }}</div>
-                    <div class="hub-text-muted" style="font-size:0.8125rem;">
-                        {{ event.get_event_type_display }} · {{ event.guild.name|default:"Site-wide" }} · {{ event.starts_at|date:"D, M j · g:i A" }}{% if event.recurrence != "none" %} · {{ event.get_recurrence_display }}{% endif %}
-                    </div>
-                    {% if google_sync_enabled and events_can_manage %}
-                    <div style="margin-top:0.35rem;">
-                        {% include "hub/partials/_sync_badge.html" with event=event can_retry=events_can_manage %}
-                    </div>
-                    {% endif %}
-                </div>
-                {% if events_can_manage %}
-                <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
-                    <a href="{% url 'hub_event_edit' event.pk %}" class="hub-btn hub-btn--sm">Edit</a>
-                    <button type="button" class="pl-btn pl-btn--danger pl-btn--sm"
-                            @click="$dispatch('open-confirm', '{{ confirm_id }}')">Delete</button>
-                    {% url 'hub_event_delete' event.pk as delete_url %}
-                    {% include "components/confirm_modal.html" with confirm_id=confirm_id confirm_title="Delete this event?" confirm_message="This removes it from the calendar. This can't be undone." confirm_action_url=delete_url confirm_button_text="Delete event" %}
-                </div>
-                {% endif %}
-            </div>
-            {% endwith %}
+        {% if events_page_obj %}
+        <div class="pl-calendar-list">
+            {% for event in events_page_obj %}
+            {% include "hub/partials/calendar_event_item.html" with show_manage=events_can_manage sync_visible=sync_flag_visible %}
             {% endfor %}
         </div>
+
+        {% if events_page_obj.paginator.num_pages > 1 %}
+        <div class="pl-events-pagination">
+            {% if events_page_obj.has_previous %}<a href="?tab=events&events_page={{ events_page_obj.previous_page_number }}" class="hub-btn hub-btn--sm" hx-boost="false">Previous</a>{% endif %}
+            <span class="hub-text-muted" style="font-size:0.875rem;">Page {{ events_page_obj.number }} of {{ events_page_obj.paginator.num_pages }}</span>
+            {% if events_page_obj.has_next %}<a href="?tab=events&events_page={{ events_page_obj.next_page_number }}" class="hub-btn hub-btn--sm" hx-boost="false">Next</a>{% endif %}
+        </div>
+        {% endif %}
         {% elif events_can_manage %}
         <p class="hub-text-muted" style="margin:0;">No upcoming events yet — add a community event or a Guild Lead Meeting.</p>
         {% else %}

--- a/templates/hub/partials/_sync_badge.html
+++ b/templates/hub/partials/_sync_badge.html
@@ -10,7 +10,7 @@ draws nothing for IDLE (an unpublished / unmanaged row), so a wrapper that shows
 whenever any badge could appear is safe.
 {% endcomment %}
 {% if event.sync_state == "synced" %}
-<span class="pl-sync-badge pl-sync-badge--synced">Synced to Google ✓</span>
+{% include "hub/partials/_sync_flag.html" %}
 {% elif event.sync_state == "pending" %}
 <span class="pl-sync-badge pl-sync-badge--pending">Sync pending{% if event.sync_error %} · {{ event.sync_error }}{% endif %}</span>
 {% elif event.sync_state == "failed" %}

--- a/templates/hub/partials/_sync_flag.html
+++ b/templates/hub/partials/_sync_flag.html
@@ -1,0 +1,11 @@
+{% comment %}
+Compact "on the shared Google Calendar" flag — a small green calendar-check glyph.
+Replaces the wordy "Synced to Google ✓" pill wherever a synced event is listed
+(the calendar list below the grid + the Events tab). The words live in the title /
+aria-label so it stays legible to screen readers and hover.
+{% endcomment %}
+<span class="pl-sync-flag" title="Synced to Google Calendar" aria-label="Synced to Google Calendar">
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><polyline points="8.5 15 10.5 17 15 12.5"/>
+    </svg>
+</span>

--- a/templates/hub/partials/calendar_content.html
+++ b/templates/hub/partials/calendar_content.html
@@ -129,7 +129,7 @@
     <div class="pl-calendar-list">
         {% if week_events %}
         {% for event in week_events %}
-        {% include "hub/partials/calendar_event_item.html" %}
+        {% include "hub/partials/calendar_event_item.html" with show_filter=True sync_visible=sync_flag_visible %}
         {% endfor %}
         {% else %}
         <div class="pl-calendar-empty">
@@ -145,7 +145,7 @@
     <div class="pl-calendar-list">
         {% if month_events %}
         {% for event in month_events %}
-        {% include "hub/partials/calendar_event_item.html" %}
+        {% include "hub/partials/calendar_event_item.html" with show_filter=True sync_visible=sync_flag_visible %}
         {% endfor %}
         {% else %}
         <div class="pl-calendar-empty">

--- a/templates/hub/partials/calendar_event_item.html
+++ b/templates/hub/partials/calendar_event_item.html
@@ -1,8 +1,23 @@
 {% load hub_tags static classes_tags %}
+{% comment %}
+One event card, shared by the calendar list-below-the-grid and the Events tab.
+
+Params:
+  event        — a CalendarEvent row or a duck-typed CalendarEntry
+  source_colors — {source_key: color} map
+  show_filter  — truthy only on the calendar grid, where the surrounding Alpine scope
+                 defines isActive(); the Events tab has no filter legend, so it omits
+                 the x-show to avoid an undefined-isActive error.
+  show_manage  — truthy on the Events tab for a manager: draw Edit/Delete for a
+                 community event (event.community_event).
+  sync_visible — truthy only for a manager while Google sync is on: draw the compact
+                 sync flag / diagnostics. Kept off for plain members (sync internals
+                 are staff-only) and when either sync switch is off.
+{% endcomment %}
 {% with src=event.source_key %}
 <div class="pl-calendar-list__item{% if event.is_in_progress %} pl-calendar-list__item--live{% endif %}"
      data-event-pk="{{ event.pk }}"
-     x-show="isActive('{{ src }}')"
+     {% if show_filter %}x-show="isActive('{{ src }}')"{% endif %}
      style="--event-color: {{ source_colors|get_item:src|default:'#888888' }};">
     {% if event.is_in_progress %}<span class="pl-calendar-list__live-pill"><span class="pl-calendar-list__live-dot"></span>Live now</span>{% endif %}
     <div class="pl-calendar-list__time">
@@ -15,10 +30,12 @@
         {% endif %}
     </div>
     <div class="pl-calendar-list__body">
-        {% if event.source == "classes" %}
-        <div class="pl-calendar-list__title">{{ event.title|strip_date_suffix }}</div>
-        {% elif event.url %}
-        <a href="{{ event.url }}" class="pl-calendar-list__title pl-calendar-list__title--link" target="_blank" rel="noopener noreferrer">{{ event.title|strip_date_suffix }}</a>
+        {% if event.url %}
+            {% if event.source == "community" %}
+            <a href="{{ event.url }}" class="pl-calendar-list__title pl-calendar-list__title--link">{{ event.title|strip_date_suffix }}</a>
+            {% else %}
+            <a href="{{ event.url }}" class="pl-calendar-list__title pl-calendar-list__title--link" target="_blank" rel="noopener noreferrer">{{ event.title|strip_date_suffix }}</a>
+            {% endif %}
         {% else %}
         <div class="pl-calendar-list__title">{{ event.title|strip_date_suffix }}</div>
         {% endif %}
@@ -37,7 +54,7 @@
             <img src="{% static 'img/guild_logos/'|add:event.guild.logo_prefix|add:'_color.svg' %}" width="14" height="14" alt="">
             {% endif %}
             <span>{% if event.guild %}{{ event.guild.name }}{% else %}Classes{% endif %}</span>
-            {% if event.url %}<a href="{{ event.url }}" class="pl-calendar-list__register" target="_blank" rel="noopener noreferrer" style="margin-left:auto;">Register →</a>{% endif %}
+            {% if event.url %}<a href="{{ event.url }}" class="pl-calendar-list__register" target="_blank" rel="noopener noreferrer" style="margin-left:auto;">More Info →</a>{% endif %}
         </div>
         {% elif event.guild %}
         <div class="pl-calendar-list__guild" style="color: {{ source_colors|get_item:src|default:'#888888' }}; display:flex; align-items:center; gap:0.35rem;">
@@ -50,6 +67,23 @@
         <div class="pl-calendar-list__guild" style="color: {{ source_colors|get_item:src|default:'#888888' }};">{{ event.feed.name }}</div>
         {% else %}
         <div class="pl-calendar-list__guild" style="color: {{ source_colors|get_item:src|default:'#888888' }};">General</div>
+        {% endif %}
+
+        {% if show_manage and event.community_event %}
+        {% with cev=event.community_event confirm_id=event.pk|stringformat:"s"|add:"-event-delete" %}
+        <div class="pl-calendar-list__manage">
+            {% if sync_visible %}{% include "hub/partials/_sync_badge.html" with event=cev can_retry=show_manage %}{% endif %}
+            <div class="pl-calendar-list__manage-actions">
+                <a href="{% url 'hub_event_edit' cev.pk %}" class="hub-btn hub-btn--sm">Edit</a>
+                <button type="button" class="pl-btn pl-btn--danger pl-btn--sm"
+                        @click="$dispatch('open-confirm', '{{ confirm_id }}')">Delete</button>
+                {% url 'hub_event_delete' cev.pk as delete_url %}
+                {% include "components/confirm_modal.html" with confirm_id=confirm_id confirm_title="Delete this event?" confirm_message="This removes it from the calendar. This can't be undone." confirm_action_url=delete_url confirm_button_text="Delete event" %}
+            </div>
+        </div>
+        {% endwith %}
+        {% elif sync_visible and event.community_event and event.community_event.sync_state == "synced" %}
+        <div class="pl-calendar-list__flag">{% include "hub/partials/_sync_flag.html" %}</div>
         {% endif %}
     </div>
 </div>

--- a/tests/hub/community_event_scheduling_spec.py
+++ b/tests/hub/community_event_scheduling_spec.py
@@ -169,7 +169,10 @@ def describe_scheduled_findability():
         resp = client.get(reverse("hub_community_calendar"))
         assert scheduled in list(resp.context["scheduled_events"])
         # A parked event never leaks into the public upcoming list.
-        assert scheduled not in list(resp.context["upcoming_events"])
+        listed_event_pks = {
+            e.community_event.pk for e in resp.context["events_page_obj"] if getattr(e, "community_event", None)
+        }
+        assert scheduled.pk not in listed_event_pks
 
     def it_hides_the_scheduled_section_from_a_non_admin(client: Client):
         _user_with_role("cal_member")

--- a/tests/hub/events_tab_parity_spec.py
+++ b/tests/hub/events_tab_parity_spec.py
@@ -1,0 +1,217 @@
+"""BDD specs for the Community Calendar Events tab — parity with the grid, pagination,
+and the event-card link markup ("More Info" + clickable title).
+
+The bug these lock down: the Events tab used to list only FOG-native CommunityEvents, so
+the guild-meeting / class / subscribed-feed events that *are* on the calendar grid were
+missing from the tab. The tab now sources the same union the grid shows.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth.models import User
+from django.template.loader import render_to_string
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from membership.models import CalendarEvent, CommunityEvent, Member
+from tests.membership.factories import CommunityEventFactory, GuildFactory, MembershipPlanFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _member(username: str = "tabuser") -> User:
+    MembershipPlanFactory()
+    user = User.objects.create_user(username=username, password="pass")
+    return user
+
+
+def _admin(username: str = "tabadmin") -> User:
+    MembershipPlanFactory()
+    user = User.objects.create_user(username=username, email=f"{username}@example.com", password="pass")
+    member = user.member
+    member.fog_role = Member.FogRole.ADMIN
+    member.save(update_fields=["fog_role"])
+    member.sync_user_permissions()
+    return user
+
+
+def _feed_event(title: str, *, days: int = 3, source: str = "guild", guild=None, url: str = "") -> CalendarEvent:
+    now = timezone.now()
+    return CalendarEvent.objects.create(
+        guild=guild,
+        source=source,
+        uid=f"uid-{title}",
+        title=title,
+        url=url,
+        start_dt=now + timedelta(days=days),
+        end_dt=now + timedelta(days=days, hours=2),
+        fetched_at=now,
+    )
+
+
+def describe_upcoming_calendar_events():
+    def it_includes_feed_class_events_not_just_community_events():
+        from hub.calendar_entries import upcoming_calendar_events
+
+        guild = GuildFactory(name="Woodshop")
+        _feed_event("Woodshop Open Hours", guild=guild)
+        CommunityEventFactory(community=True, title="Spring Mixer")
+
+        titles = [e.title for e in upcoming_calendar_events()]
+        assert "Woodshop Open Hours" in titles  # the previously-missing feed event
+        assert "Spring Mixer" in titles  # the community event was already listed
+
+    def it_carries_the_backing_community_event_for_management_and_sync():
+        from hub.calendar_entries import upcoming_calendar_events
+
+        event = CommunityEventFactory(community=True, title="Backed Event")
+        entry = next(e for e in upcoming_calendar_events() if getattr(e, "community_event", None))
+        assert entry.community_event == event
+
+    def it_collapses_a_recurring_series_to_a_single_upcoming_row():
+        from hub.calendar_entries import upcoming_calendar_events
+
+        # A weekly studio-hours event has many occurrences, but the tab lists it once.
+        CommunityEventFactory(
+            community=True,
+            title="Weekly Studio Hours",
+            recurrence=CommunityEvent.Recurrence.WEEKLY,
+            starts_at=timezone.now() - timedelta(days=1),
+            ends_at=timezone.now() - timedelta(days=1) + timedelta(hours=2),
+        )
+        rows = [e for e in upcoming_calendar_events() if e.title == "Weekly Studio Hours"]
+        assert len(rows) == 1
+
+    def it_excludes_a_past_non_recurring_event():
+        from hub.calendar_entries import upcoming_calendar_events
+
+        now = timezone.now()
+        CommunityEventFactory(
+            community=True,
+            title="Last Month's Talk",
+            starts_at=now - timedelta(days=30),
+            ends_at=now - timedelta(days=30) + timedelta(hours=1),
+        )
+        assert "Last Month's Talk" not in [e.title for e in upcoming_calendar_events()]
+
+
+def describe_events_tab_view():
+    def it_lists_a_feed_event_that_shows_on_the_grid(client: Client):
+        _member("parity1")
+        client.login(username="parity1", password="pass")
+        guild = GuildFactory(name="Metal Guild")
+        _feed_event("Forge Night", guild=guild)
+
+        resp = client.get(reverse("hub_community_calendar"))
+        assert resp.status_code == 200
+        titles = [e.title for e in resp.context["events_page_obj"]]
+        assert "Forge Night" in titles
+        assert b"Forge Night" in resp.content
+
+    def it_paginates_when_there_are_more_than_a_page_of_events(client: Client):
+        _member("parity_page")
+        client.login(username="parity_page", password="pass")
+        guild = GuildFactory(name="Busy Guild")
+        for i in range(14):
+            _feed_event(f"Event {i:02d}", days=i + 1, guild=guild)
+
+        resp = client.get(reverse("hub_community_calendar"))
+        page = resp.context["events_page_obj"]
+        assert page.paginator.num_pages == 2
+        assert len(page.object_list) == 10
+
+        resp2 = client.get(reverse("hub_community_calendar") + "?events_page=2")
+        page2 = resp2.context["events_page_obj"]
+        assert page2.number == 2
+        assert len(page2.object_list) == 4
+
+
+def describe_event_card_links():
+    def it_links_a_community_event_title_to_its_detail_page():
+        event = CommunityEventFactory(community=True, title="Gallery Opening")
+        from hub.calendar_entries import upcoming_calendar_events
+
+        entry = next(e for e in upcoming_calendar_events() if getattr(e, "community_event", None) == event)
+        html = render_to_string(
+            "hub/partials/calendar_event_item.html",
+            {"event": entry, "source_colors": {"community": "#3d8bd4"}},
+        )
+        assert f'href="{event.absolute_url}"' in html
+        assert "pl-calendar-list__title--link" in html
+
+    def it_renders_more_info_not_register_for_a_class_event():
+        event = _feed_event("Intro to Welding", source="classes", url="https://book.pastlives.space/classes/welding/")
+        html = render_to_string(
+            "hub/partials/calendar_event_item.html",
+            {"event": event, "source_colors": {"classes": "#AA33BB"}},
+        )
+        assert "More Info" in html
+        assert "Register" not in html
+        # The class title is now itself a link, not plain text.
+        assert "pl-calendar-list__title--link" in html
+
+
+def describe_sync_flag():
+    def it_shows_a_compact_synced_flag_on_a_synced_community_event():
+        from hub.calendar_entries import upcoming_calendar_events
+
+        event = CommunityEventFactory(community=True, pushed=True, title="Synced Party")
+        assert event.sync_state == CommunityEvent.SyncState.SYNCED
+        entry = next(e for e in upcoming_calendar_events() if getattr(e, "community_event", None) == event)
+        html = render_to_string(
+            "hub/partials/calendar_event_item.html",
+            {"event": entry, "source_colors": {"community": "#3d8bd4"}, "sync_visible": True},
+        )
+        assert "pl-sync-flag" in html
+        assert "Synced to Google" in html  # words preserved in the flag's title/aria
+
+    def it_shows_admin_edit_and_delete_on_the_events_tab(client: Client):
+        _admin("flagadmin")
+        client.login(username="flagadmin", password="pass")
+        CommunityEventFactory(community=True, title="Managed Event")
+        resp = client.get(reverse("hub_community_calendar"))
+        assert b"pl-calendar-list__manage" in resp.content
+        assert b"Managed Event" in resp.content
+
+    def it_shows_the_flag_on_the_calendar_grid_list_too(client: Client, settings):
+        from core.models import SiteConfiguration
+
+        _admin("gridadmin")
+        settings.GOOGLE_CALENDAR_SYNC_ENABLED = True
+        config = SiteConfiguration.load()
+        config.google_calendar_sync_enabled = True
+        config.save(update_fields=["google_calendar_sync_enabled"])
+        client.login(username="gridadmin", password="pass")
+        CommunityEventFactory(
+            community=True,
+            pushed=True,
+            title="Grid Synced Event",
+            starts_at=timezone.now() + timedelta(days=2),
+            ends_at=timezone.now() + timedelta(days=2, hours=2),
+        )
+        # The list below the calendar grid (the HTMX partial), not just the Events tab.
+        resp = client.get(reverse("hub_community_calendar_events"))
+        assert b"pl-sync-flag" in resp.content
+
+    def it_hides_the_flag_from_a_plain_member_on_the_grid_list(client: Client, settings):
+        from core.models import SiteConfiguration
+
+        _member("gridmember")
+        settings.GOOGLE_CALENDAR_SYNC_ENABLED = True
+        config = SiteConfiguration.load()
+        config.google_calendar_sync_enabled = True
+        config.save(update_fields=["google_calendar_sync_enabled"])
+        client.login(username="gridmember", password="pass")
+        CommunityEventFactory(
+            community=True,
+            pushed=True,
+            title="Grid Synced Event",
+            starts_at=timezone.now() + timedelta(days=2),
+            ends_at=timezone.now() + timedelta(days=2, hours=2),
+        )
+        resp = client.get(reverse("hub_community_calendar_events"))
+        assert b"pl-sync-flag" not in resp.content


### PR DESCRIPTION
## What & why

Three fixes to the Community Calendar's **Events tab** (`/calendar/?tab=events`), reported by Josh.

### 1. Events tab was missing events (+ pagination)
**Root cause:** the Events tab listed only `CommunityEvent.objects.published().upcoming()` — FOG-native community events. The calendar *grid* renders the union of `CalendarEvent` rows (guild / general / class iCal feeds) **plus** synthetic community-event entries, so every feed/class event on the grid was absent from the tab.

The tab now sources the same union the grid shows, via a new `hub.calendar_entries.upcoming_calendar_events()`: the echo-deduped feed/general/class `CalendarEvent` rows **plus** one entry per published `CommunityEvent` at its next occurrence (a recurring series collapses to a single upcoming row, so admins get one Edit/Delete per event, not one per occurrence). The list is paginated with the hub's standard `Paginator` (`?events_page=N`, `_CALENDAR_PAGE_SIZE` = 10).

### 2. "Synced to Google" flag → compact icon badge, shown on both views
The wordy `Synced to Google ✓` pill is now a small green calendar-check glyph (`_sync_flag.html`, `.pl-sync-flag`), with the words preserved in the `title`/`aria-label`. It now also appears on the calendar list below the grid — not just the Events tab. The flag keeps its existing contract: **admin-only and gated by both Google-sync switches** (I did **not** broaden the audience — that's an existing product decision encoded in `sync_badge_spec`; flag if it should change).

### 3. "Register →" → "More Info →" + clickable titles
Event cards now say **More Info →** instead of Register, and the event **title** is itself a link to the detail/registration page (community events → their FOG detail page; classes now link too, in a new tab).

## Files
- `hub/calendar_entries.py` — `CalendarEntry.community_event` field + `upcoming_calendar_events()` builder
- `hub/views.py` — `community_calendar` paginates the union; `_get_calendar_context` exposes `sync_flag_visible`
- `templates/hub/partials/{calendar_event_item,_sync_badge,_sync_flag,calendar_content}.html`, `templates/hub/community_calendar.html`
- `static/css/{hub,calendar}.css`
- `plfog/version.py` — v0.23.7 + member-facing changelog entry

## Tests
New `tests/hub/events_tab_parity_spec.py` (parity, pagination, More Info + title-link markup, flag gating on both views). Full relevant suite green in Docker (SQLite): **235 passed**.