### PR TITLE
[notifications] Transactional events now always email (v0.23.21)

### DIFF
--- a/billing/models.py
+++ b/billing/models.py
@@ -437,7 +437,7 @@ class Tab(models.Model):
         current: Decimal,
         locked_self: Tab,
     ) -> None:
-        """Dispatch in-app notifications for a newly added tab entry.
+        """Dispatch the notifications for a newly added tab entry.
 
         Each event is keyed by the entry's pk in its dedupe ``period`` so every entry
         fires its own notification (the old ``dispatch`` had no dedupe) while a re-run
@@ -445,17 +445,23 @@ class Tab(models.Model):
         """
         from core.events.emit import emit
 
-        # Both events resolve the TAB_MEMBER (the tab's own member); their EMAIL channel
-        # defaults off, so this matches the old in-app-only dispatch. The SiteActivity row
-        # for the entry is logged by ``add_entry`` (the event's registry ``activity_kind``
-        # is None to avoid duplicating it).
+        # Both events resolve the TAB_MEMBER (the tab's own member) and are transactional
+        # (money the member owes), so their EMAIL channel is FORCED — the bell row and the
+        # email both go out, rendered from the DB-editable copy catalogue. The SiteActivity
+        # row for the entry is logged by ``add_entry`` (the event's registry
+        # ``activity_kind`` is None to avoid duplicating it).
+        tab_url = self.absolute_tab_url
         if added_by is not None and not is_self_service and self.member.user is not None:
             emit(
                 "tab_entry_added",
                 actor=added_by,
-                context={"member": self.member},
-                title="Tab entry added",
-                body=f"{description} — ${amount}",
+                context={
+                    "member": self.member,
+                    "member_name": self.member.display_name,
+                    "description": description,
+                    "amount": f"${amount}",
+                    "tab_url": tab_url,
+                },
                 url="/tab/",
                 period=f"entry:{entry.pk}:added",
             )
@@ -463,12 +469,21 @@ class Tab(models.Model):
         if self.member.user is not None and limit and (current + amount) / limit >= Decimal("0.80"):
             emit(
                 "tab_approaching_limit",
-                context={"member": self.member},
-                title="Tab approaching its limit",
-                body=f"Your tab balance is ${current + amount} of ${limit}.",
+                context={
+                    "member": self.member,
+                    "member_name": self.member.display_name,
+                    "balance": f"${current + amount}",
+                    "limit": f"${limit}",
+                    "tab_url": tab_url,
+                },
                 url="/tab/",
                 period=f"entry:{entry.pk}:limit",
             )
+
+    @property
+    def absolute_tab_url(self) -> str:
+        """The member-site URL of the tab page, absolute so it works from an email."""
+        return f"{settings.MEMBER_BASE_URL.rstrip('/')}/tab/"
 
     def lock(self, reason: str) -> None:
         """Lock the tab, preventing new entries."""

--- a/classes/models.py
+++ b/classes/models.py
@@ -724,15 +724,55 @@ class ClassOffering(HeroCropMixin, models.Model):
 
         activity.log(CmsActivity.Kind.CLASS_ARCHIVED, class_offering=self)
         # In-app broadcast to all active members (the ``class_cancelled`` event resolves
-        # ALL_ACTIVE_MEMBERS; its EMAIL channel defaults off, so this matches the old
-        # in-app-only dispatch — email only to a member who has opted in).
+        # ALL_ACTIVE_MEMBERS), but the EMAIL goes ONLY to the people who actually booked
+        # the class — including guests with no account, who are unreachable by the
+        # resolver. ``suppress_email=True`` is unconditional (not merely implied by a
+        # non-empty ``email_to``) so archiving a class nobody booked can never turn into a
+        # site-wide email blast to every active member.
         emit(
             "class_cancelled",
             target=self,
-            title="A class was cancelled",
-            body=self.title,
+            context={
+                "member_name": "there",
+                "class_title": self.title,
+                "class_starts_at": self.cancellation_date_label,
+            },
             url="/classes/",
+            email_to=self.registrant_notice_emails,
+            suppress_email=True,
             period=f"offering:{self.pk}:archived",
+        )
+
+    @property
+    def cancellation_date_label(self) -> str:
+        """A human date for the cancellation copy ("Saturday, July 12").
+
+        Falls back to a neutral phrase for a flexibly-scheduled class with no session
+        rows, so the copy never renders a bare placeholder.
+        """
+        starts_at = self.earliest_session_at
+        if starts_at is None:
+            return "its scheduled date"
+        return date_format(localtime(starts_at), "l, F j")
+
+    @property
+    def registrant_notice_emails(self) -> list[str]:
+        """Every registrant address that should hear about a change to this class.
+
+        Drawn from ``Registration.email`` rather than the linked member, so a **guest**
+        registrant (no account, ``member`` is ``NULL``) is reached too. Rows that have
+        already left the class (cancelled / refunded) are excluded.
+        """
+        return list(
+            self.registrations.filter(
+                status__in=[
+                    Registration.Status.PENDING,
+                    Registration.Status.CONFIRMED,
+                    Registration.Status.WAITLISTED,
+                ]
+            )
+            .exclude(email="")
+            .values_list("email", flat=True)
         )
 
     def promote_next_from_waitlist(self) -> "Registration | None":
@@ -1858,22 +1898,34 @@ class Registration(models.Model):
                     registration=self,
                     actor=acting,
                 )
-                if self.member is not None:
-                    # In-app row (+ email only if the member opted into refund email) to the
-                    # member the refund concerns. The ``refund_issued`` event resolves the
-                    # REGISTRANT; its EMAIL channel defaults off, matching the old dispatch.
-                    from core.events.emit import emit
+                # A refund is transactional: the receipt always emails, and it emails the
+                # address ON THE REGISTRATION so a **guest** registrant (no linked member,
+                # so invisible to the REGISTRANT resolver) is reached too. The resolver
+                # still posts the in-app row to a linked member's user; for a guest it
+                # simply finds nobody and the email is the whole notification.
+                from django.urls import reverse
 
-                    emit(
-                        "refund_issued",
-                        actor=acting,
-                        target=self,
-                        context={"member": self.member},
-                        title="Refund issued",
-                        body=self.class_offering.title,
-                        url="/classes/account/",
-                        period=f"reg:{self.pk}:refund",
-                    )
+                from classes.emails import _absolute_url
+                from core.events.emit import emit
+
+                registration_url = _absolute_url(
+                    reverse("classes:my_registration", kwargs={"token": self.self_serve_token})
+                )
+                emit(
+                    "refund_issued",
+                    actor=acting,
+                    target=self,
+                    context={
+                        "member": self.member,
+                        "member_name": self.first_name or "there",
+                        "class_title": self.class_offering.title,
+                        "amount": f"${self.amount_paid_cents / 100:.2f}",
+                        "registration_url": registration_url,
+                    },
+                    url="/classes/account/",
+                    email_to=self.email,
+                    period=f"reg:{self.pk}:refund",
+                )
 
     @staticmethod
     def _generate_order_number() -> str:

--- a/core/events/copy.py
+++ b/core/events/copy.py
@@ -292,6 +292,137 @@ _CURATED: dict[str, EventCopy] = {
             ),
         },
     ),
+    "tab_entry_added": EventCopy(
+        placeholders=("member_name", "description", "amount", "tab_url"),
+        sample_context={
+            "member_name": "Robin Vale",
+            "description": "Bandsaw blade",
+            "amount": "$18.00",
+            "tab_url": "https://pastlives.example/tab/",
+        },
+        channels={
+            Channel.IN_APP: ChannelCopy(
+                subject="Tab entry added",
+                body_text="{{ description }} — {{ amount }} was added to your tab.",
+            ),
+            Channel.EMAIL: ChannelCopy(
+                subject="{{ amount }} added to your tab",
+                body_text=(
+                    "Hi {{ member_name }},\n\n"
+                    "{{ description }} — {{ amount }} was added to your tab at Past Lives. "
+                    "It will be included in your next monthly charge.\n\n"
+                    "See everything on your tab: {{ tab_url }}\n\n"
+                    "If this doesn't look right, reply to this email and we'll sort it out.\n\n"
+                    "Past Lives Makerspace"
+                ),
+                body_html=(
+                    "<p>Hi {{ member_name }},</p>"
+                    "<p><strong>{{ description }} — {{ amount }}</strong> was added to your tab at Past Lives. "
+                    "It will be included in your next monthly charge.</p>"
+                    '<p><a href="{{ tab_url }}">See everything on your tab</a></p>'
+                    "<p>If this doesn't look right, reply to this email and we'll sort it out.</p>"
+                    "<p>Past Lives Makerspace</p>"
+                ),
+            ),
+        },
+    ),
+    "tab_approaching_limit": EventCopy(
+        placeholders=("member_name", "balance", "limit", "tab_url"),
+        sample_context={
+            "member_name": "Robin Vale",
+            "balance": "$168.00",
+            "limit": "$200.00",
+            "tab_url": "https://pastlives.example/tab/",
+        },
+        channels={
+            Channel.IN_APP: ChannelCopy(
+                subject="Your tab is near its limit",
+                body_text="Your tab balance is {{ balance }} of {{ limit }}.",
+            ),
+            Channel.EMAIL: ChannelCopy(
+                subject="Your tab is near its limit ({{ balance }} of {{ limit }})",
+                body_text=(
+                    "Hi {{ member_name }},\n\n"
+                    "Your tab balance is {{ balance }} of your {{ limit }} limit. Once you reach the "
+                    "limit your tab locks until it's paid down, so it's worth settling up before then.\n\n"
+                    "Pay down your tab: {{ tab_url }}\n\n"
+                    "Past Lives Makerspace"
+                ),
+                body_html=(
+                    "<p>Hi {{ member_name }},</p>"
+                    "<p>Your tab balance is <strong>{{ balance }}</strong> of your {{ limit }} limit. "
+                    "Once you reach the limit your tab locks until it's paid down, so it's worth "
+                    "settling up before then.</p>"
+                    '<p><a href="{{ tab_url }}">Pay down your tab</a></p>'
+                    "<p>Past Lives Makerspace</p>"
+                ),
+            ),
+        },
+    ),
+    "refund_issued": EventCopy(
+        placeholders=("member_name", "class_title", "amount", "registration_url"),
+        sample_context={
+            "member_name": "Robin",
+            "class_title": "Intro to Lost-Wax Casting",
+            "amount": "$65.00",
+            "registration_url": "https://pastlives.example/classes/my/abc123/",
+        },
+        channels={
+            Channel.IN_APP: ChannelCopy(
+                subject="Refund issued",
+                body_text="Your {{ amount }} for {{ class_title }} has been refunded.",
+            ),
+            Channel.EMAIL: ChannelCopy(
+                subject="Refund issued for {{ class_title }}",
+                body_text=(
+                    "Hi {{ member_name }},\n\n"
+                    "We've refunded {{ amount }} for {{ class_title }}. Refunds usually land back on "
+                    "your original payment method within 5–10 business days.\n\n"
+                    "View your booking: {{ registration_url }}\n\n"
+                    "Past Lives Makerspace"
+                ),
+                body_html=(
+                    "<p>Hi {{ member_name }},</p>"
+                    "<p>We've refunded <strong>{{ amount }}</strong> for {{ class_title }}. Refunds usually "
+                    "land back on your original payment method within 5–10 business days.</p>"
+                    '<p><a href="{{ registration_url }}">View your booking</a></p>'
+                    "<p>Past Lives Makerspace</p>"
+                ),
+            ),
+        },
+    ),
+    "lease_expiring": EventCopy(
+        placeholders=("member_name", "space_name", "end_date"),
+        sample_context={
+            "member_name": "Robin Vale",
+            "space_name": "Studio 4",
+            "end_date": "August 21, 2026",
+        },
+        channels={
+            Channel.IN_APP: ChannelCopy(
+                subject="Your lease is expiring",
+                body_text="Your lease for {{ space_name }} ends on {{ end_date }}.",
+            ),
+            Channel.EMAIL: ChannelCopy(
+                subject="Your {{ space_name }} lease ends {{ end_date }}",
+                body_text=(
+                    "Hi {{ member_name }},\n\n"
+                    "Your lease for {{ space_name }} ends on {{ end_date }} — about a month from now.\n\n"
+                    "If you'd like to renew, reply to this email or talk to a staff member at the space "
+                    "and we'll get it sorted before the end date.\n\n"
+                    "Past Lives Makerspace"
+                ),
+                body_html=(
+                    "<p>Hi {{ member_name }},</p>"
+                    "<p>Your lease for <strong>{{ space_name }}</strong> ends on {{ end_date }} — "
+                    "about a month from now.</p>"
+                    "<p>If you'd like to renew, reply to this email or talk to a staff member at the "
+                    "space and we'll get it sorted before the end date.</p>"
+                    "<p>Past Lives Makerspace</p>"
+                ),
+            ),
+        },
+    ),
     "orientation_requested": EventCopy(
         placeholders=("member_name", "guild_name", "slot_starts_at", "orientation_url"),
         sample_context={

--- a/core/management/commands/send_lease_expiry_reminders.py
+++ b/core/management/commands/send_lease_expiry_reminders.py
@@ -6,6 +6,11 @@ lease. Idempotency is the spine's :class:`core.models.EventDelivery` ledger — 
 (replacing the old per-job ``ScheduledNotificationMarker`` dedupe). The
 ``lease_tenant`` resolver finds the member tenant's linked user; a guild-tenant lease
 or a tenant with no usable account resolves to nobody and is skipped automatically.
+
+The message is rendered from the DB-editable copy catalogue (no explicit
+``title``/``body``), so the context carries the documented merge fields
+(``member_name`` / ``space_name`` / ``end_date``). The event's EMAIL channel is FORCED
+— a tenant always hears that their lease is ending.
 """
 
 from __future__ import annotations
@@ -35,9 +40,12 @@ class Command(BaseCommand):
             result = emit(
                 "lease_expiring",
                 target=lease,
-                context={"member": member},
-                title="Your space lease is expiring",
-                body=f"Your lease for {lease.space} ends on {lease.end_date:%b %d, %Y}.",
+                context={
+                    "member": member,
+                    "member_name": member.display_name,
+                    "space_name": str(lease.space),
+                    "end_date": f"{lease.end_date:%B %-d, %Y}",
+                },
                 url="/",
                 period=f"lease:{lease.pk}:expiring",
             )

--- a/core/models.py
+++ b/core/models.py
@@ -618,6 +618,13 @@ class Invite(models.Model):
         # "invite_accepted") with actor=member.user and target=member, and resolves
         # the recipient via INVITER → self.invited_by (yielding no recipient, and so
         # no notification, when invited_by is None).
+        #
+        # The ``period`` MUST be unique per invite: it is the EventDelivery ledger's
+        # idempotency bucket, and a blank one collapses every acceptance in the app onto
+        # a single (event, inviter, channel) slot — so only the FIRST invite an admin
+        # ever sent would notify them and every later acceptance would be silently
+        # swallowed as a duplicate. Keying on the invite pk makes each invite its own
+        # slot while a re-run of the same acceptance stays idempotent.
         emit(
             "invite_accepted",
             actor=member.user if member is not None else None,
@@ -626,6 +633,7 @@ class Invite(models.Model):
             title="Your invite was accepted",
             body="Someone you invited has joined Past Lives.",
             url="/members/",
+            period=f"invite:{self.pk}:accepted",
         )
 
     @classmethod

--- a/core/triggers.py
+++ b/core/triggers.py
@@ -36,12 +36,27 @@ TRIGGERS: list[Trigger] = [
     Trigger("class_published", "New class published", "A new class or workshop goes live.", "Classes"),
     Trigger("class_reminder", "Class reminder", "24 hours before a session you're registered for.", "Classes"),
     Trigger("registration_confirmed", "Registration confirmed", "Your registration and payment cleared.", "Classes"),
-    Trigger("class_cancelled", "Class cancelled", "A class you're registered for was cancelled.", "Classes"),
+    # Transactional: a cancelled class always emails the people who booked it (including
+    # guests with no account), so it is forced rather than opt-in.
+    Trigger(
+        "class_cancelled",
+        "Class cancelled",
+        "A class you're registered for was cancelled.",
+        "Classes",
+        force_email=True,
+    ),
     Trigger(
         "waitlist_spot_available", "Waitlist spot available", "A spot opened in a class you waitlisted.", "Classes"
     ),
     Trigger("waitlist_confirmed", "Added to waitlist", "You joined a class waitlist.", "Classes"),
-    Trigger("refund_issued", "Refund issued", "A refund was processed for a registration.", "Classes"),
+    # Transactional: a refund is a money movement — the receipt always goes out.
+    Trigger(
+        "refund_issued",
+        "Refund issued",
+        "A refund was processed for a registration.",
+        "Classes",
+        force_email=True,
+    ),
     # Classes — instructor-side
     Trigger(
         "instructor_class_approved",
@@ -100,13 +115,34 @@ TRIGGERS: list[Trigger] = [
     # Billing / tab
     Trigger("tab_charged", "Tab charged", "Your monthly tab was charged.", "Billing"),
     Trigger("tab_charge_failed", "Tab charge failed", "A charge failed — update your payment method.", "Billing"),
-    Trigger("tab_entry_added", "Tab entry added", "An admin added a line item to your tab.", "Billing"),
-    Trigger("tab_approaching_limit", "Tab approaching limit", "Your balance is near your tab limit.", "Billing"),
+    # Transactional: both concern money owed on the member's tab — a charge they did not
+    # enter themselves, and the warning before the tab locks. Neither is opt-out-able.
+    Trigger(
+        "tab_entry_added",
+        "Tab entry added",
+        "An admin added a line item to your tab.",
+        "Billing",
+        force_email=True,
+    ),
+    Trigger(
+        "tab_approaching_limit",
+        "Tab approaching limit",
+        "Your balance is near your tab limit.",
+        "Billing",
+        force_email=True,
+    ),
     # Membership
     Trigger("invite_accepted", "Invite accepted", "Someone you invited has joined.", "Membership"),
     Trigger("new_member_joined", "New member joined", "A new member signed up.", "Membership", Audience.STAFF_ONLY),
     # Spaces / leases
-    Trigger("lease_expiring", "Lease expiring soon", "Your space lease ends within 30 days.", "Spaces"),
+    # Transactional: a tenant must hear that their lease is about to end.
+    Trigger(
+        "lease_expiring",
+        "Lease expiring soon",
+        "Your space lease ends within 30 days.",
+        "Spaces",
+        force_email=True,
+    ),
     # Admin broadcasts
     Trigger("site_announcement", "Makerspace-wide announcement", "Staff posted a site-wide notice.", "Announcements"),
 ]

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,34 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.18"
+VERSION = "0.23.20"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.20",
+        "date": "2026-07-22",
+        "title": "Important notices now reach you by email, not just the bell",
+        "changes": [
+            (
+                "A handful of things that really matter were only ever showing up as a "
+                "notification in the app, so they were easy to miss. From now on they email you "
+                "too: a class you booked being cancelled, a refund going out, a charge an admin "
+                "adds to your tab, your tab getting close to its limit, and your studio lease "
+                "coming up for renewal. Each one now spells out the details — which class, how "
+                "much, which space, what date — instead of a one-line nudge."
+            ),
+            (
+                "Booked a class as a guest, without a Past Lives account? Cancellation and refund "
+                "emails now reach you too. Before, they only went to people with accounts, so "
+                "guests heard nothing at all."
+            ),
+            (
+                "Fixed: if you'd invited more than one person to Past Lives, only the very first "
+                "acceptance ever notified you. Every invite you send now tells you when it's "
+                "accepted."
+            ),
+        ],
+    },
     {
         "version": "0.23.18",
         "date": "2026-07-21",

--- a/tests/core/events/emit_spec.py
+++ b/tests/core/events/emit_spec.py
@@ -109,12 +109,15 @@ def describe_emit():
 
     def describe_result():
         def it_reports_recipient_and_delivery_counts(linked_member):
-            # class_cancelled is a non-broadcast site-wide event (in_app only, by default),
-            # so one recipient yields exactly one delivery — no Discord post to inflate it.
+            # class_cancelled is a non-broadcast site-wide event — no Discord post to
+            # inflate the count — so its ONE recipient yields exactly two deliveries: the
+            # in-app bell row plus the FORCED transactional email (a cancelled class always
+            # emails the people it concerns).
             linked_member()
             result = emit("class_cancelled", context={}, title="t", body="b")
             assert result.recipient_count == 1
-            assert result.delivery_count == 1
+            assert result.delivery_count == 2
+            assert {channel for _user, channel in result.delivered} == {Channel.IN_APP, Channel.EMAIL}
             assert "class_cancelled" in repr(result)
 
     def describe_unknown_event():

--- a/tests/core/events/transactional_email_defaults_spec.py
+++ b/tests/core/events/transactional_email_defaults_spec.py
@@ -1,0 +1,327 @@
+"""The five legacy events that should always email, and the invite-accepted period.
+
+Every event seeded into the registry from ``core/triggers.py`` inherited ``EMAIL = OFF``
+because no legacy :class:`core.triggers.Trigger` ever set ``force_email`` /
+``email_default`` — so a cancelled class, a refund, a tab charge an admin added, a tab
+near its limit, and an expiring lease all reached members as a bell row only. These
+specs pin the fix:
+
+* each of the five now declares ``EMAIL = FORCED`` and actually puts a message in the
+  outbox when emitted through its real call site;
+* the two class events reach a **guest** registrant (no linked ``Member``, therefore
+  invisible to the ``registrant`` / ``all_active_members`` resolvers) via ``email_to``;
+* ``Invite.mark_accepted`` carries a per-invite ``period``, so a second invite's
+  acceptance is not swallowed as a ledger duplicate of the first.
+
+Emails are asserted on ``django.core.mail.outbox`` (the locmem backend the test env
+installs); bell rows on :class:`core.models.Notification`.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.management import call_command
+from django.db.models.signals import post_save
+from django.utils import timezone
+from factory.django import mute_signals
+
+from classes.factories import ClassOfferingFactory, ClassSessionFactory, RegistrationFactory, UserFactory
+from classes.models import ClassOffering, Registration
+from core.events.registry import Channel, ChannelDefault, get_event
+from core.models import Invite, Notification
+from membership.models import Member
+from tests.billing.factories import BillingSettingsFactory, ProductFactory, TabFactory
+from tests.membership.factories import LeaseFactory, MemberFactory
+
+pytestmark = pytest.mark.django_db
+
+# The five legacy events Josh decided must always email.
+FORCED_EMAIL_EVENTS = (
+    "class_cancelled",
+    "refund_issued",
+    "tab_entry_added",
+    "tab_approaching_limit",
+    "lease_expiring",
+)
+
+
+def _linked_member(*, email: str, username: str) -> Member:
+    """A Member with a linked, email-bearing User so a resolver can address it.
+
+    Signals are muted while creating the User so ``ensure_user_has_member`` does not
+    auto-create a second Member that would collide on the one-to-one ``user`` key.
+    """
+    member = MemberFactory(_pre_signup_email=email)
+    with mute_signals(post_save):
+        user = User.objects.create_user(username=username, email=email)
+    member.user = user
+    member.save(update_fields=["user"])
+    return member
+
+
+def _emails_to(address: str) -> list[mail.EmailMessage]:
+    return [message for message in mail.outbox if address in message.to]
+
+
+def _invite(email: str, inviter: User) -> Invite:
+    return Invite.objects.create(email=email, invited_by=inviter)
+
+
+def describe_forced_email_registry():
+    def it_declares_email_forced_for_every_transactional_event():
+        for key in FORCED_EMAIL_EVENTS:
+            spec = get_event(key).channel(Channel.EMAIL)
+            assert spec is not None, f"{key} declares no EMAIL channel"
+            assert spec.default is ChannelDefault.FORCED, f"{key} EMAIL is {spec.default}, expected FORCED"
+
+    def it_short_circuits_the_preference_check_for_a_member_who_opted_out():
+        from core.events import preferences
+        from core.models import NotificationPreference
+
+        user = UserFactory()
+        for key in FORCED_EMAIL_EVENTS:
+            NotificationPreference.objects.create(user=user, event_key=key, channel=Channel.EMAIL.value, enabled=False)
+            assert preferences.wants(user, key, Channel.EMAIL) is True
+
+
+def describe_class_cancelled_email():
+    def it_emails_the_member_who_booked_the_class():
+        member = _linked_member(email="booked@example.com", username="booked_member")
+        offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED, title="Lost-Wax Casting")
+        RegistrationFactory(
+            class_offering=offering,
+            member=member,
+            email="booked@example.com",
+            status=Registration.Status.CONFIRMED,
+        )
+        mail.outbox.clear()
+
+        offering.archive()
+
+        sent = _emails_to("booked@example.com")
+        assert len(sent) == 1
+        assert "Lost-Wax Casting" in sent[0].subject
+
+    def it_emails_a_guest_registrant_with_no_member_account():
+        offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED, title="Blacksmithing Basics")
+        RegistrationFactory(
+            class_offering=offering,
+            member=None,
+            email="guest@example.com",
+            status=Registration.Status.CONFIRMED,
+        )
+        mail.outbox.clear()
+
+        offering.archive()
+
+        sent = _emails_to("guest@example.com")
+        assert len(sent) == 1
+        assert "Blacksmithing Basics" in sent[0].subject
+
+    def it_names_the_class_and_its_date_in_the_body():
+        offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED, title="Wheel Throwing")
+        ClassSessionFactory(class_offering=offering, starts_at=timezone.now() + timedelta(days=9))
+        RegistrationFactory(
+            class_offering=offering,
+            member=None,
+            email="dated@example.com",
+            status=Registration.Status.CONFIRMED,
+        )
+        mail.outbox.clear()
+
+        offering.archive()
+
+        body = _emails_to("dated@example.com")[0].body
+        assert "Wheel Throwing" in body
+        assert offering.cancellation_date_label in body
+        assert "[missing:" not in body
+
+    def it_does_not_email_a_registrant_who_already_cancelled():
+        offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED)
+        RegistrationFactory(
+            class_offering=offering,
+            member=None,
+            email="gone@example.com",
+            status=Registration.Status.CANCELLED,
+        )
+        mail.outbox.clear()
+
+        offering.archive()
+
+        assert _emails_to("gone@example.com") == []
+
+    def it_never_emails_the_whole_membership():
+        # The event resolves ALL_ACTIVE_MEMBERS for the bell row; the email must stay
+        # with the registrants, so an uninvolved active member gets a bell and no mail.
+        bystander_user = UserFactory(last_login=timezone.now(), email="bystander@example.com")
+        offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED)
+        RegistrationFactory(
+            class_offering=offering,
+            member=None,
+            email="onlyme@example.com",
+            status=Registration.Status.CONFIRMED,
+        )
+        mail.outbox.clear()
+
+        offering.archive()
+
+        assert _emails_to("bystander@example.com") == []
+        assert Notification.objects.filter(trigger="class_cancelled", user=bystander_user).exists()
+
+    def describe_when_nobody_booked_the_class():
+        def it_sends_no_email_at_all():
+            UserFactory(last_login=timezone.now(), email="quiet@example.com")
+            offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED)
+            mail.outbox.clear()
+
+            offering.archive()
+
+            assert mail.outbox == []
+
+
+def describe_refund_issued_email():
+    def it_emails_the_member_the_refund_concerns():
+        member = _linked_member(email="refunded@example.com", username="refunded_member")
+        offering = ClassOfferingFactory(title="Screen Printing")
+        registration = RegistrationFactory(
+            class_offering=offering,
+            member=member,
+            email="refunded@example.com",
+            status=Registration.Status.CONFIRMED,
+            amount_paid_cents=6500,
+        )
+        mail.outbox.clear()
+
+        registration.status = Registration.Status.REFUNDED
+        registration.save()
+
+        sent = _emails_to("refunded@example.com")
+        assert len(sent) == 1
+        assert "Screen Printing" in sent[0].subject
+        assert "$65.00" in sent[0].body
+        assert "[missing:" not in sent[0].body
+
+    def it_emails_a_guest_registrant_with_no_member_account():
+        registration = RegistrationFactory(
+            member=None,
+            email="guestrefund@example.com",
+            status=Registration.Status.CONFIRMED,
+            amount_paid_cents=2500,
+        )
+        mail.outbox.clear()
+
+        registration.status = Registration.Status.REFUNDED
+        registration.save()
+
+        sent = _emails_to("guestrefund@example.com")
+        assert len(sent) == 1
+        assert "$25.00" in sent[0].body
+
+    def it_still_writes_the_bell_row_for_a_linked_member():
+        member = _linked_member(email="bell@example.com", username="bell_member")
+        registration = RegistrationFactory(
+            class_offering=ClassOfferingFactory(),
+            member=member,
+            email="bell@example.com",
+            status=Registration.Status.CONFIRMED,
+        )
+
+        registration.status = Registration.Status.REFUNDED
+        registration.save()
+
+        assert Notification.objects.filter(trigger="refund_issued", user=member.user).exists()
+
+
+def describe_tab_email():
+    @pytest.fixture
+    def tab():
+        BillingSettingsFactory()
+        member = _linked_member(email="tabholder@example.com", username="tab_member")
+        return TabFactory(member=member)
+
+    def it_emails_the_member_when_an_admin_adds_an_entry(tab):
+        admin = UserFactory()
+        product = ProductFactory()
+        mail.outbox.clear()
+
+        tab.add_entry(description="Bandsaw blade", amount=Decimal("18.00"), added_by=admin, product=product)
+
+        sent = _emails_to("tabholder@example.com")
+        assert len(sent) == 1
+        assert "$18.00" in sent[0].subject
+        assert "Bandsaw blade" in sent[0].body
+        assert "[missing:" not in sent[0].body
+
+    def it_emails_the_member_when_the_tab_nears_its_limit(tab):
+        admin = UserFactory()
+        product = ProductFactory()
+        mail.outbox.clear()
+
+        # 80% of the $200 default limit trips the warning.
+        tab.add_entry(description="Kiln firing", amount=Decimal("160.00"), added_by=admin, product=product)
+
+        subjects = [message.subject for message in _emails_to("tabholder@example.com")]
+        assert any("near its limit" in subject for subject in subjects)
+        limit_email = next(message for message in mail.outbox if "near its limit" in message.subject)
+        assert "$160.00" in limit_email.body
+        assert "[missing:" not in limit_email.body
+
+    def it_stays_quiet_for_a_self_service_entry(tab):
+        product = ProductFactory()
+        mail.outbox.clear()
+
+        tab.add_entry(description="Self swipe", amount=Decimal("5.00"), is_self_service=True, product=product)
+
+        assert _emails_to("tabholder@example.com") == []
+
+
+def describe_lease_expiring_email():
+    def it_emails_the_tenant_thirty_days_out():
+        member = _linked_member(email="tenant@example.com", username="tenant_member")
+        LeaseFactory(tenant_obj=member, end_date=timezone.now().date() + timedelta(days=30))
+        mail.outbox.clear()
+
+        call_command("send_lease_expiry_reminders")
+
+        sent = _emails_to("tenant@example.com")
+        assert len(sent) == 1
+        assert "lease ends" in sent[0].subject
+        assert "[missing:" not in sent[0].body
+
+    def it_sends_only_once_across_reruns():
+        member = _linked_member(email="oncetenant@example.com", username="once_tenant")
+        LeaseFactory(tenant_obj=member, end_date=timezone.now().date() + timedelta(days=30))
+        mail.outbox.clear()
+
+        call_command("send_lease_expiry_reminders")
+        call_command("send_lease_expiry_reminders")
+
+        assert len(_emails_to("oncetenant@example.com")) == 1
+
+
+def describe_invite_accepted_period():
+    def it_notifies_the_inviter_for_every_invite_not_just_the_first():
+        # A blank ``period`` collapses every acceptance onto one EventDelivery slot, so
+        # only the first invite an admin ever sent would ever notify them.
+        inviter = UserFactory()
+        first = _invite("first@example.com", inviter)
+        second = _invite("second@example.com", inviter)
+
+        first.mark_accepted()
+        second.mark_accepted()
+
+        assert Notification.objects.filter(trigger="invite_accepted", user=inviter).count() == 2
+
+    def it_stays_idempotent_for_a_repeated_acceptance_of_one_invite():
+        inviter = UserFactory()
+        invite = _invite("repeat@example.com", inviter)
+
+        invite.mark_accepted()
+        invite.mark_accepted()
+
+        assert Notification.objects.filter(trigger="invite_accepted", user=inviter).count() == 1

--- a/tests/e2e/email_gallery/registry.py
+++ b/tests/e2e/email_gallery/registry.py
@@ -572,13 +572,31 @@ _TRIGGER_NOTES: dict[str, str] = {
 }
 
 
+# Events whose EMAIL audience is NOT the one their in-app recipient resolver describes,
+# because the send addresses explicit ``email_to`` addresses instead (the guest-safe
+# transactional path). The card must document who gets the *email*, so these win over
+# ``audience_description``.
+_EMAIL_AUDIENCE_OVERRIDES: dict[str, str] = {
+    "class_cancelled": (
+        "Everyone holding a spot on the class — members and guests alike. "
+        "(The in-app bell row still goes to every active member.)"
+    ),
+    "refund_issued": "Whoever booked the registration, member or guest, at the address they booked with.",
+}
+
+
+def _spine_audience(event: EventType) -> str:
+    """Who receives this event's EMAIL — the override when one exists, else the resolver."""
+    return _EMAIL_AUDIENCE_OVERRIDES.get(event.key, audience_description(event))
+
+
 def _spine_trigger_note(event: EventType) -> str:
     """The plain-language trigger note for a derived spine card."""
     if event.key in _TRIGGER_NOTES:
-        return f"{_TRIGGER_NOTES[event.key]} Goes to: {audience_description(event)}"
+        return f"{_TRIGGER_NOTES[event.key]} Goes to: {_spine_audience(event)}"
     desc = event.description.rstrip(".")
     desc = desc[0].lower() + desc[1:] if desc else event.label.lower()
-    return f"Sent when {desc}. Goes to: {audience_description(event)}"
+    return f"Sent when {desc}. Goes to: {_spine_audience(event)}"
 
 
 def _spine_entry(event: EventType) -> GalleryEmail:
@@ -591,7 +609,7 @@ def _spine_entry(event: EventType) -> GalleryEmail:
         renderer=Renderer.SPINE_COPY,
         trigger_note=_spine_trigger_note(event),
         edit_pointer="Edit in Site Settings → Notifications",
-        audience=audience_description(event),
+        audience=_spine_audience(event),
         event_keys=frozenset({event.key}),
     )
 


### PR DESCRIPTION
## The bug

Every event the registry seeds from `core/triggers.py` inherited **`EMAIL = OFF`**.
`core/events/registry.py::_channels_from_trigger` derives the email channel from
`trigger.force_email` / `trigger.email_default` — and not one of the ~24 legacy
`Trigger` rows ever set either flag. Later Phase-6 events were hand-classified
`_EMAIL_ON` / `_EMAIL_FORCED`; nobody went back for the legacy ones. That is why the
email-copy review gallery listed 14 events under **"No email is sent"**.

Genuinely transactional emails (registration confirmation, reminders, waitlist,
orientations, tab receipts, invites) were never affected — they pass `email_to=` to
`emit()`, which bypasses preferences entirely.

Five events fell through the crack and have only ever reached members as an in-app
bell row:

| Event | Resolver | Emitted at |
|---|---|---|
| `class_cancelled` | `ALL_ACTIVE_MEMBERS` | `ClassOffering.archive` |
| `refund_issued` | `REGISTRANT` | `Registration.save` |
| `tab_entry_added` | `TAB_MEMBER` | `Tab._dispatch_entry_notifications` |
| `tab_approaching_limit` | `TAB_MEMBER` | `Tab._dispatch_entry_notifications` |
| `lease_expiring` | `LEASE_TENANT` | `send_lease_expiry_reminders` |

## What changed

**1. `force_email=True` on all five triggers.** These are transactional, not opt-out-able;
`preferences.wants()` short-circuits on a `FORCED` spec before it ever reads a
`NotificationPreference` row. They stay visible on the settings matrix, rendered
locked-on (`settings_matrix` sources the registry, not `triggers.for_member`).

**2. The guest hole is closed.** `refund_issued` was emitted inside `if self.member is not
None`, and `class_cancelled` could only reach people the `ALL_ACTIVE_MEMBERS` resolver
knew about — so a **guest registrant with no account got nothing at all**: no bell, no
email. Both now pass `email_to=` with the address on the *registration*, following
`classes.emails.send_registration_confirmation`.

`ClassOffering.archive` also passes **`suppress_email=True` unconditionally**. `email_to`
alone implies it, but only when the list is non-empty — so archiving a class nobody
booked would have fanned a FORCED email out to every active member. The bell row still
broadcasts to all active members; the email stays with the people who actually booked.
This is also strictly better than the alternative: archiving is routine housekeeping and
mailing ~600 members about it would be spam.

**3. All five now render from the DB copy catalogue.** They dropped their explicit
`title`/`body` ("fixed message" mode, one flat string to every channel) and pass the
documented merge fields instead. `class_cancelled` already had good curated copy;
`refund_issued`, `tab_entry_added`, `tab_approaching_limit` and `lease_expiring` were
falling back to `_generic_copy` (the settings-page blurb, with no amount, class, space
or date in it) and gained curated copy that says the actual thing:

```
[tab_entry_added] SUBJECT: $18.00 added to your tab
Hi Robin Vale,

Bandsaw blade — $18.00 was added to your tab at Past Lives.
It will be included in your next monthly charge.

See everything on your tab: https://…/tab/

If this doesn't look right, reply to this email and we'll sort it out.
```

**4. The one emit call site with no `period=`.** `Invite.mark_accepted` had none, so every
acceptance in the app collapsed onto a single `EventDelivery` slot — meaning only the
**first** invite an admin ever sent notified them, and every later acceptance was
silently swallowed as a duplicate. Now `invite:<pk>:accepted`.

**5. The gallery updates itself.** The "No email is sent" table drops from **14 rows to 9**
and all five gain rendered cards, no context fixes needed. `class_cancelled` /
`refund_issued` carry an explicit EMAIL-audience override so the card documents who gets
the *mail* (registrants, guests included), not who gets the bell.

## Tests

`tests/core/events/transactional_email_defaults_spec.py` — 18 specs: the FORCED
declaration + the preference short-circuit for a member who explicitly opted out; a real
email in the outbox from each of the five real call sites; the **guest** case for
`class_cancelled` and `refund_issued`; that an uninvolved active member gets a bell and
no mail; that an unbooked archive sends nothing at all; and that a second invite's
acceptance still notifies.

```
tests/core/events/transactional_email_defaults_spec.py ................. [ 94%]
.                                                                        [100%]
======================== 18 passed, 3 warnings in 9.51s ========================
```

Full suite: **6265 passed, 3 failed** — all three pre-existing/environmental and
unrelated:
* `discord_events_spec::it_maps_monthly_to_an_nth_weekday_rule` — reproduced on a clean
  `origin/main` worktree (date-dependent: today is the 5th Wednesday).
* two `settings_spec` `EMAIL_BACKEND` tests — the local dev image bakes
  `EMAIL_BACKEND=smtp`; they pass in CI's clean env.

`ruff format` / `ruff check` clean; `mypy plfog/ core/ membership/ hub/` clean, and clean
on `classes/models.py` + `billing/models.py`.

## Post-deploy op

The DB is the source of truth for copy at send time. The four newly-curated entries only
reach production once **`seed_notification_templates`** re-runs (it refreshes any row not
flagged `is_overridden`, so admin-authored copy is safe). Without it these four keep
sending the old generic body — correct, just thin.
