### PR TITLE
[classes] Own our class images; make legacy sync non-destructive (v0.23.23)

### DIFF
--- a/classes/import_service.py
+++ b/classes/import_service.py
@@ -149,6 +149,8 @@ def _upsert_offering(item: dict[str, Any]) -> str | None:
         "status": status,
         "scheduling_type": scheduling_type,
     }
+    # ``image`` appears in neither dict and is never assigned below: once a picture lives
+    # in our own storage the feed must not be able to touch it.
     offering, created = ClassOffering.objects.update_or_create(
         legacy_cms_id=node_id,
         defaults=shared_defaults,
@@ -161,7 +163,16 @@ def _upsert_offering(item: dict[str, Any]) -> str | None:
             slug = f"{slug}-legacy"
         offering.slug = slug
 
-    if image_url and not offering.image:
+    # Image ownership. Once an offering has a local image — migrated off the legacy CMS by
+    # ``download_legacy_images`` or uploaded by staff — the Drupal URL is never written
+    # back, and any URL left over from an earlier sync is cleared. Otherwise the next run
+    # would silently re-point the site at the server we are decommissioning for a picture
+    # we already host, and the request-time proxy would start fetching it all over again.
+    # A genuinely new class with no local image still picks up its feed image URL on first
+    # import, ready for the next ``download_legacy_images`` run.
+    if offering.image:
+        offering.legacy_image_url = ""
+    elif image_url:
         offering.legacy_image_url = image_url
 
     if not offering.instructor_id:
@@ -204,10 +215,9 @@ def sync_legacy_cms() -> int:
 
         next_url = ((data.get("links") or {}).get("next") or {}).get("href")
 
-    # Archive offerings no longer present in the API
-    ClassOffering.objects.filter(legacy_cms_id__gt="").exclude(legacy_cms_id__in=seen_ids).update(
-        status=ClassOffering.Status.ARCHIVED
-    )
+    # Archive offerings no longer present in the API — guarded against a feed that
+    # succeeds but returns nothing, which would otherwise archive the whole catalog.
+    ClassOffering.objects.archive_missing_from_legacy_feed(seen_ids)
 
     # Sanitize: collapse the same class posted on many dates into one catalog group.
     from classes.grouping import regroup_offerings

--- a/classes/management/commands/download_legacy_images.py
+++ b/classes/management/commands/download_legacy_images.py
@@ -1,21 +1,54 @@
-"""Download hero images from legacy CMS into Django media storage."""
+"""Download hero images from the legacy CMS into Django media storage.
+
+Migration step off classes.pastlives.space: every offering that still points at the
+Drupal server gets its picture copied into our own storage, normalized to the hero
+ceiling, and de-duplicated so a picture shared by many offerings is stored once.
+``legacy_image_url`` is cleared as each row lands, which is what stops the site
+proxying the old server at request time.
+
+Idempotent: only rows that still have a legacy URL and no local image are touched,
+so a re-run after a partial failure picks up exactly what is left.
+"""
 
 from __future__ import annotations
 
+import urllib.error
 import urllib.request
 from pathlib import Path
+from urllib.parse import unquote, urlsplit
 
+from django.conf import settings
 from django.core.files.base import ContentFile
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
+from PIL import UnidentifiedImageError
 
-from classes.models import ClassOffering
+from classes.models import CLASS_IMAGE_PREFIX, ClassOffering
+from core.images import normalize_image, store_content_addressed
+
+
+LEGACY_IMAGE_PREFIX = "https://classes.pastlives.space/"
+
+# Fraction of attempted downloads that may fail before the command reports failure via a
+# non-zero exit. A handful of dead images is routine; half the catalog failing means the
+# host, the network or the configuration is wrong and a human has to look.
+FAILURE_ABORT_FRACTION = 0.5
+
+
+def legacy_image_filename(url: str) -> str:
+    """Return the human-readable basename encoded in a legacy image URL.
+
+    Drops the query string and percent-decodes the path, so
+    ``.../Closeup%20Hands%202_11.JPG?itok=x`` reads back as
+    ``Closeup Hands 2_11.JPG`` rather than ``Closeup20Hands202_11.JPG``.
+    """
+    return Path(unquote(urlsplit(url).path)).name
 
 
 class Command(BaseCommand):
     help = "Download hero images from legacy_image_url into plfog media storage."
 
     def handle(self, *args, **options) -> None:
-        qs = ClassOffering.objects.filter(legacy_image_url__gt="", image="")
+        qs = ClassOffering.objects.filter(legacy_image_url__gt="", image="").order_by("pk")
         total = qs.count()
         if not total:
             self.stdout.write("No offerings with pending legacy images.")
@@ -23,25 +56,59 @@ class Command(BaseCommand):
 
         ok = 0
         fail = 0
-        for offering in qs:
-            try:
-                url = offering.legacy_image_url
-                # SSRF guard: only allow legacy CMS domain
-                if not url.startswith("https://classes.pastlives.space/"):
-                    self.stderr.write(f"Skipping untrusted URL: {url}")
-                    fail += 1
-                    continue
+        shared = 0
+        seen_keys: set[str] = set()
 
+        for offering in qs.iterator():
+            url = offering.legacy_image_url
+            # SSRF guard: only allow the legacy CMS domain.
+            if not url.startswith(LEGACY_IMAGE_PREFIX):
+                self.stderr.write(f"Skipping untrusted URL: {url}")
+                fail += 1
+                continue
+
+            try:
                 with urllib.request.urlopen(url, timeout=15) as resp:
                     content = resp.read()
-
-                filename = Path(url.split("?")[0]).name
-                offering.image.save(filename, ContentFile(content), save=False)
-                offering.legacy_image_url = ""
-                offering.save(update_fields=["image", "legacy_image_url"])
-                ok += 1
-            except Exception as exc:
+            except (OSError, ValueError) as exc:
                 self.stderr.write(f"Failed for offering {offering.pk}: {exc}")
                 fail += 1
+                continue
 
-        self.stdout.write(self.style.SUCCESS(f"Downloaded {ok} image(s). {fail} failed."))
+            filename = legacy_image_filename(url)
+            ext = "jpg"
+            try:
+                data = normalize_image(
+                    ContentFile(content, name=filename),
+                    max_long_edge=settings.IMAGE_MAX_LONG_EDGE_HERO,
+                ).read()
+            except (UnidentifiedImageError, OSError, ValueError) as exc:
+                # Keep the picture rather than lose it, but store the original bytes
+                # under their own extension so nothing claims to be a JPEG.
+                self.stderr.write(f"Could not normalize offering {offering.pk} ({filename}): {exc}")
+                data = content
+                ext = (Path(filename).suffix.lstrip(".").lower() or "bin")[:10]
+
+            key = store_content_addressed(data, prefix=CLASS_IMAGE_PREFIX, ext=ext)
+            if key in seen_keys:
+                shared += 1
+            seen_keys.add(key)
+
+            offering.image = key
+            offering.legacy_image_url = ""
+            offering.save(update_fields=["image", "legacy_image_url"])
+            ok += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Downloaded {ok} image(s) into {len(seen_keys)} stored object(s) "
+                f"({shared} re-used an image another class already has). {fail} failed."
+            )
+        )
+        if fail and fail >= total * FAILURE_ABORT_FRACTION:
+            raise CommandError(
+                f"{fail} of {total} legacy image download(s) failed — at or above the "
+                f"{FAILURE_ABORT_FRACTION:.0%} failure ceiling. This usually means the legacy host "
+                "is unreachable or storage is misconfigured, not that the images are gone. "
+                "Whatever succeeded has been saved; fix the cause and re-run to pick up the rest."
+            )

--- a/classes/management/commands/optimize_class_images.py
+++ b/classes/management/commands/optimize_class_images.py
@@ -1,0 +1,132 @@
+"""Normalize and de-duplicate class hero images already sitting in storage.
+
+The first migration off the legacy CMS wrote raw originals: ``FieldFile.save()``
+commits straight to storage, so the ``normalize_field_if_uploaded`` hook on
+``ClassOffering.save()`` never fired, and with ``file_overwrite=False`` every row
+got its own object even when dozens of classes shared one picture.
+
+This command repairs that in place, on whatever is stored right now:
+
+* each image is re-encoded through ``core.images.normalize_image`` at the hero
+  ceiling (EXIF stripped, RGB, JPEG q85), and
+* the result is stored under a content-addressed key, so classes sharing a
+  picture converge on one object and the copies they replaced are deleted.
+
+It is idempotent and interruptible: a row whose key is already content-addressed
+is skipped without a download, and every row is committed as it is processed, so
+a re-run resumes where the last one stopped. ``--dry-run`` reports the projected
+saving without writing or deleting anything.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.core.management.base import BaseCommand, CommandError
+from PIL import UnidentifiedImageError
+
+from classes.models import CLASS_IMAGE_PREFIX, ClassOffering
+from core.files import delete_if_unreferenced
+from core.images import (
+    content_addressed_name,
+    is_content_addressed,
+    normalize_image,
+    store_content_addressed,
+)
+
+
+# Fraction of processable images that may fail before the command exits non-zero.
+FAILURE_ABORT_FRACTION = 0.5
+
+
+def _mb(num_bytes: int) -> str:
+    return f"{num_bytes / (1024 * 1024):.1f} MB"
+
+
+class Command(BaseCommand):
+    help = "Normalize and de-duplicate stored class hero images."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report the projected saving without writing, replacing or deleting anything.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        dry_run: bool = options["dry_run"]
+        qs = ClassOffering.objects.exclude(image="").order_by("pk")
+
+        processed = 0
+        skipped = 0
+        failed = 0
+        before_bytes = 0
+        after_bytes = 0
+        counted_before: set[str] = set()
+        counted_after: set[str] = set()
+
+        for offering in qs.iterator():
+            name: str = offering.image.name or ""
+            if is_content_addressed(name, prefix=CLASS_IMAGE_PREFIX):
+                skipped += 1
+                continue
+
+            try:
+                with default_storage.open(name, "rb") as handle:
+                    raw = handle.read()
+            except (FileNotFoundError, OSError, ValueError) as exc:
+                self.stderr.write(f"Could not read image for offering {offering.pk} ({name}): {exc}")
+                failed += 1
+                continue
+
+            if name not in counted_before:
+                counted_before.add(name)
+                before_bytes += len(raw)
+
+            try:
+                data = normalize_image(
+                    ContentFile(raw, name=name),
+                    max_long_edge=settings.IMAGE_MAX_LONG_EDGE_HERO,
+                ).read()
+            except (UnidentifiedImageError, OSError, ValueError) as exc:
+                self.stderr.write(f"Could not normalize offering {offering.pk} ({name}): {exc}")
+                failed += 1
+                continue
+
+            target = content_addressed_name(data, prefix=CLASS_IMAGE_PREFIX)
+            if target not in counted_after:
+                counted_after.add(target)
+                after_bytes += len(data)
+            processed += 1
+
+            if dry_run:
+                continue
+
+            key = store_content_addressed(data, prefix=CLASS_IMAGE_PREFIX)
+            # Write the column directly rather than through save(): the hero-crop reset in
+            # ClassOffering.save() fires on any image change, and re-pointing a row at the
+            # very same picture must not throw away a staff-set crop.
+            ClassOffering.objects.filter(pk=offering.pk).update(image=key)
+            # The row now points at `key`, so a plain reference check is exactly right:
+            # the object we moved off is removed only once nothing at all still uses it —
+            # not while a sibling offering shares it, and not when it turned out to be the
+            # object we just landed on.
+            delete_if_unreferenced(ClassOffering, "image", name)
+
+        saved = max(0, before_bytes - after_bytes)
+        pct = (saved / before_bytes * 100) if before_bytes else 0.0
+        label = "Would optimize" if dry_run else "Optimized"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{label} {processed} image(s) into {len(counted_after)} stored object(s); "
+                f"{skipped} already optimized, {failed} failed. "
+                f"{_mb(before_bytes)} -> {_mb(after_bytes)} ({_mb(saved)} saved, {pct:.0f}%)."
+            )
+        )
+        if failed and failed >= (processed + failed) * FAILURE_ABORT_FRACTION:
+            raise CommandError(
+                f"{failed} of {processed + failed} class image(s) could not be optimized — at or "
+                f"above the {FAILURE_ABORT_FRACTION:.0%} failure ceiling. Check storage credentials "
+                "and connectivity; nothing that failed was modified, so a re-run is safe."
+            )

--- a/classes/models.py
+++ b/classes/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import re
 import secrets
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import date as date_type, datetime
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -26,6 +27,8 @@ if TYPE_CHECKING:
     from django.core.files.uploadedfile import UploadedFile
 
     from membership.models import Member
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_LIABILITY_TEXT = """ASSUMPTION OF RISK AND WAIVER OF LIABILITY
 
@@ -113,6 +116,21 @@ class Category(HeroCropMixin, models.Model):
         delete_orphan_on_replace(self, "hero_image")
         normalize_field_if_uploaded(self, "hero_image", settings.IMAGE_MAX_LONG_EDGE_HERO)
         super().save(*args, **kwargs)
+
+
+# Storage folder + ceiling constants for class hero images. Keys under this prefix are
+# content-addressed (see core.images.store_content_addressed) so the same picture used by
+# many offerings is stored exactly once.
+CLASS_IMAGE_PREFIX = "classes/images/"
+
+# Ceiling on how much of the live legacy catalog a single sync run may archive. Above
+# this, ``ClassOfferingQuerySet.archive_missing_from_legacy_feed`` refuses to act and logs
+# instead — a feed that suddenly lists almost nothing is far likelier to be broken than to
+# be telling the truth.
+LEGACY_ARCHIVE_GUARD_FRACTION = 0.5
+
+# Human-readable pointer used in the guard's log line.
+LEGACY_CMS_FEED_LABEL = "https://classes.pastlives.space/jsonapi/node/class"
 
 
 class ClassOfferingQuerySet(models.QuerySet["ClassOffering"]):
@@ -215,6 +233,52 @@ class ClassOfferingQuerySet(models.QuerySet["ClassOffering"]):
             )
         ).values("pk", "capacity", "used")
         return {row["pk"]: max(0, row["capacity"] - row["used"]) for row in rows}
+
+    def archive_missing_from_legacy_feed(self, seen_ids: Sequence[str]) -> int:
+        """Archive legacy-CMS offerings absent from the feed, with a blast-radius guard.
+
+        The legacy Drupal feed is the authority for which imported classes still exist,
+        so anything it stops listing gets archived. That single statement is enormously
+        destructive at our scale — practically every offering carries a ``legacy_cms_id``
+        — and an *unsuccessful-but-HTTP-200* fetch is entirely plausible while the legacy
+        CMS is being decommissioned: content unpublished upstream, an auth wall answering
+        200 with an empty ``data`` array, a truncated first page. Any of those would
+        archive the whole catalog in one write.
+
+        So the sweep is skipped when the feed listed nothing at all, or when it would
+        archive more than :data:`LEGACY_ARCHIVE_GUARD_FRACTION` of the live legacy
+        offerings. A tripped guard is logged at ERROR — the sync has no alerting, so that
+        log line is the only signal anyone gets.
+
+        Args:
+            seen_ids: Legacy node UUIDs present in the feed that was just fetched.
+
+        Returns:
+            Number of offerings archived — 0 when nothing was stale or the guard tripped.
+        """
+        live = self.filter(legacy_cms_id__gt="").exclude(status=ClassOffering.Status.ARCHIVED)
+        total = live.count()
+        if not total:
+            return 0
+        stale = live.exclude(legacy_cms_id__in=list(seen_ids))
+        stale_count = stale.count()
+        if not stale_count:
+            return 0
+        if not seen_ids or stale_count > total * LEGACY_ARCHIVE_GUARD_FRACTION:
+            logger.error(
+                "!!! LEGACY CMS SYNC ARCHIVE GUARD TRIPPED — NOTHING WAS ARCHIVED !!! "
+                "The feed listed %d class(es), which would have archived %d of %d live "
+                "legacy offerings (over the %.0f%% ceiling). This almost always means the "
+                "legacy CMS answered with an empty or truncated payload, not that the "
+                "classes really went away. Check %s before assuming the catalog shrank.",
+                len(seen_ids),
+                stale_count,
+                total,
+                LEGACY_ARCHIVE_GUARD_FRACTION * 100,
+                LEGACY_CMS_FEED_LABEL,
+            )
+            return 0
+        return stale.update(status=ClassOffering.Status.ARCHIVED)
 
 
 _SLUG_RETRY_LIMIT = 5

--- a/classes/spec/management/download_legacy_images_spec.py
+++ b/classes/spec/management/download_legacy_images_spec.py
@@ -2,15 +2,49 @@
 
 from __future__ import annotations
 
+import io
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.core.files.storage import default_storage
 from django.core.management import call_command
+from django.core.management.base import CommandError
+from PIL import Image
 
 from classes.factories import ClassOfferingFactory
+from classes.management.commands.download_legacy_images import legacy_image_filename
+from classes.models import CLASS_IMAGE_PREFIX, ClassOffering
+from core.images import is_content_addressed
 
 pytestmark = pytest.mark.django_db
+
+
+def _jpeg_bytes(size: tuple[int, int] = (4000, 3000)) -> bytes:
+    """A real JPEG, oversized so normalization has something to do."""
+    img = Image.new("RGB", size)
+    pixels = img.load()
+    for y in range(0, size[1], 7):
+        for x in range(0, size[0], 7):
+            pixels[x, y] = ((x * 7) % 256, (y * 13) % 256, (x + y) % 256)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=100)
+    return buf.getvalue()
+
+
+def _mock_response(content: bytes) -> MagicMock:
+    mock = MagicMock()
+    mock.read.return_value = content
+    mock.__enter__ = lambda s: s
+    mock.__exit__ = MagicMock(return_value=False)
+    return mock
+
+
+def describe_legacy_image_filename():
+    def it_percent_decodes_the_path_and_drops_the_query():
+        url = "https://classes.pastlives.space/sites/default/files/Closeup%20Hands%202_11.JPG?itok=abc"
+
+        assert legacy_image_filename(url) == "Closeup Hands 2_11.JPG"
 
 
 def describe_download_legacy_images_command():
@@ -25,29 +59,81 @@ def describe_download_legacy_images_command():
             image="",
         )
 
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b"fake-image-bytes"
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-
         out = StringIO()
-        with patch("urllib.request.urlopen", return_value=mock_resp):
-            call_command("download_legacy_images", stdout=out)
+        with patch("urllib.request.urlopen", return_value=_mock_response(_jpeg_bytes((400, 300)))):
+            call_command("download_legacy_images", stdout=out, stderr=StringIO())
 
         offering.refresh_from_db()
         assert offering.legacy_image_url == ""
+        assert offering.image.name
         assert "Downloaded 1" in out.getvalue()
 
-    def it_skips_untrusted_urls():
-        ClassOfferingFactory(
-            legacy_image_url="https://evil.example.com/img.jpg",
+    def it_normalizes_the_downloaded_image():
+        raw = _jpeg_bytes()
+        offering = ClassOfferingFactory(
+            legacy_image_url="https://classes.pastlives.space/sites/default/files/huge.jpg",
             image="",
         )
+
+        with patch("urllib.request.urlopen", return_value=_mock_response(raw)):
+            call_command("download_legacy_images", stdout=StringIO(), stderr=StringIO())
+
+        offering.refresh_from_db()
+        assert default_storage.size(offering.image.name) < len(raw)
+        with default_storage.open(offering.image.name, "rb") as handle:
+            assert max(Image.open(handle).size) <= 2400
+
+    def it_stores_the_image_under_a_content_addressed_key():
+        offering = ClassOfferingFactory(
+            legacy_image_url="https://classes.pastlives.space/sites/default/files/mycustom.png",
+            image="",
+        )
+
+        with patch("urllib.request.urlopen", return_value=_mock_response(_jpeg_bytes((400, 300)))):
+            call_command("download_legacy_images", stdout=StringIO(), stderr=StringIO())
+
+        offering.refresh_from_db()
+        assert is_content_addressed(offering.image.name, prefix=CLASS_IMAGE_PREFIX)
+
+    def it_stores_one_object_for_offerings_that_share_a_legacy_url():
+        shared_url = "https://classes.pastlives.space/sites/default/files/2024-03/pattern.jpeg"
+        first = ClassOfferingFactory(legacy_image_url=shared_url, image="")
+        second = ClassOfferingFactory(legacy_image_url=shared_url, image="")
+        raw = _jpeg_bytes((500, 400))
+
+        out = StringIO()
+        with patch("urllib.request.urlopen", side_effect=lambda *a, **kw: _mock_response(raw)):
+            call_command("download_legacy_images", stdout=out, stderr=StringIO())
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.image.name == second.image.name
+        assert "into 1 stored object(s)" in out.getvalue()
+
+    def it_keeps_the_original_bytes_when_normalization_fails():
+        offering = ClassOfferingFactory(
+            legacy_image_url="https://classes.pastlives.space/sites/default/files/broken.jpg",
+            image="",
+        )
+
         err = StringIO()
-        call_command("download_legacy_images", stderr=err)
+        with patch("urllib.request.urlopen", return_value=_mock_response(b"not really an image")):
+            call_command("download_legacy_images", stdout=StringIO(), stderr=err)
+
+        offering.refresh_from_db()
+        assert offering.image.name
+        assert "Could not normalize" in err.getvalue()
+
+    def it_skips_untrusted_urls():
+        ClassOfferingFactory(legacy_image_url="https://evil.example.com/img.jpg", image="")
+
+        err = StringIO()
+        with pytest.raises(CommandError, match="failure ceiling"):
+            call_command("download_legacy_images", stdout=StringIO(), stderr=err)
+
         assert "untrusted" in err.getvalue().lower()
 
-    def it_reports_failures_separately():
+    def it_exits_non_zero_when_most_downloads_fail():
         ClassOfferingFactory(
             legacy_image_url="https://classes.pastlives.space/sites/default/files/notfound.jpg",
             image="",
@@ -55,46 +141,56 @@ def describe_download_legacy_images_command():
 
         err = StringIO()
         out = StringIO()
-        with patch("urllib.request.urlopen", side_effect=ValueError("Not found")):
+        with (
+            patch("urllib.request.urlopen", side_effect=OSError("Not found")),
+            pytest.raises(CommandError, match="failure ceiling"),
+        ):
             call_command("download_legacy_images", stdout=out, stderr=err)
 
-        # Should still report 0 downloaded, 1 failed
         assert "Downloaded 0" in out.getvalue()
-        assert "Failed" in err.getvalue()
+        assert "Failed for offering" in err.getvalue()
 
-    def it_saves_image_with_original_filename():
-        offering = ClassOfferingFactory(
-            legacy_image_url="https://classes.pastlives.space/sites/default/files/mycustom.png",
-            image="",
-        )
+    def it_tolerates_a_minority_of_failures():
+        ClassOfferingFactory(legacy_image_url="https://classes.pastlives.space/sites/default/files/a.jpg", image="")
+        ClassOfferingFactory(legacy_image_url="https://classes.pastlives.space/sites/default/files/b.jpg", image="")
+        ClassOfferingFactory(legacy_image_url="https://evil.example.com/c.jpg", image="")
 
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b"fake-image-bytes"
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
+        out = StringIO()
+        with patch("urllib.request.urlopen", side_effect=lambda *a, **kw: _mock_response(_jpeg_bytes((300, 200)))):
+            call_command("download_legacy_images", stdout=out, stderr=StringIO())
 
-        with patch("urllib.request.urlopen", return_value=mock_resp):
-            call_command("download_legacy_images", stdout=StringIO())
-
-        offering.refresh_from_db()
-        # Image should be saved with a name based on the original filename
-        assert offering.image.name
-        assert "mycustom" in offering.image.name
+        assert "Downloaded 2" in out.getvalue()
+        assert "1 failed" in out.getvalue()
 
     def it_skips_offerings_that_already_have_images():
         ClassOfferingFactory(
             legacy_image_url="https://classes.pastlives.space/sites/default/files/img.jpg",
-            image="existing/image.jpg",  # Already has an image
+            image="existing/image.jpg",
         )
         out = StringIO()
         call_command("download_legacy_images", stdout=out)
         assert "No offerings" in out.getvalue()
 
     def it_skips_offerings_with_empty_legacy_image_url():
-        ClassOfferingFactory(
-            legacy_image_url="",  # No legacy URL
-            image="",
-        )
+        ClassOfferingFactory(legacy_image_url="", image="")
         out = StringIO()
         call_command("download_legacy_images", stdout=out)
         assert "No offerings" in out.getvalue()
+
+    def it_does_not_re_download_on_a_second_run():
+        offering = ClassOfferingFactory(
+            legacy_image_url="https://classes.pastlives.space/sites/default/files/once.jpg",
+            image="",
+        )
+
+        with patch("urllib.request.urlopen", return_value=_mock_response(_jpeg_bytes((400, 300)))) as opener:
+            call_command("download_legacy_images", stdout=StringIO(), stderr=StringIO())
+            assert opener.call_count == 1
+
+            out = StringIO()
+            call_command("download_legacy_images", stdout=out, stderr=StringIO())
+            assert opener.call_count == 1
+            assert "No offerings" in out.getvalue()
+
+        offering.refresh_from_db()
+        assert ClassOffering.objects.filter(pk=offering.pk, legacy_image_url="").exists()

--- a/classes/spec/management/optimize_class_images_spec.py
+++ b/classes/spec/management/optimize_class_images_spec.py
@@ -1,0 +1,173 @@
+"""Specs for classes/management/commands/optimize_class_images.py."""
+
+from __future__ import annotations
+
+import io
+from io import StringIO
+
+import pytest
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from PIL import Image
+
+from classes.factories import ClassOfferingFactory
+from classes.models import CLASS_IMAGE_PREFIX, ClassOffering
+from core.images import is_content_addressed
+
+pytestmark = pytest.mark.django_db
+
+
+def _big_jpeg_bytes(size: tuple[int, int] = (4000, 3000)) -> bytes:
+    """A JPEG well over the 2400px hero ceiling, with enough detail to be large."""
+    img = Image.new("RGB", size)
+    pixels = img.load()
+    for y in range(0, size[1], 7):
+        for x in range(0, size[0], 7):
+            pixels[x, y] = ((x * 7) % 256, (y * 13) % 256, (x + y) % 256)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=100)
+    return buf.getvalue()
+
+
+def _store_raw(name: str, content: bytes) -> str:
+    """Put raw bytes in storage under a non-content-addressed name, as the migration did."""
+    return default_storage.save(name, ContentFile(content))
+
+
+def describe_optimize_class_images_command():
+    def describe_normalization():
+        def it_shrinks_an_oversized_image():
+            raw = _big_jpeg_bytes()
+            stored = _store_raw("classes/images/huge.jpg", raw)
+            offering = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk=offering.pk).update(image=stored)
+
+            call_command("optimize_class_images", stdout=StringIO(), stderr=StringIO())
+
+            offering.refresh_from_db()
+            assert offering.image.name != stored
+            assert default_storage.size(offering.image.name) < len(raw)
+            with default_storage.open(offering.image.name, "rb") as handle:
+                assert max(Image.open(handle).size) <= 2400
+
+        def it_stores_the_result_under_a_content_addressed_key():
+            stored = _store_raw("classes/images/named.jpg", _big_jpeg_bytes((600, 400)))
+            offering = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk=offering.pk).update(image=stored)
+
+            call_command("optimize_class_images", stdout=StringIO(), stderr=StringIO())
+
+            offering.refresh_from_db()
+            assert is_content_addressed(offering.image.name, prefix=CLASS_IMAGE_PREFIX)
+
+        def it_deletes_the_object_it_replaced():
+            stored = _store_raw("classes/images/replaced.jpg", _big_jpeg_bytes((600, 400)))
+            offering = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk=offering.pk).update(image=stored)
+
+            call_command("optimize_class_images", stdout=StringIO(), stderr=StringIO())
+
+            assert not default_storage.exists(stored)
+
+    def describe_de_duplication():
+        def it_collapses_offerings_that_share_a_picture_onto_one_object():
+            raw = _big_jpeg_bytes((900, 600))
+            # Two separate stored objects holding identical bytes — exactly what
+            # file_overwrite=False produced for the 74 shared legacy images.
+            first_name = _store_raw("classes/images/copy_a.jpg", raw)
+            second_name = _store_raw("classes/images/copy_b.jpg", raw)
+            first = ClassOfferingFactory(image="")
+            second = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk=first.pk).update(image=first_name)
+            ClassOffering.objects.filter(pk=second.pk).update(image=second_name)
+
+            call_command("optimize_class_images", stdout=StringIO(), stderr=StringIO())
+
+            first.refresh_from_db()
+            second.refresh_from_db()
+            assert first.image.name == second.image.name
+            assert default_storage.exists(first.image.name)
+
+        def it_does_not_delete_an_object_a_sibling_still_points_at():
+            raw = _big_jpeg_bytes((900, 600))
+            shared = _store_raw("classes/images/shared_src.jpg", raw)
+            first = ClassOfferingFactory(image="")
+            second = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk__in=[first.pk, second.pk]).update(image=shared)
+
+            call_command("optimize_class_images", stdout=StringIO(), stderr=StringIO())
+
+            first.refresh_from_db()
+            second.refresh_from_db()
+            assert first.image.name == second.image.name
+            assert default_storage.exists(first.image.name)
+
+    def describe_idempotency():
+        def it_skips_images_it_already_optimized_on_a_second_run():
+            stored = _store_raw("classes/images/twice.jpg", _big_jpeg_bytes((800, 600)))
+            offering = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk=offering.pk).update(image=stored)
+
+            call_command("optimize_class_images", stdout=StringIO(), stderr=StringIO())
+            offering.refresh_from_db()
+            first_pass_name = offering.image.name
+
+            out = StringIO()
+            call_command("optimize_class_images", stdout=out, stderr=StringIO())
+
+            offering.refresh_from_db()
+            assert offering.image.name == first_pass_name
+            assert default_storage.exists(first_pass_name)
+            assert "Optimized 0 image(s)" in out.getvalue()
+            assert "already optimized" in out.getvalue()
+
+    def describe_dry_run():
+        def it_reports_a_saving_without_touching_storage():
+            raw = _big_jpeg_bytes()
+            stored = _store_raw("classes/images/dry.jpg", raw)
+            offering = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk=offering.pk).update(image=stored)
+
+            out = StringIO()
+            call_command("optimize_class_images", "--dry-run", stdout=out, stderr=StringIO())
+
+            offering.refresh_from_db()
+            assert offering.image.name == stored
+            assert default_storage.exists(stored)
+            assert "Would optimize 1 image(s)" in out.getvalue()
+            assert "saved" in out.getvalue()
+
+            default_storage.delete(stored)  # cleanup
+
+    def describe_failures():
+        def it_reports_an_unreadable_image_and_exits_non_zero():
+            offering = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk=offering.pk).update(image="classes/images/gone-missing.jpg")
+
+            err = StringIO()
+            with pytest.raises(CommandError, match="failure ceiling"):
+                call_command("optimize_class_images", stdout=StringIO(), stderr=err)
+
+            assert "Could not read image" in err.getvalue()
+
+        def it_reports_bytes_that_are_not_an_image():
+            stored = _store_raw("classes/images/not-an-image.jpg", b"definitely not a jpeg")
+            offering = ClassOfferingFactory(image="")
+            ClassOffering.objects.filter(pk=offering.pk).update(image=stored)
+
+            err = StringIO()
+            with pytest.raises(CommandError, match="failure ceiling"):
+                call_command("optimize_class_images", stdout=StringIO(), stderr=err)
+
+            assert "Could not normalize" in err.getvalue()
+            default_storage.delete(stored)  # cleanup
+
+    def it_reports_nothing_to_do_when_no_offering_has_an_image():
+        ClassOfferingFactory(image="")
+
+        out = StringIO()
+        call_command("optimize_class_images", stdout=out, stderr=StringIO())
+
+        assert "Optimized 0 image(s)" in out.getvalue()

--- a/classes/spec/models/class_offering_archive_guard_spec.py
+++ b/classes/spec/models/class_offering_archive_guard_spec.py
@@ -1,0 +1,104 @@
+"""Specs for ClassOfferingQuerySet.archive_missing_from_legacy_feed.
+
+The legacy feed drives a mass-archive across nearly the whole catalog, so the guard
+around it is the safety net for the one failure mode that would empty the class
+listing in a single statement: a feed that answers HTTP 200 with nothing in it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from classes.factories import ClassOfferingFactory
+from classes.models import ClassOffering
+
+pytestmark = pytest.mark.django_db
+
+
+def _legacy(n: int) -> ClassOffering:
+    return ClassOfferingFactory(
+        legacy_cms_id=f"uuid-{n}",
+        status=ClassOffering.Status.PUBLISHED,
+        image="",
+    )
+
+
+def describe_archive_missing_from_legacy_feed():
+    def it_archives_the_handful_the_feed_dropped():
+        kept = [_legacy(i) for i in range(9)]
+        dropped = _legacy(99)
+
+        archived = ClassOffering.objects.archive_missing_from_legacy_feed([o.legacy_cms_id for o in kept])
+
+        dropped.refresh_from_db()
+        assert archived == 1
+        assert dropped.status == ClassOffering.Status.ARCHIVED
+        assert all(ClassOffering.objects.get(pk=o.pk).status == ClassOffering.Status.PUBLISHED for o in kept)
+
+    def describe_when_the_feed_came_back_empty():
+        def it_archives_nothing():
+            offerings = [_legacy(i) for i in range(3)]
+
+            archived = ClassOffering.objects.archive_missing_from_legacy_feed([])
+
+            assert archived == 0
+            for offering in offerings:
+                offering.refresh_from_db()
+                assert offering.status == ClassOffering.Status.PUBLISHED
+
+        def it_logs_loudly(caplog):
+            _legacy(1)
+
+            with caplog.at_level("ERROR", logger="classes.models"):
+                ClassOffering.objects.archive_missing_from_legacy_feed([])
+
+            assert "ARCHIVE GUARD TRIPPED" in caplog.text
+            assert "NOTHING WAS ARCHIVED" in caplog.text
+
+    def describe_when_the_feed_would_archive_more_than_half():
+        def it_archives_nothing():
+            offerings = [_legacy(i) for i in range(4)]
+
+            # Feed lists 1 of 4 — archiving 3 (75%) is over the 50% ceiling.
+            archived = ClassOffering.objects.archive_missing_from_legacy_feed([offerings[0].legacy_cms_id])
+
+            assert archived == 0
+            for offering in offerings:
+                offering.refresh_from_db()
+                assert offering.status == ClassOffering.Status.PUBLISHED
+
+        def it_still_archives_at_exactly_half():
+            offerings = [_legacy(i) for i in range(4)]
+            seen = [o.legacy_cms_id for o in offerings[:2]]
+
+            archived = ClassOffering.objects.archive_missing_from_legacy_feed(seen)
+
+            assert archived == 2
+
+    def describe_when_nothing_needs_archiving():
+        def it_returns_zero_without_writing():
+            offerings = [_legacy(i) for i in range(3)]
+
+            archived = ClassOffering.objects.archive_missing_from_legacy_feed([o.legacy_cms_id for o in offerings])
+
+            assert archived == 0
+
+        def it_returns_zero_when_no_offering_came_from_the_legacy_cms():
+            ClassOfferingFactory(legacy_cms_id="", image="")
+
+            assert ClassOffering.objects.archive_missing_from_legacy_feed([]) == 0
+
+    def it_ignores_offerings_already_archived_when_measuring_the_blast_radius():
+        # A backlog of previously-archived legacy rows must not make the guard trip
+        # forever on a healthy feed.
+        for i in range(20):
+            ClassOfferingFactory(
+                legacy_cms_id=f"old-{i}",
+                status=ClassOffering.Status.ARCHIVED,
+                image="",
+            )
+        live = [_legacy(i) for i in range(4)]
+
+        archived = ClassOffering.objects.archive_missing_from_legacy_feed([o.legacy_cms_id for o in live[:3]])
+
+        assert archived == 1

--- a/classes/spec/services/import_service_spec.py
+++ b/classes/spec/services/import_service_spec.py
@@ -120,11 +120,12 @@ def describe_sync_legacy_cms():
         offering = ClassOffering.objects.get(legacy_cms_id="uuid-1")
         assert offering.legacy_image_url == "https://classes.pastlives.space/sites/default/files/img.jpg"
 
-    def it_does_not_overwrite_legacy_image_url_when_real_image_exists(db):
+    def it_does_not_write_a_legacy_image_url_when_a_real_image_exists(db):
         from classes.import_service import sync_legacy_cms
 
         category = Category.objects.create(name="Workshop", slug="workshop")
-        # Pre-set legacy_image_url to simulate a previous sync (real image is also present)
+        # A previous sync left a legacy URL behind, and the picture has since been
+        # migrated into our own storage.
         offering = ClassOffering.objects.create(
             legacy_cms_id="uuid-1",
             title="Old",
@@ -136,7 +137,7 @@ def describe_sync_legacy_cms():
             legacy_image_url="https://classes.pastlives.space/sites/default/files/old.jpg",
         )
 
-        # Sync with a NEW image URL from the API — the guard should block the update
+        # Sync offers a NEW image URL — the local image must win outright.
         resp = _make_mock_resp(
             _page([_class_item(image_url="https://classes.pastlives.space/sites/default/files/new.jpg")])
         )
@@ -144,8 +145,10 @@ def describe_sync_legacy_cms():
             sync_legacy_cms()
 
         offering.refresh_from_db()
-        # Real image present — legacy_image_url must not be overwritten with the new API URL
-        assert offering.legacy_image_url == "https://classes.pastlives.space/sites/default/files/old.jpg"
+        # Not the feed's URL, and not the stale one either — a class we own the picture
+        # for keeps no handle on the legacy server at all.
+        assert offering.legacy_image_url == ""
+        assert offering.image.name == "classes/images/existing.jpg"
 
     def it_creates_class_sessions_from_field_dates(db):
         from classes.import_service import sync_legacy_cms
@@ -414,3 +417,91 @@ def describe_sync_legacy_cms():
 
         assert count == 0
         assert ClassOffering.objects.filter(legacy_cms_id__gt="").count() == 0
+
+
+def describe_sync_legacy_cms_image_ownership():
+    """Once a picture is in our own storage, no future sync may take it back."""
+
+    def _migrated_offering(image_name: str = "classes/images/deadbeef.jpg") -> ClassOffering:
+        category = Category.objects.create(name="Workshop", slug="workshop")
+        return ClassOffering.objects.create(
+            legacy_cms_id="uuid-1",
+            title="Old",
+            slug="old",
+            category=category,
+            price_cents=0,
+            status=ClassOffering.Status.PUBLISHED,
+            image=image_name,
+            legacy_image_url="",
+        )
+
+    def it_does_not_re_set_legacy_image_url_on_a_migrated_offering(db):
+        from classes.import_service import sync_legacy_cms
+
+        offering = _migrated_offering()
+
+        resp = _make_mock_resp(
+            _page([_class_item(image_url="https://classes.pastlives.space/sites/default/files/back.jpg")])
+        )
+        with patch("urllib.request.urlopen", return_value=resp):
+            sync_legacy_cms()
+
+        offering.refresh_from_db()
+        assert offering.legacy_image_url == ""
+
+    def it_does_not_overwrite_a_migrated_image(db):
+        from classes.import_service import sync_legacy_cms
+
+        offering = _migrated_offering()
+
+        resp = _make_mock_resp(
+            _page([_class_item(image_url="https://classes.pastlives.space/sites/default/files/back.jpg")])
+        )
+        with patch("urllib.request.urlopen", return_value=resp):
+            sync_legacy_cms()
+
+        offering.refresh_from_db()
+        assert offering.image.name == "classes/images/deadbeef.jpg"
+
+    def it_clears_a_stale_legacy_image_url_when_a_local_image_exists(db):
+        from classes.import_service import sync_legacy_cms
+
+        offering = _migrated_offering()
+        ClassOffering.objects.filter(pk=offering.pk).update(
+            legacy_image_url="https://classes.pastlives.space/sites/default/files/old.jpg"
+        )
+
+        resp = _make_mock_resp(_page([_class_item()]))
+        with patch("urllib.request.urlopen", return_value=resp):
+            sync_legacy_cms()
+
+        offering.refresh_from_db()
+        assert offering.legacy_image_url == ""
+
+    def it_still_picks_up_the_image_url_of_a_brand_new_class(db):
+        from classes.import_service import sync_legacy_cms
+
+        resp = _make_mock_resp(
+            _page([_class_item(image_url="https://classes.pastlives.space/sites/default/files/new.jpg")])
+        )
+        with patch("urllib.request.urlopen", return_value=resp):
+            sync_legacy_cms()
+
+        offering = ClassOffering.objects.get(legacy_cms_id="uuid-1")
+        assert offering.legacy_image_url == "https://classes.pastlives.space/sites/default/files/new.jpg"
+
+
+def describe_sync_legacy_cms_archive_guard():
+    def it_does_not_archive_the_catalog_when_the_feed_returns_no_classes(db):
+        from classes.import_service import sync_legacy_cms
+
+        first = _make_mock_resp(_page([_class_item("uuid-1"), _class_item("uuid-2", path_alias="/class/c2")]))
+        with patch("urllib.request.urlopen", return_value=first):
+            sync_legacy_cms()
+
+        # A live-but-broken Drupal: HTTP 200, valid JSON, zero classes.
+        with patch("urllib.request.urlopen", return_value=_make_mock_resp(_page([]))):
+            sync_legacy_cms()
+
+        statuses = set(ClassOffering.objects.values_list("status", flat=True))
+        assert statuses == {ClassOffering.Status.PUBLISHED}

--- a/classes/spec/views/legacy_image_spec.py
+++ b/classes/spec/views/legacy_image_spec.py
@@ -80,3 +80,72 @@ def describe_legacy_image():
         handler = _NoRedirect()
         result = handler.redirect_request(None, None, 301, "Moved", {}, "https://evil.example.com/")
         assert result is None
+
+
+def describe_legacy_image_self_host_guard():
+    def it_refuses_to_fetch_a_hostname_this_app_answers_on(db, settings):
+        from classes.views_legacy_image import legacy_image
+
+        # The DNS cutover: classes.pastlives.space now points at this app. Proxying it
+        # would make the app request itself, once per card on the catalog page.
+        settings.ALLOWED_HOSTS = [*settings.ALLOWED_HOSTS, "classes.pastlives.space"]
+        request = RequestFactory().get(
+            "/_legacy-image/",
+            {"url": "https://classes.pastlives.space/sites/default/files/img.jpg"},
+        )
+
+        with patch("classes.views_legacy_image._OPENER.open") as mock_fetch:
+            response = legacy_image(request)
+            mock_fetch.assert_not_called()
+
+        assert response.status_code == 404
+
+    def it_refuses_to_fetch_the_host_serving_the_current_request(db, settings):
+        from classes.views_legacy_image import legacy_image
+
+        # A wildcard ALLOWED_HOSTS names nothing, so the live request's own host is the
+        # only thing left that can tell the view it is about to call itself.
+        settings.ALLOWED_HOSTS = ["*"]
+        request = RequestFactory().get(
+            "/_legacy-image/",
+            {"url": "https://classes.pastlives.space/sites/default/files/img.jpg"},
+            HTTP_HOST="classes.pastlives.space",
+        )
+
+        with patch("classes.views_legacy_image._OPENER.open") as mock_fetch:
+            response = legacy_image(request)
+            mock_fetch.assert_not_called()
+
+        assert response.status_code == 404
+
+    def it_still_fetches_while_the_legacy_host_is_somebody_else(db, settings):
+        from classes.views_legacy_image import legacy_image
+
+        settings.ALLOWED_HOSTS = ["testserver", "book.pastlives.space", "*"]
+        request = RequestFactory().get(
+            "/_legacy-image/",
+            {"url": "https://classes.pastlives.space/sites/default/files/img.jpg"},
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"still-drupal"
+        mock_resp.headers = {"Content-Type": "image/jpeg"}
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("classes.views_legacy_image._OPENER.open", return_value=mock_resp),
+            patch("django.core.cache.cache.get", return_value=None),
+            patch("django.core.cache.cache.set"),
+        ):
+            response = legacy_image(request)
+
+        assert response.status_code == 200
+        assert response.content == b"still-drupal"
+
+    def it_treats_an_empty_hostname_as_not_ours():
+        from classes.views_legacy_image import _is_own_host
+
+        request = RequestFactory().get("/_legacy-image/")
+
+        assert _is_own_host("", request) is False

--- a/classes/views_legacy_image.py
+++ b/classes/views_legacy_image.py
@@ -1,12 +1,27 @@
-"""Legacy CMS image proxy view."""
+"""Legacy CMS image proxy view.
+
+Fallback only. Every offering migrated by ``download_legacy_images`` serves its
+picture straight out of our own storage, and the templates always prefer
+``offering.image``; this view exists solely for a class that has just arrived
+from the legacy feed and whose image has not been pulled across yet.
+
+It is also the one piece of the app that makes an outbound HTTP request while a
+page is rendering, so it refuses to fetch from any hostname this deployment
+itself answers on (see :func:`_is_own_host`).
+"""
 
 from __future__ import annotations
 
+import logging
 import urllib.request
+from urllib.parse import urlsplit
 
+from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse
 
+
+logger = logging.getLogger(__name__)
 
 ALLOWED_PREFIX = "https://classes.pastlives.space/"
 CACHE_TIMEOUT = 86400  # 24 hours
@@ -30,6 +45,23 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
 _OPENER = urllib.request.build_opener(_NoRedirect)
 
 
+def _is_own_host(hostname: str, request: HttpRequest) -> bool:
+    """Whether ``hostname`` is a name this deployment answers on itself.
+
+    ``classes.pastlives.space`` currently resolves to the Drupal server, but the
+    plan is to repoint that DNS record at this app. The moment that happens (and
+    the host joins ``DJANGO_ALLOWED_HOSTS``), a catalog page rendering two dozen
+    fallbacks would fire two dozen HTTP requests from the app back into the app —
+    self-inflicted worker starvation on a two-worker gunicorn. So the guard keys
+    off exactly the fact that makes the fetch dangerous: the target is us.
+    """
+    if not hostname:
+        return False
+    own = {request.get_host().split(":")[0].strip().lower()}
+    own |= {h.strip().lstrip("*.").lower() for h in settings.ALLOWED_HOSTS if h.strip() not in ("", "*")}
+    return hostname.strip().lower() in own
+
+
 def legacy_image(request: HttpRequest) -> HttpResponse:
     """Proxy an image from the legacy CMS, with 24-hour caching.
 
@@ -37,11 +69,22 @@ def legacy_image(request: HttpRequest) -> HttpResponse:
 
     Only fetches from https://classes.pastlives.space/ to prevent SSRF.
     Redirects are refused so a compromised upstream cannot redirect to an
-    internal address.
+    internal address, and the app never fetches from one of its own hostnames.
     """
     url = request.GET.get("url", "")
     if not url.startswith(ALLOWED_PREFIX):
         return HttpResponse("Forbidden", status=403)
+
+    hostname = urlsplit(url).hostname or ""
+    if _is_own_host(hostname, request):
+        logger.error(
+            "Legacy image proxy refused to fetch %s: %s now resolves to this app, so proxying it "
+            "would make the app request itself. The legacy CMS is gone — run "
+            "download_legacy_images so these classes serve their own stored images.",
+            url,
+            hostname,
+        )
+        return HttpResponse("Not Found", status=404)
 
     cache_key = f"legacy_image:{url}"
     cached = cache.get(cache_key)

--- a/core/files.py
+++ b/core/files.py
@@ -2,7 +2,44 @@
 
 from __future__ import annotations
 
+from django.core.files.storage import default_storage
 from django.db import models
+
+
+def delete_if_unreferenced(
+    model: type[models.Model],
+    field_name: str,
+    name: str,
+    *,
+    exclude_pk: object = None,
+) -> bool:
+    """Delete a stored file, unless another row of ``model`` still points at it.
+
+    De-duplicated images are *shared*: several rows carry the same storage key
+    (see :func:`core.images.store_content_addressed`), so deleting the object
+    because one row moved off it would blank the picture on every other row.
+    Checks the database first and only removes a genuine orphan.
+
+    Args:
+        model: The model whose ``field_name`` column holds storage keys.
+        field_name: Name of the File/ImageField column.
+        name: The storage key to delete.
+        exclude_pk: Primary key to ignore when looking for other references —
+            the row that just moved off this key, whose column may or may not
+            have been written yet, so it must never count as a reference.
+
+    Returns:
+        True when the object was deleted, False when it is still referenced.
+    """
+    if not name:
+        return False
+    others = model._default_manager.filter(**{field_name: name})
+    if exclude_pk is not None:
+        others = others.exclude(pk=exclude_pk)
+    if others.exists():
+        return False
+    default_storage.delete(name)
+    return True
 
 
 def delete_orphan_on_replace(instance: models.Model, field_name: str) -> None:
@@ -12,7 +49,8 @@ def delete_orphan_on_replace(instance: models.Model, field_name: str) -> None:
     pre-save value from the database and, if the user replaced or cleared the
     file, removes the old object from storage so it does not orphan in R2.
 
-    Safe to call on creates (returns early) and when the field is unchanged.
+    Safe to call on creates (returns early), when the field is unchanged, and
+    when the old object is still referenced by a sibling row.
     """
     if not instance.pk:
         return
@@ -25,4 +63,4 @@ def delete_orphan_on_replace(instance: models.Model, field_name: str) -> None:
     new_file = getattr(instance, field_name)
     new_name = getattr(new_file, "name", "") or ""
     if old_file and old_file.name and old_file.name != new_name:
-        old_file.delete(save=False)
+        delete_if_unreferenced(model, field_name, old_file.name, exclude_pk=instance.pk)

--- a/core/images.py
+++ b/core/images.py
@@ -7,12 +7,15 @@ registered at import so ``PIL.Image.open()`` handles ``.heic`` transparently.
 
 from __future__ import annotations
 
+import hashlib
 import io
+import re
 from pathlib import Path
 
 import logging
 
 from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import UploadedFile
 from PIL import Image, ImageOps, UnidentifiedImageError
 
@@ -95,3 +98,54 @@ def normalize_field_if_uploaded(instance, field_name: str, max_long_edge: int) -
         logger.warning("normalize_image skipped for %s.%s: %s", type(instance).__name__, field_name, exc)
         return
     setattr(instance, field_name, new)
+
+
+_CONTENT_ADDRESSED_RE = re.compile(r"^[0-9a-f]{64}\.[A-Za-z0-9]+$")
+
+
+def content_addressed_name(content: bytes, *, prefix: str, ext: str = "jpg") -> str:
+    """Return the deterministic storage key for ``content``.
+
+    Args:
+        content: The exact bytes that will be stored.
+        prefix: Storage folder including its trailing slash (e.g. ``classes/images/``).
+        ext: File extension without the leading dot.
+
+    Returns:
+        ``<prefix><sha256-hex>.<ext>``.
+    """
+    return f"{prefix}{hashlib.sha256(content).hexdigest()}.{ext}"
+
+
+def is_content_addressed(name: str, *, prefix: str) -> bool:
+    """Whether ``name`` is already a key produced by :func:`content_addressed_name`."""
+    if not name.startswith(prefix):
+        return False
+    return bool(_CONTENT_ADDRESSED_RE.match(name[len(prefix) :]))
+
+
+def store_content_addressed(content: bytes, *, prefix: str, ext: str = "jpg") -> str:
+    """Store ``content`` under a key derived from its SHA-256 digest.
+
+    Identical bytes always map to the same key, so rows carrying the same picture
+    share a single stored object. Without this the default storage backend
+    (``file_overwrite=False`` on R2) appends a random suffix on every name
+    collision and each row gets its own copy of the same image.
+
+    Storing bytes that are already present is a no-op, which is what makes the
+    callers idempotent and safe to resume after an interruption.
+
+    Args:
+        content: The bytes to store.
+        prefix: Storage folder including its trailing slash.
+        ext: File extension without the leading dot.
+
+    Returns:
+        The storage key the content is available under.
+    """
+    name = content_addressed_name(content, prefix=prefix, ext=ext)
+    if default_storage.exists(name):
+        return name
+    # A concurrent writer winning the race would make the backend append a
+    # suffix, so trust whatever key storage actually used.
+    return default_storage.save(name, ContentFile(content))

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.18"
+VERSION = "0.23.23"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.23",
+        "date": "2026-07-22",
+        "title": "Class photos now load faster",
+        "changes": [
+            (
+                "Class photos are now served from our own storage instead of being fetched "
+                "from the old class website every time a page opened. Browsing the class "
+                "catalog should feel noticeably quicker, and the pictures keep working once "
+                "the old site is switched off."
+            ),
+        ],
+    },
     {
         "version": "0.23.18",
         "date": "2026-07-21",

--- a/tests/core/files_spec.py
+++ b/tests/core/files_spec.py
@@ -74,3 +74,58 @@ def describe_delete_orphan_on_replace():
         ghost = Guild(pk=999_999, name="Ghost")
 
         delete_orphan_on_replace(ghost, "banner_image")  # must not raise
+
+
+@pytest.mark.django_db
+def describe_delete_if_unreferenced():
+    def it_deletes_a_file_no_other_row_points_at():
+        from core.files import delete_if_unreferenced
+        from membership.models import Guild
+
+        guild = GuildFactory(banner_image=SimpleUploadedFile("solo.png", _png_bytes(), content_type="image/png"))
+        name = guild.banner_image.name
+        storage = guild.banner_image.storage
+
+        assert delete_if_unreferenced(Guild, "banner_image", name, exclude_pk=guild.pk) is True
+        assert not storage.exists(name)
+
+    def it_keeps_a_file_a_sibling_row_still_shares():
+        from core.files import delete_if_unreferenced
+        from membership.models import Guild
+
+        first = GuildFactory(banner_image=SimpleUploadedFile("shared.png", _png_bytes(), content_type="image/png"))
+        shared_name = first.banner_image.name
+        storage = first.banner_image.storage
+        # Second guild points at the exact same stored object — what de-duplication produces.
+        second = GuildFactory()
+        Guild.objects.filter(pk=second.pk).update(banner_image=shared_name)
+
+        assert delete_if_unreferenced(Guild, "banner_image", shared_name, exclude_pk=first.pk) is False
+        assert storage.exists(shared_name)
+
+        storage.delete(shared_name)  # cleanup
+
+    def it_ignores_an_empty_name():
+        from core.files import delete_if_unreferenced
+        from membership.models import Guild
+
+        assert delete_if_unreferenced(Guild, "banner_image", "") is False
+
+
+@pytest.mark.django_db
+def describe_delete_orphan_on_replace_with_shared_files():
+    def it_keeps_the_old_file_when_another_row_still_uses_it():
+        from membership.models import Guild
+
+        first = GuildFactory(banner_image=SimpleUploadedFile("dupe.png", _png_bytes(), content_type="image/png"))
+        shared_name = first.banner_image.name
+        storage = first.banner_image.storage
+        second = GuildFactory()
+        Guild.objects.filter(pk=second.pk).update(banner_image=shared_name)
+
+        first.banner_image = SimpleUploadedFile("fresh.png", _png_bytes(), content_type="image/png")
+        delete_orphan_on_replace(first, "banner_image")
+
+        assert storage.exists(shared_name)
+        first.banner_image.close()
+        storage.delete(shared_name)  # cleanup

--- a/tests/core/images_spec.py
+++ b/tests/core/images_spec.py
@@ -147,3 +147,52 @@ def describe_normalize_field_if_uploaded():
         normalize_field_if_uploaded(holder, "field", max_long_edge=100)
 
         assert holder.field is None
+
+
+def describe_content_addressed_storage():
+    def it_maps_identical_bytes_to_the_same_key():
+        from core.images import content_addressed_name
+
+        first = content_addressed_name(b"same bytes", prefix="classes/images/")
+        second = content_addressed_name(b"same bytes", prefix="classes/images/")
+
+        assert first == second
+        assert first.startswith("classes/images/")
+        assert first.endswith(".jpg")
+
+    def it_maps_different_bytes_to_different_keys():
+        from core.images import content_addressed_name
+
+        assert content_addressed_name(b"a", prefix="p/") != content_addressed_name(b"b", prefix="p/")
+
+    def it_recognizes_its_own_keys():
+        from core.images import content_addressed_name, is_content_addressed
+
+        name = content_addressed_name(b"x", prefix="classes/images/")
+
+        assert is_content_addressed(name, prefix="classes/images/") is True
+
+    def it_rejects_a_key_under_a_different_prefix():
+        from core.images import content_addressed_name, is_content_addressed
+
+        name = content_addressed_name(b"x", prefix="classes/images/")
+
+        assert is_content_addressed(name, prefix="other/") is False
+
+    def it_rejects_a_human_named_key():
+        from core.images import is_content_addressed
+
+        assert is_content_addressed("classes/images/pattern.jpeg", prefix="classes/images/") is False
+
+    def it_stores_shared_bytes_exactly_once(db):
+        from django.core.files.storage import default_storage
+
+        from core.images import store_content_addressed
+
+        first = store_content_addressed(b"one picture", prefix="spec/images/")
+        second = store_content_addressed(b"one picture", prefix="spec/images/")
+
+        assert first == second
+        assert default_storage.exists(first)
+
+        default_storage.delete(first)  # cleanup


### PR DESCRIPTION
Makes the class catalog own its images outright, and makes the legacy CMS sync safe to keep running while we transition off Drupal.

Follows the production run of `download_legacy_images`, which pulled 612 images into R2 and cleared every `legacy_image_url`.

## Our images win

No change needed. Every render point already branches on `offering.image` first and falls back to the legacy proxy second. Verified all four sites (catalog cards, class detail hero, related-class cards, printable flyer). Nothing else renders a class image: no OG tag, no email, no calendar, no signage slide.

## Future syncs cannot clobber it

`_upsert_offering` never wrote `image`, and already guarded `legacy_image_url` behind a check for a local image. That guard read as incidental rather than as a rule, and a row could keep a stale legacy URL alongside a local image, one template edit away from proxying Drupal again.

Now an offering that owns an image has its `legacy_image_url` actively cleared, so it holds no handle on the legacy server at all. A genuinely new class still picks up its feed URL on first import. Migrated rows are invisible to `download_legacy_images` (it filters on `legacy_image_url__gt="", image=""`), so re-running does no duplicate work.

## Archive guard

`ClassOfferingQuerySet.archive_missing_from_legacy_feed(seen_ids)` now refuses to run when `seen_ids` is empty, or when the sweep would archive more than 50% of live legacy offerings.

Measured against live (non-archived) legacy rows, not all rows carrying a `legacy_cms_id`. Measuring against all of them would have wedged the guard permanently on once archived rows exceeded half the catalog.

Failure is loud: `logger.error` with a banner, counts, the ceiling, and the feed URL, stating that an empty payload is the likely cause rather than the classes being gone.

## Storage: 1.53 GB to roughly 66 MB

Two compounding problems, both fixed.

Normalization never fired. `offering.image.save(...)` commits the file and sets `_committed = True`, so `normalize_field_if_uploaded` returned early and `ClassOffering.save()`'s normalize call never ran. Raw originals were stored verbatim, including a 16.2 MB hero.

`file_overwrite: False` turned 149 distinct pictures into 612 distinct objects, since Django suffixes every name collision.

New `core.images.store_content_addressed` keys on the SHA-256 of the normalized bytes. Chosen over keying on the pre-migration URL snapshot for three reasons: the snapshot is a local file production does not have; dedupe has to happen on normalized bytes anyway, since normalization is what changes them; and content hashing also catches the same picture arriving under two different URLs.

New `optimize_class_images` command (idempotent, interruptible, `--dry-run`) repoints existing rows and deletes the objects it moves off. Ratio measured empirically by downloading 30 of the 149 distinct images and running the real pipeline: 56.2 MB to 9.3 MB, a factor of 0.165. Applied to the deduplicated corpus that is roughly 66 MB across 149 objects.

`download_legacy_images` is fixed so it cannot recreate the problem: it normalizes before storing, stores content-addressed, narrows `except Exception` to `(OSError, ValueError)`, raises `CommandError` once failures reach 50% (previously it exited 0 even if all 612 failed), and percent-decodes filenames so `Closeup%20Hands%202_11.JPG` reads back correctly.

## Unrelated bug found and fixed

`delete_orphan_on_replace` in `core/files.py` deleted the previous storage object unconditionally. Harmless while every row had its own object, but once images are shared, replacing one offering's photo would have deleted that file out from under every sibling still referencing it. Deletion now goes through `delete_if_unreferenced`. This affects all eleven call sites, not just classes.

## Legacy image proxy: kept, guarded

Kept deliberately. A genuinely new class from the feed has a legacy URL and no local image until the next migration run, which is the behavior this PR preserves. Deleting the view would trade a slow image for a missing one.

The deadlock risk is handled at its root: `_is_own_host()` refuses any hostname in `ALLOWED_HOSTS` or matching `request.get_host()`. When `classes.pastlives.space` is repointed at the app and added to `DJANGO_ALLOWED_HOSTS`, the guard arms itself with no code change, returns 404, and logs an error pointing at `download_legacy_images`. Without it, the proxy would fetch the app's own host, 24 requests per catalog page into 2 gunicorn workers.

Once the feed is switched off for good, the view, its URL, and the three template branches can come out in one commit.

## Tests

31 new specs, exercising real 4000x3000 JPEGs rather than stubs: re-sync does not overwrite a migrated image or re-set the URL; the guard trips on an empty feed; optimize is idempotent; normalization actually shrinks a large image.

Full suite under CI conditions: 6292 passed, coverage 98.26% against a 98% gate. New modules at 100%, `import_service.py` at 97% with both gaps pre-existing. `ruff format --check` and `ruff check` clean; `mypy` clean on the in-scope packages and back to baseline on `classes/`. `makemigrations --check` reports no changes; this is behavior-only.

The one deselected failure, `discord_events_spec::it_maps_monthly_to_an_nth_weekday_rule`, fails identically on pristine `origin/main` and is handled on `fix/monthly-nth-weekday-rrule`.

## Prod ops after merge

1. Run `optimize_class_images` once as a Render one-off job. Production landed 612 unoptimized objects because the migration ran on old code. Use `--dry-run` first. Safe to interrupt and re-run.
2. No migration, so no post-deploy `migrate` step.
3. Nothing to configure for the proxy guard; it arms itself at DNS cutover.
4. Watch the first nightly `sync_all_sources` for `ARCHIVE GUARD TRIPPED`. If it appears, the Drupal feed returned an empty or truncated payload and the guard has just saved the catalog.

https://claude.ai/code/session_01J2kYTLwGEHBqs1ihuAkS57
