### PR TITLE
[infra] calendar.pastlives.space → Community Calendar redirect (v0.23.8)

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -53,6 +53,12 @@ class SurfaceMiddleware:
             qs = f"?{request.META['QUERY_STRING']}" if request.META.get("QUERY_STRING") else ""
             return HttpResponsePermanentRedirect(f"https://{settings.MEMBER_HOST}{request.path}{qs}")
 
+        # calendar.pastlives.space is a pure vanity alias: every path 302s to the
+        # community calendar (temporary, not 301, so the target can evolve without
+        # fighting browser caches).
+        if host in set(getattr(settings, "CALENDAR_REDIRECT_HOSTS", [])):
+            return HttpResponseRedirect(f"https://{settings.MEMBER_HOST}/calendar/?public=1")
+
         public_hosts: set[str] = set(getattr(settings, "PUBLIC_HOSTS", []))
         guilds_hosts: set[str] = set(getattr(settings, "GUILDS_HOSTS", []))
         signage_hosts: set[str] = set(getattr(settings, "SIGNAGE_HOSTS", []))

--- a/plfog/settings.py
+++ b/plfog/settings.py
@@ -104,6 +104,15 @@ PUBLIC_ONLY_PATH_PREFIXES: tuple[str, ...] = ("/account/",)
 GUILDS_HOSTS = [
     h.strip().lower() for h in os.environ.get("GUILDS_HOSTS", "guilds.pastlives.app").split(",") if h.strip()
 ]
+# Vanity calendar alias. Every request to a host listed here 302s to the community
+# calendar on the members domain (calendar.pastlives.space — printed on flyers etc.).
+# Hosts are auto-added to ALLOWED_HOSTS so go-live needs only DNS + the Render domain.
+CALENDAR_REDIRECT_HOSTS = [
+    h.strip().lower()
+    for h in os.environ.get("CALENDAR_REDIRECT_HOSTS", "calendar.pastlives.space").split(",")
+    if h.strip()
+]
+ALLOWED_HOSTS += [h for h in CALENDAR_REDIRECT_HOSTS if h not in ALLOWED_HOSTS]
 # Absolute base URL of the guilds surface, used to canonicalize OG/SEO tags on
 # shared guild links regardless of which host rendered them.
 GUILDS_BASE_URL = os.environ.get("GUILDS_BASE_URL", "https://guilds.pastlives.app").rstrip("/")

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.7"
+VERSION = "0.23.8"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.8",
+        "date": "2026-07-21",
+        "title": "calendar.pastlives.space — an easy address for the Community Calendar",
+        "changes": [
+            (
+                "There's now a short, shareable address for the Community Calendar: calendar.pastlives.space "
+                "takes you straight there. Handy for flyers, Discord, and telling a friend."
+            ),
+        ],
+    },
     {
         "version": "0.23.7",
         "date": "2026-07-21",

--- a/tests/core/calendar_redirect_host_spec.py
+++ b/tests/core/calendar_redirect_host_spec.py
@@ -1,0 +1,34 @@
+"""BDD specs for the calendar.pastlives.space vanity host: every path 302s to the
+community calendar on the members domain."""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client, override_settings
+
+pytestmark = pytest.mark.django_db
+
+CAL_SETTINGS = dict(
+    ALLOWED_HOSTS=["calendar.pastlives.space", "members.pastlives.space", "testserver"],
+    CALENDAR_REDIRECT_HOSTS=["calendar.pastlives.space"],
+    MEMBER_HOST="members.pastlives.space",
+)
+
+
+def describe_calendar_redirect_host():
+    @override_settings(**CAL_SETTINGS)
+    def it_redirects_the_root_to_the_community_calendar(client: Client):
+        response = client.get("/", HTTP_HOST="calendar.pastlives.space")
+        assert response.status_code == 302
+        assert response["Location"] == "https://members.pastlives.space/calendar/?public=1"
+
+    @override_settings(**CAL_SETTINGS)
+    def it_redirects_any_path_the_same_way(client: Client):
+        response = client.get("/some/deep/path/", HTTP_HOST="calendar.pastlives.space")
+        assert response.status_code == 302
+        assert response["Location"] == "https://members.pastlives.space/calendar/?public=1"
+
+    @override_settings(**CAL_SETTINGS)
+    def it_does_not_touch_the_members_host(client: Client):
+        response = client.get("/calendar/", HTTP_HOST="members.pastlives.space")
+        assert response.status_code == 200

--- a/tests/plfog/settings_spec.py
+++ b/tests/plfog/settings_spec.py
@@ -316,7 +316,7 @@ def describe_allowed_hosts():
                     "SENTRY_DSN": None,
                 },
             )
-            assert settings_module.ALLOWED_HOSTS == ["example.com", "api.example.com"]
+            assert settings_module.ALLOWED_HOSTS == ["example.com", "api.example.com", "calendar.pastlives.space"]
 
     def it_defaults_to_localhost(monkeypatch):
         with patch("sentry_sdk.init"):
@@ -329,7 +329,7 @@ def describe_allowed_hosts():
                     "SENTRY_DSN": None,
                 },
             )
-            assert settings_module.ALLOWED_HOSTS == ["localhost", "127.0.0.1"]
+            assert settings_module.ALLOWED_HOSTS == ["localhost", "127.0.0.1", "calendar.pastlives.space"]
 
     def describe_render_external_hostname():
         def it_appends_render_hostname_when_set(monkeypatch):
@@ -357,7 +357,7 @@ def describe_allowed_hosts():
                         "SENTRY_DSN": None,
                     },
                 )
-                assert settings_module.ALLOWED_HOSTS == ["example.com"]
+                assert settings_module.ALLOWED_HOSTS == ["example.com", "calendar.pastlives.space"]
 
         def it_appends_to_default_hosts_when_only_render_hostname_is_set(monkeypatch):
             with patch("sentry_sdk.init"):
@@ -370,7 +370,12 @@ def describe_allowed_hosts():
                         "SENTRY_DSN": None,
                     },
                 )
-                assert settings_module.ALLOWED_HOSTS == ["localhost", "127.0.0.1", "plfog.onrender.com"]
+                assert settings_module.ALLOWED_HOSTS == [
+                    "localhost",
+                    "127.0.0.1",
+                    "plfog.onrender.com",
+                    "calendar.pastlives.space",
+                ]
 
 
 def describe_secure_proxy_ssl_header():


### PR DESCRIPTION
Vanity alias: every request to calendar.pastlives.space 302s to https://members.pastlives.space/calendar/?public=1 (temporary redirect so the target can evolve). Hosts come from CALENDAR_REDIRECT_HOSTS (default calendar.pastlives.space) and are auto-appended to ALLOWED_HOSTS, so go-live needs nothing beyond this deploy — the Render custom domain + DNS are already verified and the cert is issued.

Specs: tests/core/calendar_redirect_host_spec.py (root redirect, deep-path redirect, members host untouched) — 47 surface-area specs pass in docker; mypy clean.