### PR TITLE
[discord] /voting replies are public; ballots stay private (v0.23.17)

### DIFF
--- a/membership/discord_commands.py
+++ b/membership/discord_commands.py
@@ -26,7 +26,7 @@ from core.events.discord_replies import (
 )
 
 if TYPE_CHECKING:
-    from membership.models import Guild, GuildOrientationSettings, Member, MemberQuerySet, VotePreference
+    from membership.models import Guild, GuildOrientationSettings, Member, MemberQuerySet
     from membership.vote_calculator import VoteStanding
 
 logger = logging.getLogger(__name__)
@@ -476,39 +476,20 @@ def _standings_block(standings: list[VoteStanding], zero_point_names: list[str])
     return "\n".join(lines)
 
 
-def _ballot_block(preference: VotePreference | None) -> str:
-    """The member's own three ranked choices — or the "you haven't voted yet" nudge."""
-    from membership.vote_calculator import WEIGHTS
-
-    if preference is None:
-        return (
-            "**Your ballot**\n"
-            "You haven't voted yet — your three ranked choices help decide where this month's "
-            "funding pool goes. It takes 30 seconds on the voting page below."
-        )
-    return (
-        "**Your ballot**\n"
-        f"1st — {preference.guild_1st.name} · {WEIGHTS['1st']} pts\n"
-        f"2nd — {preference.guild_2nd.name} · {WEIGHTS['2nd']} pts\n"
-        f"3rd — {preference.guild_3rd.name} · {WEIGHTS['3rd']} pts\n"
-        f"_Last updated {format_local(preference.updated_at)}_"
-    )
-
-
 def _voting(interaction: Interaction, member: Member | None) -> dict:
-    """This month's live guild-funding standings + the member's own ballot, as one ephemeral embed.
+    """This month's live guild-funding standings as one **public** embed.
 
-    Read-only: check the race and confirm your ballot without leaving Discord; the link button
-    is the change-your-vote path (the page owns the form). No writes, no notifications.
+    Visible to everyone in the channel, so it carries no personal data: the member's own
+    ballot is deliberately absent (a `/vote` nudge points at the private path instead —
+    that reply is ephemeral). Read-only: the link button is the change-your-vote path
+    (the page owns the form). No writes, no notifications.
     """
     from membership.cycle import get_cycle_context
     from membership.models import Guild
     from membership.vote_calculator import WEIGHTS, compute_live_standings
 
-    member = cast("Member", member)  # requires_link=True: dispatch resolved a linked member before this runs
     standings = compute_live_standings()
     cycle = get_cycle_context()
-    preference: VotePreference | None = getattr(member, "vote_preference", None)
 
     # The shared tally (hub page included) drops zero-point guilds; here every active guild
     # renders so the whole field is visible — the voteless ones follow the ranked rows.
@@ -520,7 +501,7 @@ def _voting(interaction: Interaction, member: Member | None) -> dict:
         "Your votes decide how the monthly funding pool is split. "
         f"This cycle closes **{cycle['cycle_closes_on']}**."
         f"\n\n{_standings_block(standings, zero_point_names)}"
-        f"\n\n{_ballot_block(preference)}",
+        "\n\nSet or change your own picks with `/vote` — only you see that reply.",
         _EMBED_DESCRIPTION_LIMIT,
     )
     footer = f"Weighting: 1st = {WEIGHTS['1st']} pts · 2nd = {WEIGHTS['2nd']} pts · 3rd = {WEIGHTS['3rd']} pts"
@@ -535,15 +516,15 @@ def _voting(interaction: Interaction, member: Member | None) -> dict:
             {"type": 2, "style": 5, "label": "Open the voting page", "url": hub_url("hub_guild_voting")},
         ],
     }
-    return reply("", ephemeral=True, embeds=[embed], components=[button_row])
+    return reply("", ephemeral=False, embeds=[embed], components=[button_row])
 
 
 VOTING = SlashCommand(
     name="voting",
-    description="See this month's live guild-funding standings and your ballot.",
+    description="See this month's live guild-funding standings.",
     handler=_voting,
     requires_link=True,
-    ephemeral=True,
+    ephemeral=False,
     defer=False,
     scope="guild",
 )

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,28 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.16"
+VERSION = "0.23.17"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.17",
+        "date": "2026-07-21",
+        "title": "Guild-funding voting comes to Discord: /voting and /vote",
+        "changes": [
+            (
+                "Type /voting in the Past Lives Discord to see this month's live guild-funding "
+                "standings as a bar graph — every guild (even the ones still at zero), medals for "
+                "the top three, and when the cycle closes. The standings reply is visible to "
+                "everyone in the channel, so anyone can check the race at a glance."
+            ),
+            (
+                "With /vote you can cast or change your ballot without leaving Discord — pick "
+                "your 1st, 2nd, and 3rd choice guilds from the dropdowns and it saves instantly, "
+                "exactly like voting on the page. Your own picks stay private: only you see the "
+                "/vote reply."
+            ),
+        ],
+    },
     {
         "version": "0.23.16",
         "date": "2026-07-21",
@@ -35,24 +54,6 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
             (
                 "Instructors: there's a new Sale section on your class edit page — flip the toggle, "
                 "pick the discount, and optionally write your own banner headline."
-            ),
-        ],
-    },
-    {
-        "version": "0.23.13",
-        "date": "2026-07-21",
-        "title": "Guild-funding voting comes to Discord: /voting and /vote",
-        "changes": [
-            (
-                "Type /voting in the Past Lives Discord to see this month's live guild-funding "
-                "standings as a bar graph — every guild (even the ones still at zero), medals for "
-                "the top three, and when the cycle closes — plus your own three ranked picks, or a "
-                "nudge if you haven't voted yet. Only you can see the reply."
-            ),
-            (
-                "And with /vote you can cast or change your ballot without leaving Discord — pick "
-                "your 1st, 2nd, and 3rd choice guilds from the dropdowns and it saves instantly, "
-                "exactly like voting on the page."
             ),
         ],
     },

--- a/tests/core/events/voting_command_spec.py
+++ b/tests/core/events/voting_command_spec.py
@@ -9,10 +9,11 @@ import pytest
 
 from core.events.discord_replies import hub_url
 from membership.discord_commands import _BAR_WIDTH, VOTING, _bar, _voting
-from membership.models import VotePreference
 from tests.membership.factories import GuildFactory, VotePreferenceFactory
 
 pytestmark = pytest.mark.django_db
+
+_VOTE_NUDGE = "Set or change your own picks with `/vote` — only you see that reply."
 
 
 def _reply(member) -> dict:
@@ -24,9 +25,11 @@ def _description(member) -> str:
 
 
 def describe_voting_command_definition():
-    def it_is_linked_only_ephemeral_and_immediate():
+    def it_is_linked_only_public_and_immediate():
+        # ephemeral=False: the standings reply is meant for the whole channel — which is
+        # exactly why the embed carries no personal ballot data (see the broadcast specs).
         assert VOTING.name == "voting"
-        assert (VOTING.requires_link, VOTING.ephemeral, VOTING.defer, VOTING.scope) == (True, True, False, "guild")
+        assert (VOTING.requires_link, VOTING.ephemeral, VOTING.defer, VOTING.scope) == (True, False, False, "guild")
 
 
 def describe_bar():
@@ -43,7 +46,7 @@ def describe_bar():
 
 
 def describe_voting():
-    def it_shows_standings_ballot_cycle_and_the_voting_page_button(linked_member, settings):
+    def it_shows_standings_cycle_and_the_voting_page_button_publicly(linked_member, settings):
         settings.MEMBER_BASE_URL = "https://members.example"
         member = linked_member()
         g1 = GuildFactory(name="Fiber Arts")
@@ -66,12 +69,13 @@ def describe_voting():
         assert "**Woodshop** — 9 pts" in embed["description"]
         assert "**Ceramics** — 6 pts" in embed["description"]
         assert embed["footer"]["text"] == "Weighting: 1st = 5 pts · 2nd = 3 pts · 3rd = 2 pts"
+        assert _VOTE_NUDGE in embed["description"]
         button = result["data"]["components"][0]["components"][0]
         assert button["style"] == 5
         assert button["label"] == "Open the voting page"
         assert button["url"] == hub_url("hub_guild_voting")
         assert button["url"] == "https://members.example/guilds/voting/"
-        assert result["data"]["flags"] == 64  # ephemeral
+        assert result["data"]["flags"] == 0  # public — visible to the whole channel
 
     def it_scales_bars_relative_to_the_leader(linked_member):
         member = linked_member()
@@ -87,25 +91,25 @@ def describe_voting():
         assert f"`{'█' * 7 + '░' * 5}` **Runner Up**" in description
         assert f"`{'█' * 5 + '░' * 7}` **Trailing Guild**" in description
 
-    def it_shows_the_members_own_ballot_with_rank_points_and_updated_at(linked_member):
+    def it_never_broadcasts_the_invoking_members_own_picks(linked_member):
+        """Privacy: the reply is public, so a member WITH a ballot must not have their three
+        ranked picks echoed to the channel — only the aggregate standings and the /vote nudge."""
         member = linked_member()
         g1 = GuildFactory(name="My First")
         g2 = GuildFactory(name="My Second")
         g3 = GuildFactory(name="My Third")
         VotePreferenceFactory(member=member, guild_1st=g1, guild_2nd=g2, guild_3rd=g3)
-        fixed = dt.datetime(2026, 7, 14, 21, 0, 0, tzinfo=dt.timezone.utc)  # 2:00 PM in America/Los_Angeles
-        VotePreference.objects.filter(member=member).update(updated_at=fixed)
-        member.refresh_from_db()
 
-        description = _description(member)
+        result = _reply(member)
 
-        assert "**Your ballot**" in description
-        assert "1st — My First · 5 pts" in description
-        assert "2nd — My Second · 3 pts" in description
-        assert "3rd — My Third · 2 pts" in description
-        assert "_Last updated Tue Jul 14, 2:00 PM_" in description
+        description = result["data"]["embeds"][0]["description"]
+        assert "**Your ballot**" not in description
+        assert "1st —" not in description
+        assert "_Last updated" not in description
+        assert _VOTE_NUDGE in description
+        assert result["data"]["flags"] == 0  # public reply — no ephemeral flag
 
-    def it_never_leaks_another_members_ballot(linked_member):
+    def it_never_broadcasts_another_members_ballot(linked_member):
         member = linked_member()
         other = linked_member()
         g1 = GuildFactory(name="Their First")
@@ -115,26 +119,9 @@ def describe_voting():
 
         description = _description(member)
 
-        # The other member's vote shapes the standings but never the ballot block.
+        # The other member's vote shapes the aggregate standings but no ballot block exists.
         assert "1st — Their First" not in description
-        assert "You haven't voted yet" in description
-
-    def describe_when_the_member_has_not_voted():
-        def it_shows_the_nudge_and_still_offers_the_button(linked_member):
-            member = linked_member()
-            g1 = GuildFactory(name="Someone Elses Pick")
-            g2 = GuildFactory(name="Another Pick")
-            g3 = GuildFactory(name="Third Pick")
-            VotePreferenceFactory(guild_1st=g1, guild_2nd=g2, guild_3rd=g3)
-
-            result = _reply(member)
-
-            description = result["data"]["embeds"][0]["description"]
-            assert "You haven't voted yet" in description
-            assert "It takes 30 seconds on the voting page below." in description
-            assert "1st —" not in description
-            button = result["data"]["components"][0]["components"][0]
-            assert button["style"] == 5
+        assert _VOTE_NUDGE in description
 
     def describe_when_no_votes_have_been_cast():
         def it_says_the_standings_are_wide_open_and_keeps_the_frame(linked_member):


### PR DESCRIPTION
## What it does

Per Josh: `/voting` replies are now **public** — visible to everyone in the channel — so the guild-funding race can be checked (and pointed at) in the open. `/vote` is untouched: still ephemeral and deferred, still the private path for a member's own picks.

- `VOTING` SlashCommand: `ephemeral=False` (handler reply + definition).
- **Privacy follows the visibility change**: since the embed now broadcasts, the personal ballot block ("Your ballot" — the member's three ranked picks and last-updated time) is **removed** from `/voting` entirely. In its place, one line: *"Set or change your own picks with `/vote` — only you see that reply."* A member's ballot is never echoed to the channel.
- Kept unchanged: all-guilds standings (ranked bars + zero-point rows), cycle label + closes-on date, `WEIGHTS`-derived weighting footer, and the style-5 link button to the voting page.

### Reply example (public)

```
Guild funding — July 2026

Your votes decide how the monthly funding pool is split. This cycle closes **July 31, 2026**.

🥇 `████████████` **Fiber Arts** — 42 pts
🥈 `████████░░░░` **Woodshop** — 28 pts
🥉 `█████░░░░░░░` **Ceramics** — 18 pts
`4.` `███░░░░░░░░░` Metals — 11 pts
`░░░░░░░░░░░░` Jewelry — 0 pts

Set or change your own picks with /vote — only you see that reply.

Weighting: 1st = 5 pts · 2nd = 3 pts · 3rd = 2 pts
[Open the voting page]
```

## Testing

`tests/core/events/voting_command_spec.py` updated:
- Definition contract: `(requires_link, ephemeral, defer, scope) == (True, False, False, "guild")`.
- Happy path asserts `flags == 0` (no ephemeral flag) and the `/vote` nudge.
- New broadcast-privacy spec: a member **with** a ballot gets a public reply containing **no** "Your ballot" section, no `1st —` rows, no last-updated line — only the aggregate standings and the nudge.
- The other-member's-ballot case reworked for the same contract; the obsolete per-member ballot and no-ballot-state specs are removed (the embed no longer varies by the caller's ballot).
- Changelog-dependent suites (release announcement/email, context processors, Discord notify) sanity-run green against the re-stamped entry.

Targeted specs (voting, vote, guild_voting, dispatcher): 100 passed. Changelog-dependent suites: 112 passed. `ruff format --check` + `ruff check` + mypy clean.

## Version / changelog

`VERSION = "0.23.17"`. Per the house rule this is an intra-cycle refinement of the `/voting`+`/vote` feature: the existing entry was **updated in place** (folded in "the standings reply is visible to everyone in the channel; your own picks stay private via /vote"), re-stamped to 0.23.17, and moved to the top. No new entry.

## Go-live

**No `register_discord_commands` re-run needed** — ephemeral is a response flag chosen at reply time, not a registration property; this takes effect on deploy. (The command's description text was also tightened to drop "and your ballot"; that cosmetic picker tweak simply lands whenever registration next runs for any other reason.)
