### PR TITLE
[tests] Pin the Discord monthly-recurrence specs to fixed dates — unblocks CI on #148/#149 (v0.23.25)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.18"
+VERSION = "0.23.25"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.23.18",
-        "date": "2026-07-21",
+        "version": "0.23.25",
+        "date": "2026-07-22",
         "title": "Picked a guild on Discord but not linked yet? The bot now gives you a heads-up",
         "changes": [
             (

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.25"
+VERSION = "0.23.19"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.23.25",
+        "version": "0.23.19",
         "date": "2026-07-22",
         "title": "Picked a guild on Discord but not linked yet? The bot now gives you a heads-up",
         "changes": [

--- a/tests/core/integrations/discord_events_spec.py
+++ b/tests/core/integrations/discord_events_spec.py
@@ -8,6 +8,7 @@ exercised through ``respx``.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -262,31 +263,68 @@ def describe__build_scheduled_event_body():
 
 @pytest.mark.django_db
 def describe__recurrence_rule_for():
-    def _event(recurrence, **kwargs) -> CommunityEvent:
+    def _event(recurrence: str, **kwargs: Any) -> CommunityEvent:
         return CommunityEventFactory(recurrence=recurrence, **kwargs)
 
-    def it_returns_none_for_a_one_off():
+    def _anchored(recurrence: str, year: int, month: int, day: int) -> CommunityEvent:
+        """An event anchored to an explicit LOCAL calendar date.
+
+        The rule a monthly event produces depends entirely on where its anchor sits in its
+        own month, so the anchor must never be derived from ``timezone.now()`` — the factory
+        default (``now + 7 days``) silently drifts across weekday ordinals and made these
+        specs pass or fail depending on the day they were run.
+        """
+        start = timezone.make_aware(datetime(year, month, day, 12, 0))
+        return _event(recurrence, starts_at=start, ends_at=start + timedelta(hours=1))
+
+    def it_returns_none_for_a_one_off() -> None:
         assert de._recurrence_rule_for(_event(CommunityEvent.Recurrence.NONE)) is None
 
-    def it_maps_weekly_to_a_single_weekday_rule():
-        event = _event(CommunityEvent.Recurrence.WEEKLY)
-        weekday = timezone.localtime(event.starts_at).weekday()
-        assert de._recurrence_rule_for(event) == {"frequency": 2, "interval": 1, "by_weekday": [weekday]}
+    def it_maps_weekly_to_a_single_weekday_rule() -> None:
+        # Wed 2026-07-08; Discord's by_weekday uses Python's 0=Monday … 6=Sunday encoding.
+        event = _anchored(CommunityEvent.Recurrence.WEEKLY, 2026, 7, 8)
+        assert de._recurrence_rule_for(event) == {"frequency": 2, "interval": 1, "by_weekday": [2]}
 
-    def it_maps_monthly_to_an_nth_weekday_rule():
-        event = _event(CommunityEvent.Recurrence.MONTHLY)
-        weekday = timezone.localtime(event.starts_at).weekday()
-        rule = de._recurrence_rule_for(event)
-        assert rule["frequency"] == 1
-        assert rule["interval"] == 1
-        assert rule["by_n_weekday"] == [{"n": event._occurrence_ordinal(), "day": weekday}]
+    @pytest.mark.parametrize(
+        ("day", "expected_n", "expected_weekday"),
+        [
+            (1, 1, 2),  # Wed 2026-07-01 — the 1st Wednesday
+            (6, 1, 0),  # Mon 2026-07-06 — the 1st Monday (weekday 0)
+            (8, 2, 2),  # Wed 2026-07-08 — the 2nd Wednesday
+            (15, 3, 2),  # Wed 2026-07-15 — the 3rd Wednesday
+            (22, 4, 2),  # Wed 2026-07-22 — the 4th Wednesday
+            (29, 5, 2),  # Wed 2026-07-29 — the 5th Wednesday: model ordinal -1 → Discord n=5
+        ],
+    )
+    def it_maps_monthly_to_an_nth_weekday_rule(day: int, expected_n: int, expected_weekday: int) -> None:
+        event = _anchored(CommunityEvent.Recurrence.MONTHLY, 2026, 7, day)
+        assert de._recurrence_rule_for(event) == {
+            "frequency": 1,
+            "interval": 1,
+            "by_n_weekday": [{"n": expected_n, "day": expected_weekday}],
+        }
 
-    def it_maps_a_last_weekday_ordinal_to_discord_5():
-        # A start on the 5th occurrence of its weekday → model ordinal -1 → Discord n=5.
-        start = timezone.make_aware(datetime(2026, 7, 29, 12, 0))
-        event = _event(CommunityEvent.Recurrence.MONTHLY, starts_at=start, ends_at=start + timedelta(hours=1))
+    def it_maps_a_last_weekday_ordinal_to_discord_5() -> None:
+        # Wed 2026-07-29 is the 5th (and last) Wednesday → model ordinal -1 → Discord n=5.
+        # Discord documents by_n_weekday.n as an int in 1–5 with no negative "last" form, so
+        # the model's -1 MUST be re-encoded; passing -1 straight through would be a hard 400.
+        event = _anchored(CommunityEvent.Recurrence.MONTHLY, 2026, 7, 29)
         assert event._occurrence_ordinal() == -1
         assert de._recurrence_rule_for(event)["by_n_weekday"][0]["n"] == 5
+
+    def it_maps_a_4th_weekday_that_is_also_the_months_last_to_discord_4() -> None:
+        # The other side of "last": Sat 2026-02-28 is both the 4th AND the final Saturday of
+        # February. Discord is told where the anchor sits (n=4), not "last" — so the series
+        # keeps landing on the 4th Saturday in months that happen to have five.
+        event = _anchored(CommunityEvent.Recurrence.MONTHLY, 2026, 2, 28)
+        assert event._occurrence_ordinal() == 4
+        assert de._recurrence_rule_for(event)["by_n_weekday"][0]["n"] == 4
+
+    def it_keeps_every_calendar_anchor_inside_discords_1_to_5_range() -> None:
+        # Every day of a 31-day month — no calendar position may produce an n Discord rejects.
+        for day in range(1, 32):
+            rule = de._recurrence_rule_for(_anchored(CommunityEvent.Recurrence.MONTHLY, 2026, 7, day))
+            assert 1 <= rule["by_n_weekday"][0]["n"] <= 5
 
     @pytest.mark.parametrize(
         "recurrence",
@@ -298,8 +336,8 @@ def describe__recurrence_rule_for():
             CommunityEvent.Recurrence.YEARLY,
         ],
     )
-    def it_returns_none_for_the_unmappable_cadences(recurrence):
-        assert de._recurrence_rule_for(_event(recurrence)) is None
+    def it_returns_none_for_the_unmappable_cadences(recurrence: str) -> None:
+        assert de._recurrence_rule_for(_anchored(recurrence, 2026, 7, 29)) is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Unblocks CI on PR #148 and PR #149

`origin/main` is red today, and therefore so is every open PR branched from it — including **#148** and **#149**. This PR fixes that failure. It is pre-existing on clean `main` and unrelated to either of those PRs.

```
FAILED tests/core/integrations/discord_events_spec.py::describe__recurrence_rule_for::it_maps_monthly_to_an_nth_weekday_rule
AssertionError: assert [{'n': 5, 'day': 2}] == [{'n': -1, 'day': 2}]
```

## Root cause

`tests/core/integrations/discord_events_spec.py:276` built its event with the bare `CommunityEventFactory`, whose default anchor is `timezone.now() + timedelta(days=7)` (`tests/membership/factories.py:244`). It then asserted:

```python
assert rule["by_n_weekday"] == [{"n": event._occurrence_ordinal(), "day": weekday}]
```

`CommunityEvent._occurrence_ordinal()` (`membership/models.py:3766`) returns `1–4`, or **`-1`** for a 5th weekday — the model's internal "last" sentinel. So on any day where `now + 7d` lands on the 5th occurrence of its weekday, the expectation became `-1` while the implementation correctly produced `5`, and the test failed. Today (2026-07-22 → Wed 2026-07-29, the 5th Wednesday) is one such day; 2026-12-24 is another. Both reproduce under a frozen clock.

## The implementation is right — this is a test defect

Discord's `recurrence_rule.by_n_weekday` is a **structured JSON object, not an RFC 5545 `BYDAY` string**, so RFC 5545's `-1WE` ("last Wednesday") form is not available here. Both the official docs and the community reference document the field identically:

> `n` | integer | *The week to reoccur on. 1 - 5*

Negative values are not permitted, and the array is capped at a single entry, monthly-frequency only. `_occurrence_n()` (`core/integrations/discord_events.py:198`) re-encoding the model's `-1` as `5` is therefore the **only** value the API accepts; passing `-1` straight through would be a hard 400. A sibling spec, `it_maps_a_last_weekday_ordinal_to_discord_5`, already pinned that mapping with a fixed date and has been passing all along — the failing assertion was simply comparing against the raw model ordinal instead of the Discord-encoded one.

Sources: [docs.discord.com — Guild Scheduled Event](https://docs.discord.com/developers/resources/guild-scheduled-event) · [Discord Userdoccers](https://docs.discord.food/resources/guild-scheduled-event)

**No production data is affected.** A read-only query against the prod database found **0** `CommunityEvent` rows with `recurrence = 'monthly'` (the only recurring event on prod is a single `weekly` one, already `synced`). Nothing to correct.

## What changed

Test-only. `_recurrence_rule_for`, `_occurrence_n` and `_occurrence_ordinal` are untouched.

- New `_anchored()` helper pins every event in the block to an explicit **local calendar date** — never derived from `timezone.now()`.
- `it_maps_monthly_to_an_nth_weekday_rule` is now parametrised over the 1st/2nd/3rd/4th/5th Wednesdays of July 2026 plus a Monday (covering the `0=Monday` weekday encoding), asserting the full rule dict.
- Both directions of "last" are now covered: Wed 2026-07-29 is the 5th *and* last Wednesday (`-1 → 5`), while Sat 2026-02-28 is the 4th *and* last Saturday (stays `4`).
- New range invariant walks all 31 anchors of a 31-day month and asserts `n` never leaves Discord's `1–5`.
- The weekly and unmappable-cadence specs are pinned to fixed anchors too.

## Proof of date-independence

The `_recurrence_rule_for` block was run under a frozen clock at eight "todays" spread across the year — including both dates that previously reproduced the failure. **16 passed** at every one:

```
today = 2026-01-01 → 16 passed      today = 2026-07-22 → 16 passed   (was RED)
today = 2026-07-01 → 16 passed      today = 2026-07-29 → 16 passed
today = 2026-07-08 → 16 passed      today = 2026-02-28 → 16 passed
today = 2026-07-15 → 16 passed      today = 2026-12-24 → 16 passed   (was RED)
```

The harness is not vacuous — restoring the pre-fix spec and running it under the same clocks reproduces the exact CI diff:

```
=== PRE-FIX spec, today = 2026-07-22 12:00:00 ===
E   At index 0 diff: {'n': 5, 'day': 2} != {'n': -1, 'day': 2}
FAILED ...::it_maps_monthly_to_an_nth_weekday_rule
=== PRE-FIX spec, today = 2026-12-24 12:00:00 ===
E   At index 0 diff: {'n': 5, 'day': 3} != {'n': -1, 'day': 3}
FAILED ...::it_maps_monthly_to_an_nth_weekday_rule
```

## Verification

- Full suite (SQLite, mirroring CI): **6257 passed**, coverage **98.26%** (gate 98%).
- `mypy plfog/ core/ membership/ hub/`: Success, 158 files.
- `ruff format --check .` + `ruff check .`: clean.

## Version & changelog

`VERSION` → **0.23.19** as of the branch tip. This PR was authored at **0.23.25**; a follow-up commit on this branch (`2957488`, *"Renumber to 0.23.19 so this lands first in the merge queue"*) renumbered it. Worth a second look before merge — **0.23.19 was reserved for PR #148**, so as it stands the two collide. Either number works for this PR; it just needs to be one nobody else is holding.

**No new CHANGELOG entry** — the shipped behaviour is unchanged, so there is nothing for members to read. Per the curation rules the existing top entry is re-stamped to the new `VERSION` instead, which also satisfies the `announce_release` invariant that `tests/core/events/new_events_spec.py::describe_release_published` enforces (it hard-fails a `VERSION` with no matching entry).

## Follow-up worth knowing (not a bug, no action here)

Discord's `n=5` means literally *the fifth week*, whereas FOG's own expansion treats a 5th-weekday anchor as **"last"** (`membership/models.py:3803`). A monthly series anchored on a 5th weekday will therefore appear on FOG's calendar every month but only in Discord's five-weekday months. Discord's schema offers no other encoding, so this is a documented ceiling of the integration rather than something fixable — noting it so it is not rediscovered as a bug later.

https://claude.ai/code/session_01J2kYTLwGEHBqs1ihuAkS57
