### PR TITLE
[fix] Member-only paths 404 instead of 500 on the public surface (v0.23.19)

### DIFF
--- a/billing/context_processors.py
+++ b/billing/context_processors.py
@@ -8,8 +8,15 @@ from django.http import HttpRequest
 
 
 def tab_context(request: HttpRequest) -> dict[str, Any]:
-    """Add tab balance and status to template context for the balance pill."""
-    if not request.user.is_authenticated:
+    """Add tab balance and status to template context for the balance pill.
+
+    ``request.user`` is read defensively. ``SurfaceMiddleware`` short-circuits member-only
+    paths on the guest surfaces with an ``Http404`` *before* ``AuthenticationMiddleware``
+    has run, and the themed ``templates/404.html`` renders every context processor — so on
+    those responses the attribute does not exist yet. Same guard as ``core.persona``.
+    """
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
         return {}
 
     from core.models import SiteConfiguration
@@ -19,7 +26,7 @@ def tab_context(request: HttpRequest) -> dict[str, Any]:
 
     from membership.models import Member
 
-    member: Member | None = getattr(request.user, "member", None)
+    member: Member | None = getattr(user, "member", None)
     if member is None:
         return {}
 

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -97,9 +97,15 @@ def google_analytics(request: HttpRequest) -> dict[str, str]:
 
 
 def notification_badge(request: HttpRequest) -> dict[str, int]:
-    """Unread notification count for the topbar bell. 0 for anonymous users."""
-    user = request.user
-    if not user.is_authenticated:
+    """Unread notification count for the topbar bell. 0 for anonymous users.
+
+    ``request.user`` is read defensively. ``SurfaceMiddleware`` short-circuits member-only
+    paths on the guest surfaces with an ``Http404`` *before* ``AuthenticationMiddleware``
+    has run, and the themed ``templates/404.html`` renders every context processor — so on
+    those responses the attribute does not exist yet. Same guard as ``persona`` below.
+    """
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
         return {"unread_notification_count": 0}
     from core.models import Notification
 

--- a/hub/context_processors.py
+++ b/hub/context_processors.py
@@ -16,13 +16,19 @@ def hub_sidebar(request: HttpRequest) -> dict[str, Any]:
     hub/base.html gets the sidebar data for free — without each view having
     to call a _get_hub_context helper. Returns empty values for anonymous
     requests so login/public pages don't hit the DB.
+
+    ``request.user`` is read defensively. ``SurfaceMiddleware`` short-circuits member-only
+    paths on the guest surfaces with an ``Http404`` *before* ``AuthenticationMiddleware``
+    has run, and the themed ``templates/404.html`` renders every context processor — so on
+    those responses the attribute does not exist yet. Same guard as ``core.persona``.
     """
-    if not getattr(request.user, "is_authenticated", False):
+    user = getattr(request, "user", None)
+    if not getattr(user, "is_authenticated", False):
         return {"guilds": Guild.objects.none(), "user_initials": "", "user_profile_photo_url": ""}
 
     initials = ""
     photo_url = ""
-    member: Member | None = getattr(request.user, "member", None)
+    member: Member | None = getattr(user, "member", None)
     if member is not None:
         initials = member.initials
         if member.profile_photo:

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.18"
+VERSION = "0.23.19"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.19",
+        "date": "2026-07-22",
+        "title": "Guild and account links from the class site now show a proper 'page not found'",
+        "changes": [
+            (
+                "Opening a guild page, member directory, settings, or billing link while you were "
+                "on the class-booking site showed an error page instead of telling you the page "
+                "isn't available there. Those links now land on a friendly 'we couldn't find that "
+                "page' message with a way back to browsing classes — and they still work as normal "
+                "when you're signed in on the member hub."
+            ),
+        ],
+    },
     {
         "version": "0.23.18",
         "date": "2026-07-21",

--- a/tests/core/public_surface_404_spec.py
+++ b/tests/core/public_surface_404_spec.py
@@ -1,0 +1,72 @@
+"""Regression specs: member-only paths must 404 (never 500) on the public surface.
+
+``SurfaceMiddleware`` runs *before* ``AuthenticationMiddleware`` on purpose, so when it
+raises ``Http404`` for a member-only path on a guest host, ``request.user`` has never been
+set. The themed ``templates/404.html`` extends ``hub/base.html``, which runs every context
+processor — so any processor that dereferences ``request.user`` bare turned that intended
+404 into a 500.
+
+These specs must run with ``DEBUG=False``. Under ``DEBUG=True`` Django serves its technical
+404 page, which never touches the context processors — which is exactly why this bug shipped
+to production unnoticed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+# The member-only prefixes that are also plausible guest-facing links (crawlers, shared URLs).
+MEMBER_ONLY_PATHS = [
+    "/guilds/",
+    "/guilds/woodworking-guild/",
+    "/members/",
+    "/settings/",
+    "/billing/",
+    "/tab/",
+    "/feedback/",
+]
+
+GUEST_HOSTS = ["book.pastlives.space", "classes.pastlives.app"]
+
+
+@pytest.fixture(autouse=True)
+def _surface_hosts(settings) -> None:
+    """Public + members hosts, with the real error page active (DEBUG off)."""
+    settings.DEBUG = False
+    settings.ALLOWED_HOSTS = ["book.pastlives.space", "classes.pastlives.app", "members.pastlives.space"]
+    settings.PUBLIC_HOSTS = ["book.pastlives.space", "classes.pastlives.app"]
+    settings.MEMBER_HOST = "members.pastlives.space"
+
+
+def describe_member_only_paths_on_the_public_surface():
+    def describe_for_an_anonymous_visitor():
+        @pytest.mark.parametrize("host", GUEST_HOSTS)
+        @pytest.mark.parametrize("path", MEMBER_ONLY_PATHS)
+        def it_renders_the_themed_404_instead_of_a_500(db, host: str, path: str) -> None:
+            client = Client(HTTP_HOST=host, raise_request_exception=False)
+            response = client.get(path)
+            assert response.status_code == 404, f"{host}{path} returned {response.status_code}, expected 404"
+            # Proves the real templates/404.html rendered (all context processors ran),
+            # not Django's technical 404 which skips them entirely.
+            assert b"We couldn't find that page." in response.content
+
+    def describe_for_a_signed_in_member():
+        @pytest.mark.parametrize("host", GUEST_HOSTS)
+        @pytest.mark.parametrize("path", MEMBER_ONLY_PATHS)
+        def it_renders_the_themed_404_instead_of_a_500(db, host: str, path: str) -> None:
+            user = User.objects.create_user(username=f"guest-404-{abs(hash(path + host))}", password="pw-not-used")
+            client = Client(HTTP_HOST=host, raise_request_exception=False)
+            client.force_login(user)
+            response = client.get(path)
+            assert response.status_code == 404, f"{host}{path} returned {response.status_code}, expected 404"
+            # Proves the real templates/404.html rendered (all context processors ran),
+            # not Django's technical 404 which skips them entirely.
+            assert b"We couldn't find that page." in response.content
+
+    def describe_on_the_members_host():
+        def it_does_not_404_member_only_paths(db) -> None:
+            client = Client(HTTP_HOST="members.pastlives.space", raise_request_exception=False)
+            response = client.get("/guilds/")
+            assert response.status_code != 404


### PR DESCRIPTION
## The bug

`https://classes.pastlives.app/guilds/woodworking-guild/` returns **500**. It is a 500 *inside* a 404.

1. `/guilds/` is in `MEMBER_ONLY_PATH_PREFIXES`, so on a guest surface `SurfaceMiddleware._handle_public_surface` **deliberately** raises `Http404`. A 404 is the intended behaviour.
2. `SurfaceMiddleware` is listed **before** `AuthenticationMiddleware`, so when it raises, `request.user` was never set.
3. `templates/404.html` extends `hub/base.html`, so Django renders it with the request and runs **every context processor**. Three of them dereferenced `request.user` bare.

```
File "django/views/defaults.py", line 64, in page_not_found
    body = template.render(context, request)
File "django/template/context.py", line 263, in bind_template
    context = processor(self.request)
File "billing/context_processors.py", line 12, in tab_context
    if not request.user.is_authenticated:
AttributeError: 'WSGIRequest' object has no attribute 'user'
```

**Scope:** all 13 `MEMBER_ONLY_PATH_PREFIXES` on **both** guest hosts (`classes.pastlives.app`, `book.pastlives.space`), for **anonymous and signed-in** visitors alike — the middleware short-circuits before auth runs either way. Ordinary unknown paths 404 correctly, because that `Http404` comes from the URL resolver *after* auth middleware.

**Regression from** #119, which introduced `templates/404.html`. Before it, Django's built-in error page rendered without context processors.

## The fix

Guard `request.user` in the three offending processors, matching the precedent already set by `core.context_processors.persona`:

| Processor | State | Fallback |
|---|---|---|
| `billing.context_processors.tab_context` | the one that actually blew up | `{}` |
| `hub.context_processors.hub_sidebar` | latent (unreached — `tab_context` failed first) | empty-sidebar dict |
| `core.context_processors.notification_badge` | latent | `{"unread_notification_count": 0}` |

**Audit:** every processor registered in `TEMPLATES['OPTIONS']['context_processors']` was checked for attributes set by later middleware. The rest were already safe — `surface` and `persona` use `getattr`, the others touch only settings/DB/`request.path`, and Django's own `auth` (`hasattr(request, "user")`) and `messages` (`getattr(request, "_messages", [])`) guard themselves. No further offenders.

## Known follow-up (deliberately not done here)

`SurfaceMiddleware` is **not** reordered relative to `AuthenticationMiddleware`. That would address the deeper ordering issue, but the pre-auth placement is deliberate and documented in `core/middleware.py`. Hardening the error page is the correct fix for a production 500; reordering is a separate, larger change.

## Tests

`tests/core/public_surface_404_spec.py` — 29 cases across 7 member-only prefixes × both guest hosts × anonymous and signed-in, plus a members-host control.

The critical detail, and the reason nothing caught this: under `DEBUG=True` Django serves a **technical 404 that skips context processors entirely**, so the bug is invisible in dev. The spec forces `DEBUG=False` and asserts on the real `404.html` body, not just the status code.

Red → green, verified by stashing only the three source fixes:

```
# before the fix
28 failed, 1 passed, 29 warnings in 11.28s
E  AssertionError: classes.pastlives.app/guilds/ returned 500, expected 404

# after the fix
29 passed, 29 warnings in 12.86s
```

Full suite: **6278 passed, 1 failed**, coverage 98.27% (gate 98%). The single failure — `tests/core/integrations/discord_events_spec.py::it_maps_monthly_to_an_nth_weekday_rule` — is a pre-existing, date-dependent failure confirmed on clean `origin/main` and unrelated to this change. `ruff format` / `ruff check` clean; `mypy plfog/ core/ membership/ hub/` clean.

## Version

`VERSION` → `0.23.19`, with a member-facing CHANGELOG entry (this is a bug members lived with on production).

https://claude.ai/code/session_01J2kYTLwGEHBqs1ihuAkS57
