### PR TITLE
[guilds] Public guild pages: short URLs, per-guild privacy, and a meeting-notes leak fix (v0.23.26)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,9 +48,13 @@ _Avoid_: treating the pair as duplicates; "Discord event" unqualified.
 A member-run interest group within the makerspace (woodshop, blacksmithing, etc.), with leads, staff, and a public page. The real `membership.Guild`.
 _Avoid_: using bare "guild" for a class catalog category — that is a **Guild Type** (see below).
 
-**Private guild** (removed concept):
-There is no such thing — every active Guild is visible on every surface (hub, public guilds site, Discord). The `is_public` flag was stripped in v22 as unused (0 of 15 guilds ever set it); "hide a guild" is `is_active` off, which removes it everywhere.
-_Avoid_: private guild, hidden guild, gating anything on guild visibility.
+**Private guild**:
+A Guild whose lead has turned `is_public` off in Guild Settings. It is hidden from the **public guilds site only** — dropped from the public directory, and its public URL answers a friendly "this page is private for now" note (HTTP 403). Inside the member hub nothing changes: members see the page exactly as before. Defaults to public, so no existing guild changed behaviour. (The flag existed in v20, was stripped in v22 as unused, and came back in v23 alongside the public guilds surface at `guilds.pastlives.space`.) To hide a guild *everywhere* — hub, public site, Discord — turn `is_active` off instead.
+_Avoid_: "hidden guild" (it is not hidden from members); using `is_public` to gate anything on the member hub.
+
+**Public guild URL**:
+`guilds.pastlives.space/<public-slug>/` — the canonical, login-free home of a guild page, where `public-slug` is the guild's slug minus a trailing `-guild` (`woodworking-guild` → `/woodworking/`). Built from `Guild.public_slug` / `public_path` / `public_url`; never hand-assembled. Both the un-stripped `/woodworking-guild/` and the member-hub shape `/guilds/woodworking-guild/` 301 to it on that host. On the member hub the URL stays `/guilds/<slug>/`, but its `<link rel="canonical">` points at the public one.
+_Avoid_: calling `/guilds/<slug>/` the public URL; adding a second view or template for the public page (it is the same view and template, differing only by auth state).
 
 **Guild Type**:
 The catalog category a class belongs to (the `classes.Category` model). User-facing copy calls it a "Guild Type" — not "category" or bare "Guild". A Guild Type may link to a hub Guild to route a submitted class's approval to that Guild's Lead, but a Guild Type (catalog category) and a Guild (member group) are distinct.

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -51,7 +51,7 @@ def surface(request: HttpRequest) -> dict[str, str | bool]:
     """Expose which surface the request arrived on so templates can branch chrome.
 
     ``surface`` is ``"public"`` on book.pastlives.space, ``"guilds"`` on
-    guilds.pastlives.app, ``"signage"`` on slideshow.pastlives.space, and
+    guilds.pastlives.space, ``"signage"`` on slideshow.pastlives.space, and
     ``"members"`` everywhere else (members host, local dev, Hetzner staging,
     Render preview). ``is_public_surface`` / ``is_guilds_surface`` /
     ``is_signage_surface`` are the convenience booleans templates branch on;
@@ -72,7 +72,7 @@ def surface(request: HttpRequest) -> dict[str, str | bool]:
         "MEMBER_HOST": settings.MEMBER_HOST,
         "MEMBER_BASE_URL": getattr(settings, "MEMBER_BASE_URL", f"https://{settings.MEMBER_HOST}"),
         "BOOK_BASE_URL": getattr(settings, "BOOK_BASE_URL", "https://book.pastlives.space"),
-        "GUILDS_BASE_URL": getattr(settings, "GUILDS_BASE_URL", "https://guilds.pastlives.app"),
+        "GUILDS_BASE_URL": getattr(settings, "GUILDS_BASE_URL", "https://guilds.pastlives.space"),
         "SIGNAGE_BASE_URL": getattr(settings, "SIGNAGE_BASE_URL", "https://slideshow.pastlives.space"),
         "guilds_page_base": "guilds/base_public.html" if is_guilds else "hub/base.html",
         "signage_page_base": "signage/base.html" if is_signage else "hub/base.html",

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -9,21 +9,24 @@ Plfog answers to three kinds of hostname:
   Everything else (admin, billing, voting, settings, member directory, the
   classes admin/instructor dashboards, etc.) returns 404 from this surface.
   ``request.surface == "public"``.
-- ``guilds.pastlives.app``: a public guild directory + guest guild pages.
+- ``guilds.pastlives.space``: a public guild directory + guest guild pages.
   ``request.surface == "guilds"``. Only the guest-appropriate views in
   ``GUILDS_ALLOWED_VIEW_NAMES`` (plus allauth's ``account_*`` login views)
   resolve here; everything else 404s, so the guild editor / product / cart
-  endpoints never leak onto the guest surface. Root redirects to ``/guilds/``.
+  endpoints never leak onto the guest surface. Root redirects to ``/guilds/``,
+  and a bare ``/<slug>/`` is served as that guild's page (the redundant
+  ``-guild`` suffix is optional there — see ``Guild.public_slug``).
 
 The middleware tags every request with ``request.surface`` so templates and
 views can branch on the chrome they should render, and short-circuits any
 request to a member-only path that arrives on the public surface.
 
-Member auth (``/accounts/*``) is served on all surfaces. On ``.pastlives.space``
-session cookies scope to ``.pastlives.space`` so a login completed on book is
-recognised on members automatically; on the ``.app`` guilds surface cookies are
-host-only (prod ``COOKIE_DOMAIN`` is unset), so login-in-place resolves on the
-guilds host with no extra plumbing.
+Member auth (``/accounts/*``) is served on all surfaces. Production leaves
+``COOKIE_DOMAIN`` unset, so session cookies are **host-only**: a login on the
+guilds host is not shared with the member hub. Every gated action on the guest
+guild page therefore links to the member hub's login carrying a ``next`` that
+points at the identical page over there (see ``hub.views._guild_login_url``),
+rather than trying to authenticate in place.
 
 The root path on the public surface redirects to ``/classes/`` so the bare
 domain lands on the catalog rather than the member hub home.
@@ -91,12 +94,14 @@ class SurfaceMiddleware:
         return self.get_response(request)
 
     def _handle_guilds_surface(self, request: HttpRequest) -> HttpResponse | None:
-        """Redirect the root to /guilds/ and gate every other path to an allowlist.
+        """Redirect the root to /guilds/, serve short guild slugs, gate everything else.
 
-        Returns a redirect for ``/``; raises :class:`~django.http.Http404` for any
-        path whose resolved view name is not guest-appropriate (so the guild editor,
-        product/cart, and book-only account routes never render on ``.app``); returns
-        ``None`` when the request may continue to the view.
+        Returns a redirect for ``/``; rewrites a bare root-level guild slug
+        (``/woodworking/``) onto the shared guild-detail route so both hosts run the
+        same view and template; raises :class:`~django.http.Http404` for any path whose
+        resolved view name is not guest-appropriate (so the guild editor, product/cart,
+        and book-only account routes never render publicly); returns ``None`` when the
+        request may continue to the view.
         """
         from django.urls import Resolver404, resolve
 
@@ -107,13 +112,44 @@ class SurfaceMiddleware:
         try:
             match = resolve(request.path)
         except Resolver404:
-            raise Http404("Not available on this surface.")
+            match = None
         # ``view_name`` carries the namespace (e.g. "account:lookup"), so allauth's
         # built-in ``account_*`` login views are allowed while the book-only
         # namespaced ``account:`` routes are not.
-        if match.view_name in allowed or match.view_name.startswith("account_"):
+        if match is not None and (match.view_name in allowed or match.view_name.startswith("account_")):
+            return None
+        if self._rewrite_root_guild_slug(request):
             return None
         raise Http404("Not available on this surface.")
+
+    @staticmethod
+    def _rewrite_root_guild_slug(request: HttpRequest) -> bool:
+        """Point a bare ``/<slug>/`` at the shared guild-detail route, in place.
+
+        The guilds host serves guild pages at the root without the redundant ``-guild``
+        suffix (``/woodworking/`` → the guild slugged ``woodworking-guild``). Rewriting
+        ``path_info`` — rather than adding a second route or a second view — means the
+        members host and the guilds host run the identical view and template, and
+        ``request.path`` still holds the URL the visitor actually asked for, so the view
+        can canonicalize it (see ``hub.views.guild_detail``).
+
+        Returns:
+            ``True`` when the path was a known guild and has been rewritten.
+        """
+        from django.urls import reverse
+
+        segment = request.path.strip("/")
+        if not segment or "/" in segment:
+            return False
+
+        from membership.models import Guild
+
+        try:
+            guild = Guild.objects.get_by_public_slug(segment)
+        except Guild.DoesNotExist:
+            return False
+        request.path_info = reverse("hub_guild_detail", args=[guild.slug])
+        return True
 
     def _handle_signage_surface(self, request: HttpRequest) -> HttpResponse | None:
         """Route the read-only kiosk surface: root → first zone, everything else gated.

--- a/core/views.py
+++ b/core/views.py
@@ -11,7 +11,6 @@ from django.contrib.auth.models import User
 from django.core.paginator import Paginator
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponsePermanentRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
@@ -203,8 +202,7 @@ def guild_vanity_redirect(request: HttpRequest, slug: str) -> HttpResponse:
     from membership.models import Guild
 
     guild = get_object_or_404(Guild, slug=slug)
-    target = f"{settings.GUILDS_BASE_URL}{reverse('hub_guild_detail', args=[guild.slug])}"
-    return HttpResponsePermanentRedirect(target)
+    return HttpResponsePermanentRedirect(guild.public_url)
 
 
 def newsletter_signup(request: HttpRequest) -> HttpResponse:

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -132,6 +132,7 @@ class GuildEditForm(forms.ModelForm):
             "discord_welcome_message",
             "website_url",
             "show_members",
+            "is_public",
             "featured_class",
             "faq_label",
         ]
@@ -181,6 +182,7 @@ class GuildEditForm(forms.ModelForm):
             "discord_welcome_message": "Discord welcome message",
             "website_url": "Website URL",
             "show_members": "Show members roster",
+            "is_public": "Share this guild's page publicly",
             "featured_class": "Featured class",
             "faq_label": "FAQ / info section heading",
         }

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path("guilds/voting/history/", views.snapshot_history, name="hub_snapshot_history"),
     path("guilds/voting/history/<int:pk>/", views.snapshot_detail, name="hub_snapshot_detail"),
     path("members/", views.member_directory, name="hub_member_directory"),
-    # Public guild directory — the guilds.pastlives.app front door (also reachable on FOG).
+    # Public guild directory — the guilds.pastlives.space front door (also reachable on FOG).
     path("guilds/", views.guild_directory, name="hub_guild_directory"),
     # Old numeric guild URLs (already shared in Discord/emails) 301 → the slug URL.
     path("guilds/<int:pk>/", views.guild_detail_redirect, name="hub_guild_detail_by_id"),

--- a/hub/views.py
+++ b/hub/views.py
@@ -3554,6 +3554,12 @@ def guild_calendar_events_partial(request: HttpRequest, pk: int) -> HttpResponse
     """HTMX partial — calendar grid/list scoped to one guild (its iCal events plus the
     guild's CMS classes and orientation slots). Drives the Guild Calendar tab's nav."""
     guild = get_object_or_404(Guild, pk=pk)
+    if _is_guilds_surface(request) and not guild.is_public:
+        # Same gate as ``guild_detail``: a private guild is withheld from the public
+        # surface. Without this the partial served the guild's iCal events, class
+        # sessions and orientation slots to anonymous callers, since it is reachable
+        # by sequential pk and is listed in GUILDS_ALLOWED_VIEW_NAMES.
+        return render(request, "hub/guild_private.html", {"guild": guild}, status=403)
     try:
         week_offset = max(-52, min(52, int(request.GET.get("week_offset", 0))))
         month_offset = max(-24, min(24, int(request.GET.get("month_offset", 0))))

--- a/hub/views.py
+++ b/hub/views.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, cast
+from urllib.parse import quote
 
 from django.utils import timezone as dj_timezone
 
@@ -18,7 +19,14 @@ from django.contrib.auth.views import redirect_to_login
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Prefetch, Q, QuerySet
 from django.forms import BaseInlineFormSet
-from django.http import Http404, HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import (
+    Http404,
+    HttpRequest,
+    HttpResponse,
+    HttpResponsePermanentRedirect,
+    JsonResponse,
+    StreamingHttpResponse,
+)
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -384,16 +392,53 @@ def _guild_pulse(guild: "Guild", limit: int = 6) -> list[dict[str, Any]]:
 def guild_detail_redirect(request: HttpRequest, pk: int) -> HttpResponse:
     """301 an old numeric guild URL (/guilds/<id>/) to its slug URL — keeps shared links alive."""
     guild = get_object_or_404(Guild, pk=pk)
+    if _is_guilds_surface(request):
+        # One hop straight to the guilds-host canonical (/woodworking/), not via the
+        # members-host shape, so shared numeric links don't chain two redirects.
+        return HttpResponsePermanentRedirect(guild.public_path)
     return redirect("hub_guild_detail", slug=guild.slug, permanent=True)
+
+
+def _is_guilds_surface(request: HttpRequest) -> bool:
+    """True when this request arrived on the public guilds host."""
+    return getattr(request, "surface", "members") == "guilds"
+
+
+def _guild_login_url(request: HttpRequest, guild: Guild) -> str:
+    """Where a logged-out visitor goes to act on this guild, with a ``next`` back to it.
+
+    Production leaves ``COOKIE_DOMAIN`` unset, so session cookies are host-only: a login
+    completed on the guilds host would NOT be shared with the member hub, and every gated
+    action (join, leave, buy, orientation, contacting the lead) ultimately lives on the
+    hub anyway. Guests on the guilds surface are therefore sent to the hub's login with
+    ``next`` pointing at the identical guild page over there — same view, same template,
+    so they land exactly where they were. On the hub itself the ordinary relative login
+    URL with the current path is used.
+    """
+    hub_path = reverse("hub_guild_detail", args=[guild.slug])
+    login_path = reverse("account_login")
+    if _is_guilds_surface(request):
+        return f"{settings.MEMBER_BASE_URL}{login_path}?next={quote(hub_path)}"
+    return f"{login_path}?next={quote(request.get_full_path())}"
 
 
 def guild_directory(request: HttpRequest) -> HttpResponse:
     """Public guild directory — featured guilds first, then alphabetical.
 
-    Renders in guest chrome on the guilds surface (guilds.pastlives.app); the
-    sidebar context is ignored there but keeps parity on the members host.
+    Renders in guest chrome on the guilds surface (guilds.pastlives.space); the
+    sidebar context is ignored there but keeps parity on the members host. Guilds
+    that opted out of a public page are listed on the hub but not on the public site.
     """
-    guilds = Guild.objects.directory().select_related("guild_lead").annotate(member_total=Count("memberships"))
+    on_guilds_surface = _is_guilds_surface(request)
+    guilds = list(
+        Guild.objects.directory(public_only=on_guilds_surface)
+        .select_related("guild_lead")
+        .annotate(member_total=Count("memberships"))
+    )
+    # Each card links to the guild page on the surface it is being rendered on: the short
+    # root-level slug publicly, the member-hub path on FOG.
+    for guild in guilds:
+        guild.card_path = guild.public_path if on_guilds_surface else reverse("hub_guild_detail", args=[guild.slug])
     ctx = _get_hub_context(request)
     hero_stats = {
         "guilds": len(guilds),
@@ -406,7 +451,13 @@ def guild_directory(request: HttpRequest) -> HttpResponse:
 
 
 def guild_detail(request: HttpRequest, slug: str) -> HttpResponse:
-    """Guild detail page — shows about text, active products, and cart interface."""
+    """Guild detail page — shows about text, active products, and cart interface.
+
+    Serves both hosts from one view and one template: on the member hub at
+    ``/guilds/<slug>/``, and on the public guilds host at the short root-level
+    ``/<public-slug>/`` (the middleware rewrites that onto this route). What differs
+    between them is auth state, not content.
+    """
     from billing.forms import CONTEXT_MEMBER_GUILD_PAGE, TabItemForm, build_product_split_formset
     from billing.models import Product
 
@@ -418,6 +469,16 @@ def guild_detail(request: HttpRequest, slug: str) -> HttpResponse:
         ),
         slug=slug,
     )
+    on_guilds_surface = _is_guilds_surface(request)
+    if on_guilds_surface:
+        if not guild.is_public:
+            # A deliberately withheld page, not a missing one: 403 keeps it out of search
+            # indexes and off aggregators while still telling a human what happened.
+            return render(request, "hub/guild_private.html", {"guild": guild}, status=403)
+        if request.path != guild.public_path:
+            # One canonical public URL per guild. The long /guilds/<slug>/ shape and the
+            # un-stripped /<slug>-guild/ shape both 301 to it rather than duplicating it.
+            return HttpResponsePermanentRedirect(guild.public_path)
     ctx = _get_hub_context(request)
     products = guild.products.order_by("name").prefetch_related("splits__guild")
     member = _get_member(request)
@@ -431,7 +492,7 @@ def guild_detail(request: HttpRequest, slug: str) -> HttpResponse:
     # Editor affordances never render on the guest guilds surface: a logged-in
     # lead there would otherwise see Edit / Adjust / product-admin buttons that
     # 404 (the editor endpoints aren't in the guilds allowlist). Leads edit on FOG.
-    can_edit_this_guild = _can_edit_guild(request, guild) and getattr(request, "surface", "members") != "guilds"
+    can_edit_this_guild = _can_edit_guild(request, guild) and not on_guilds_surface
     product_form = None
     product_splits_formset = None
     all_guilds = None
@@ -524,6 +585,7 @@ def guild_detail(request: HttpRequest, slug: str) -> HttpResponse:
             "show_orientation": show_orientation,
             "orientation_slots": orientation_slots,
             "custom_request_form": custom_request_form,
+            "guild_login_url": _guild_login_url(request, guild),
         },
     )
 

--- a/membership/migrations/0099_guild_is_public.py
+++ b/membership/migrations/0099_guild_is_public.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("membership", "0098_discordlinknudge"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="guild",
+            name="is_public",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "On: anyone with the link can read this guild's page on the public guilds site. "
+                    "Off: the page stays inside the member hub, and visitors get a short, friendly note instead."
+                ),
+                verbose_name="Share this guild's page publicly",
+            ),
+        ),
+    ]

--- a/membership/models.py
+++ b/membership/models.py
@@ -1170,19 +1170,74 @@ class VirtualLink:
     url: str
 
 
+# Guild slugs are auto-generated from the guild's name, so almost every one of them
+# ends in "-guild". On the public guilds site that suffix is pure noise — the host is
+# already guilds.pastlives.space — so it is stripped from the URL (see
+# ``Guild.public_slug`` and ``GuildManager.get_by_public_slug``).
+PUBLIC_SLUG_SUFFIX = "-guild"
+
+# Root-level paths on the guilds host that are NOT guild pages (the directory, the org
+# info page, allauth, static/media, and the crawler files). A guild whose short slug
+# would collide with one of these keeps the longer /guilds/<slug>/ URL in public, so a
+# collision can never silently serve the wrong page.
+RESERVED_PUBLIC_SLUGS = frozenset(
+    {
+        "account",
+        "accounts",
+        "classes",
+        "g",
+        "guilds",
+        "health",
+        "info",
+        "media",
+        "newsletter",
+        "notifications",
+        "static",
+    }
+)
+
+
 class GuildManager(models.Manager["Guild"]):
     """Default manager that hides soft-deleted guilds from every query."""
 
     def get_queryset(self) -> models.QuerySet[Guild]:
         return super().get_queryset().filter(deleted_at__isnull=True)
 
-    def directory(self) -> models.QuerySet[Guild]:
+    def directory(self, *, public_only: bool = False) -> models.QuerySet[Guild]:
         """Active guilds for the directory: featured first, then alphabetical.
 
-        Every active guild is public and appears everywhere; soft-deleting or
-        deactivating a guild (``is_active=False``) is the only way to hide it.
+        Args:
+            public_only: Drop guilds whose lead has switched their page to private
+                (``is_public=False``). The public guilds site passes ``True``; the
+                member hub leaves it ``False`` so members still see every guild.
         """
-        return self.filter(is_active=True).order_by("-is_featured", "name")
+        guilds = self.filter(is_active=True)
+        if public_only:
+            guilds = guilds.filter(is_public=True)
+        return guilds.order_by("-is_featured", "name")
+
+    def get_by_public_slug(self, public_slug: str) -> Guild:
+        """Resolve a guilds-surface slug, tolerating the stripped ``-guild`` suffix.
+
+        The public surface serves ``guilds.pastlives.space/woodworking/`` for the guild
+        whose stored slug is ``woodworking-guild`` (see :attr:`Guild.public_slug`). An
+        **exact** slug match always wins, so if both ``woodworking`` and
+        ``woodworking-guild`` exist the short URL deterministically belongs to the guild
+        that actually owns that slug; the other keeps its full slug as its public one.
+
+        Args:
+            public_slug: The single URL segment the visitor asked for.
+
+        Returns:
+            The matching guild.
+
+        Raises:
+            Guild.DoesNotExist: If neither the exact slug nor ``<slug>-guild`` exists.
+        """
+        try:
+            return self.get(slug=public_slug)
+        except self.model.DoesNotExist:
+            return self.get(slug=f"{public_slug}{PUBLIC_SLUG_SUFFIX}")
 
     def for_discord_channel(self, channel_id: str) -> Guild | None:
         """The active guild whose Discord channel is ``channel_id``, or ``None`` if unmapped.
@@ -1212,6 +1267,9 @@ class GuildManager(models.Manager["Guild"]):
 class Guild(HeroCropMixin, models.Model):
     # Queryset annotation (set by GuildAdmin.get_queryset)
     sublet_count: int
+    # Per-render link, set by hub.views.guild_directory (surface-dependent, so it can't
+    # live on the model as a property).
+    card_path: str
 
     name = models.CharField(max_length=255, unique=True)
     slug = models.SlugField(
@@ -1363,6 +1421,14 @@ class Guild(HeroCropMixin, models.Model):
     is_featured = models.BooleanField(
         default=False, help_text="Pin this guild to the top of the public guilds directory."
     )
+    is_public = models.BooleanField(
+        default=True,
+        verbose_name="Share this guild's page publicly",
+        help_text=(
+            "On: anyone with the link can read this guild's page on the public guilds site. "
+            "Off: the page stays inside the member hub, and visitors get a short, friendly note instead."
+        ),
+    )
     featured_class = models.ForeignKey(
         "classes.ClassOffering",
         null=True,
@@ -1429,6 +1495,46 @@ class Guild(HeroCropMixin, models.Model):
         path = f"{reverse('classes:public_list')}?guild={self.slug}"
         url = f"{settings.BOOK_BASE_URL}{path}" if guilds_surface else path
         return VirtualLink(label=f"{self.name} Classes", url=url)
+
+    @cached_property
+    def public_slug(self) -> str:
+        """The single URL segment this guild is served under on the public guilds site.
+
+        A trailing ``-guild`` is dropped (``woodworking-guild`` → ``woodworking``) because
+        the host already says "guilds". The suffix is kept in the one case where dropping
+        it would be ambiguous: another guild already owns the shortened slug outright, and
+        exact matches win in :meth:`GuildManager.get_by_public_slug`.
+        """
+        stripped = self.slug.removesuffix(PUBLIC_SLUG_SUFFIX)
+        if not stripped or stripped == self.slug or stripped in RESERVED_PUBLIC_SLUGS:
+            return self.slug
+        if type(self)._default_manager.filter(slug=stripped).exclude(pk=self.pk).exists():
+            return self.slug
+        return stripped
+
+    @property
+    def public_path(self) -> str:
+        """Root-relative canonical path on the guilds host, e.g. ``/woodworking/``.
+
+        Falls back to the longer ``/guilds/<slug>/`` (which also resolves on the guilds
+        host) for the rare guild whose slug is a reserved root path — better a longer
+        public URL than one that would land on the directory or the info page.
+        """
+        from django.urls import reverse
+
+        if self.public_slug in RESERVED_PUBLIC_SLUGS:
+            return reverse("hub_guild_detail", args=[self.slug])
+        return f"/{self.public_slug}/"
+
+    @property
+    def public_url(self) -> str:
+        """Absolute canonical URL of the public guild page, e.g.
+        ``https://guilds.pastlives.space/woodworking/``.
+
+        The one source of truth for canonical/Open-Graph tags, emails, and any link that
+        leaves the app — never hand-build this from the slug.
+        """
+        return f"{settings.GUILDS_BASE_URL}{self.public_path}"
 
     @property
     def vanity_url(self) -> str:

--- a/plfog/settings.py
+++ b/plfog/settings.py
@@ -51,12 +51,14 @@ if _cookie_domain:
 
 # Theme-persistence cookie. Written client-side by the theme toggle (see
 # templates/hub/base.html) so an explicit light/dark choice follows the member
-# across subdomains of the same registrable domain — the member hub,
-# guilds.pastlives.app, and the Discord OAuth callback all live on .pastlives.app.
-# It is deliberately separate from COOKIE_DOMAIN (which scopes the session/CSRF
-# cookies to .pastlives.space) because a single cookie cannot span two different
-# registrable domains. Empty (the default) → host-only cookie, correct for local
-# dev (pastlives.test); production sets THEME_COOKIE_DOMAIN=.pastlives.app.
+# across subdomains of the same registrable domain — the member hub and the Discord
+# OAuth callback live on .pastlives.app. NOTE: the public guilds surface lives on
+# guilds.pastlives.space, so a .pastlives.app theme cookie does not reach it; guests
+# there simply start on this surface's light default. It is deliberately separate
+# from COOKIE_DOMAIN (which scopes the session/CSRF cookies to .pastlives.space)
+# because a single cookie cannot span two different registrable domains. Empty (the
+# default) → host-only cookie, correct for local dev (pastlives.test); production
+# sets THEME_COOKIE_DOMAIN=.pastlives.app.
 THEME_COOKIE_DOMAIN = os.environ.get("THEME_COOKIE_DOMAIN", "").strip()
 
 # Surface routing. PUBLIC_HOSTS is the set of hostnames that serve the public
@@ -94,15 +96,17 @@ MEMBER_ONLY_PATH_PREFIXES: tuple[str, ...] = (
 PUBLIC_ONLY_PATH_PREFIXES: tuple[str, ...] = ("/account/",)
 
 # Guilds surface. GUILDS_HOSTS is the set of hostnames that serve the public
-# guild directory + guest guild pages (guilds.pastlives.app). Root redirects to
-# /guilds/ and only the guest-appropriate views below resolve there; everything
-# else 404s. Empty defaults are safe hooks — until DNS + DJANGO_ALLOWED_HOSTS
-# include the host, no request ever reaches the guilds branch. Go-live: set
-# GUILDS_HOSTS=guilds.pastlives.app and add the host to ALLOWED_HOSTS +
-# CSRF_TRUSTED_ORIGINS (do NOT add it to PUBLIC_HOSTS — that serves the class
-# catalog and redirects / to /classes/).
+# guild directory + guest guild pages (guilds.pastlives.space). Root redirects to
+# /guilds/, guild pages are served at the SHORT root-level slug (/woodworking/ for
+# the guild slugged "woodworking-guild" — see Guild.public_slug), and only the
+# guest-appropriate views below resolve there; everything else 404s. Until DNS +
+# DJANGO_ALLOWED_HOSTS include the host, no request ever reaches the guilds branch.
+# Go-live: set GUILDS_HOSTS=guilds.pastlives.space and add the host to ALLOWED_HOSTS
+# + CSRF_TRUSTED_ORIGINS (do NOT add it to PUBLIC_HOSTS — that serves the class
+# catalog and redirects / to /classes/). The surface lives on .pastlives.space, not
+# .pastlives.app: pastlives.app is only a redirect to members.pastlives.space.
 GUILDS_HOSTS = [
-    h.strip().lower() for h in os.environ.get("GUILDS_HOSTS", "guilds.pastlives.app").split(",") if h.strip()
+    h.strip().lower() for h in os.environ.get("GUILDS_HOSTS", "guilds.pastlives.space").split(",") if h.strip()
 ]
 # Vanity calendar alias. Every request to a host listed here 302s to the community
 # calendar on the members domain (calendar.pastlives.space — printed on flyers etc.).
@@ -115,7 +119,7 @@ CALENDAR_REDIRECT_HOSTS = [
 ALLOWED_HOSTS += [h for h in CALENDAR_REDIRECT_HOSTS if h not in ALLOWED_HOSTS]
 # Absolute base URL of the guilds surface, used to canonicalize OG/SEO tags on
 # shared guild links regardless of which host rendered them.
-GUILDS_BASE_URL = os.environ.get("GUILDS_BASE_URL", "https://guilds.pastlives.app").rstrip("/")
+GUILDS_BASE_URL = os.environ.get("GUILDS_BASE_URL", "https://guilds.pastlives.space").rstrip("/")
 # Precise allowlist of view names that may resolve on the guilds host. A precise
 # allowlist (not a broad /guilds/ prefix) keeps the guild editor + product/cart
 # endpoints off the guest surface. Allauth's built-in ``account_*`` login/signup/
@@ -127,7 +131,9 @@ GUILDS_ALLOWED_VIEW_NAMES: frozenset[str] = frozenset(
         "hub_guild_directory",
         "hub_guild_detail",
         "hub_guild_detail_by_id",
+        "hub_guild_calendar_events",
         "hub_org_info",
+        "robots_txt",
         "hub_guild_join",
         "hub_guild_leave",
         "hub_orientation_book",

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,37 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.18"
+VERSION = "0.23.24"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.24",
+        "date": "2026-07-22",
+        "title": "Your guild now has a public page you can share with anyone",
+        "changes": [
+            (
+                "Every guild has a public home on the web that works without a login, so you can "
+                "share it with a friend, a class, or anyone curious about what your guild does. "
+                "The link is short and easy to say out loud \u2014 no more \u201cslash guilds slash "
+                "woodworking dash guild\u201d."
+            ),
+            (
+                "Visitors see the welcoming stuff: what your guild is about, who leads it, when it "
+                "meets, your studio hours, classes, photos and FAQ. Anything that belongs to "
+                "members only \u2014 meeting notes, announcements, the member list, and everyone\u2019s "
+                "contact details \u2014 stays behind a login."
+            ),
+            (
+                "Buttons like Join, Buy and Contact take a visitor straight to the sign-in page and "
+                "bring them right back to the same guild page afterwards."
+            ),
+            (
+                "Would you rather keep your page in-house? Guild leads can switch it off in Guild "
+                "Settings \u2192 Basic Information. Visitors then get a short, friendly note instead, "
+                "and members carry on seeing the page as normal."
+            ),
+        ],
+    },
     {
         "version": "0.23.18",
         "date": "2026-07-21",

--- a/static/css/cms-guilds.css
+++ b/static/css/cms-guilds.css
@@ -1,5 +1,5 @@
 /* ====================================================================
-   Guilds Public Surface — guilds.pastlives.app directory + guest guild page
+   Guilds Public Surface — guilds.pastlives.space directory + guest guild page
    Layers on cms-public.css, which owns the .cp-page tokens and the #hero /
    .cls-* card styles the directory reuses. Only the directory extras that
    aren't already in .cls-* live here, plus centering for the reused guild
@@ -97,4 +97,49 @@ body.guilds-portal .hub-content {
   font-weight: 700;
   letter-spacing: 0.03em;
   text-transform: uppercase;
+}
+
+
+/* ── Private-guild notice (templates/hub/guild_private.html) ─────────
+   Shown with HTTP 403 when a lead has switched their page off. Uses the
+   shared .hub-card / .pl-btn components, so only the layout lives here.
+   Dual-theme by construction — every value is a --hub-* token. */
+.pl-guild-private {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1rem;
+}
+.pl-guild-private__card {
+  max-width: 34rem;
+  text-align: center;
+  padding: 2rem 1.5rem;
+}
+.pl-guild-private__title {
+  font-family: "Lato", sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--hub-text);
+  margin: 0 0 1rem;
+}
+.pl-guild-private__body {
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--hub-text-muted);
+  margin: 0 0 1rem;
+}
+.pl-guild-private__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 480px) {
+  .pl-guild-private {
+    padding: 2rem 0.75rem;
+  }
+  .pl-guild-private__actions .pl-btn {
+    width: 100%;
+  }
 }

--- a/templates/guilds/base_public.html
+++ b/templates/guilds/base_public.html
@@ -1,7 +1,7 @@
 {% extends "hub/base.html" %}
 {% load static %}
 {% comment %}
-Guest base template for the public guilds surface (guilds.pastlives.app).
+Guest base template for the public guilds surface (guilds.pastlives.space).
 Mirrors classes/base_public.html — the slim .cp-topbar chrome, light by default,
 burger drawer on mobile — changed only where guilds differ (nav "Guilds" marked
 current, Become-a-member CTA, guilds-portal body class, cms-guilds.css). The

--- a/templates/guilds/directory.html
+++ b/templates/guilds/directory.html
@@ -27,11 +27,15 @@
     </div>
   </section>
 
+  {% comment %}
+  card_path is set by the view: the short root-level slug (/woodworking/) on the guilds
+  host, the member-hub path (/guilds/woodworking-guild/) on FOG. Never hand-build it.
+  {% endcomment %}
   {% if guilds %}
   <div class="cls-grid pl-guild-dir__grid">
     {% for guild in guilds %}
     <div class="cls-card">
-      <a href="{% url 'hub_guild_detail' guild.slug %}" class="cls-media" aria-label="{{ guild.name }}">
+      <a href="{{ guild.card_path }}" class="cls-media" aria-label="{{ guild.name }}">
         {% if guild.banner_image %}
         <img class="cls-img" src="{{ guild.banner_image.url }}" alt="{{ guild.name }}">
         {% else %}
@@ -44,7 +48,7 @@
         {% if guild.is_featured %}<span class="pl-guild-dir__star">★ Featured</span>{% endif %}
       </a>
       <div class="cls-body">
-        <a href="{% url 'hub_guild_detail' guild.slug %}" class="cls-title">{{ guild.name }}</a>
+        <a href="{{ guild.card_path }}" class="cls-title">{{ guild.name }}</a>
         {% if guild.guild_lead %}<div class="cls-inst">Led by {{ guild.guild_lead.display_name }}</div>{% endif %}
         {% if guild.about %}<p class="pl-guild-dir__blurb">{{ guild.about|striptags|truncatewords:18 }}</p>{% endif %}
         <div class="pl-guild-dir__meta">

--- a/templates/hub/guild_detail.html
+++ b/templates/hub/guild_detail.html
@@ -6,12 +6,17 @@
 
 {% block extra_head %}{{ block.super }}
 <link rel="stylesheet" href="{% static 'css/calendar.css' %}">
-{% if is_guilds_surface %}{# ── OG / SEO — only where the guild link is shared publicly ── #}
-<link rel="canonical" href="{{ GUILDS_BASE_URL }}{% url 'hub_guild_detail' guild.slug %}">
+{% comment %}
+The guilds host is the canonical home of a guild page, so BOTH surfaces point their
+canonical tag there — the member-hub copy at /guilds/<slug>/ is the same content and
+must not compete with it in search. A guild whose page is private advertises nothing.
+{% endcomment %}
+{% if guild.is_public %}<link rel="canonical" href="{{ guild.public_url }}">{% endif %}
+{% if is_guilds_surface %}{# ── Open Graph — only where the link is actually shared ── #}
 <meta property="og:type" content="website">
 <meta property="og:title" content="{{ guild.name }} — Past Lives Guilds">
 <meta property="og:description" content="{{ guild.about|striptags|truncatewords:30|default:'A guild at Past Lives Makerspace in Portland, OR.' }}">
-<meta property="og:url" content="{{ GUILDS_BASE_URL }}{% url 'hub_guild_detail' guild.slug %}">
+<meta property="og:url" content="{{ guild.public_url }}">
 <meta property="og:image" content="{% if guild.banner_image %}{{ guild.banner_image.url }}{% else %}{{ GUILDS_BASE_URL }}{% static 'img/og-guild-default.png' %}{% endif %}">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="description" content="{{ guild.about|striptags|truncatewords:30|default:'A guild at Past Lives Makerspace in Portland, OR.' }}">
@@ -65,7 +70,7 @@
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:0.25rem;"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                 Guild Settings
             </a>
-            <a href="{{ GUILDS_BASE_URL }}{% url 'hub_guild_detail' guild.slug %}" target="_blank" rel="noopener"
+            <a href="{{ guild.public_url }}" target="_blank" rel="noopener"
                class="pl-btn pl-btn--secondary" title="Open this guild's public page as a guest" x-show="!isAdjusting">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:0.25rem;"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
                 View public page
@@ -119,7 +124,12 @@
     <button type="button" class="vote-tab" :class="section === 'schedule' ? 'vote-tab--active' : ''" @click="section = 'schedule'">Guild Calendar</button>
     {% if tab_payments_enabled and not is_guilds_surface %}<button type="button" class="vote-tab" :class="section === 'buyables' ? 'vote-tab--active' : ''" @click="section = 'buyables'">Buyables</button>{% endif %}
     {% if faq_items %}<button type="button" class="vote-tab" :class="section === 'faq' ? 'vote-tab--active' : ''" @click="section = 'faq'">{{ guild.faq_label|default:"FAQ" }}</button>{% endif %}
-    {% if meeting_notes or can_edit_this_guild %}<button type="button" class="vote-tab" :class="section === 'notes' ? 'vote-tab--active' : ''" @click="section = 'notes'">Meeting Notes</button>{% endif %}
+    {% comment %}
+    Meeting notes are internal: "members who can view the guild page can read these".
+    Both the tab button and the panel below are gated on authentication so an anonymous
+    visitor on the public guilds site never sees them.
+    {% endcomment %}
+    {% if user.is_authenticated and meeting_notes or can_edit_this_guild %}<button type="button" class="vote-tab" :class="section === 'notes' ? 'vote-tab--active' : ''" @click="section = 'notes'">Meeting Notes</button>{% endif %}
     {% if gallery_images %}<button type="button" class="vote-tab" :class="section === 'gallery' ? 'vote-tab--active' : ''" @click="section = 'gallery'">Gallery</button>{% endif %}
 </nav>
 
@@ -140,11 +150,15 @@
         </section>
         {% endif %}
 
-        {% if announcements or user.is_authenticated and not can_edit_this_guild %}
+        {% comment %}
+        Guild announcements are written for members (and mirrored to Discord/email), so
+        they are shown to signed-in viewers only — not published to the open internet.
+        {% endcomment %}
+        {% if user.is_authenticated %}{% if announcements or not can_edit_this_guild %}
         <section class="pl-guild-section">
             <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap;">
                 <h2 class="pl-guild-section__h2" style="margin:0;">Announcements</h2>
-                {% if user.is_authenticated and not can_edit_this_guild %}
+                {% if not can_edit_this_guild %}
                 <a href="{% url 'hub_guild_announcement_propose' %}?guild={{ guild.pk }}" class="hub-btn hub-btn--sm">+ Suggest an announcement</a>
                 {% endif %}
             </div>
@@ -162,7 +176,7 @@
             <p class="hub-text-muted" style="margin-top:0.5rem;">No announcements yet — be the first to suggest one.</p>
             {% endif %}
         </section>
-        {% endif %}
+        {% endif %}{% endif %}
 
         {# About — keeps the "Nothing here yet" placeholder the specs assert. #}
         <section class="pl-guild-section">
@@ -281,9 +295,15 @@
         <div class="hub-card">
             <h3 class="hub-detail-label">Get Involved</h3>
             <div style="display:flex; flex-direction:column; gap:0.5rem;">
-                {# Join / Leave — three-way on auth + membership. "Log in to join" carries a GET-path next so the member lands right back here. #}
+                {% comment %}
+                Join / Leave — three-way on auth + membership. guild_login_url is built by
+                the view: on the public guilds site it points at the member hub's login
+                (session cookies are host-only) with a next back to this same guild page
+                there; on the hub it is the plain relative login URL. Always a GET page as
+                the next target, never a POST-only action endpoint.
+                {% endcomment %}
                 {% if not user.is_authenticated %}
-                <a href="{% url 'account_login' %}?next={{ request.path|urlencode }}" class="pl-btn pl-btn--primary" style="width:100%;">Log in to join</a>
+                <a href="{{ guild_login_url }}" class="pl-btn pl-btn--primary" style="width:100%;" hx-boost="false">Log in to join</a>
                 {% elif member and not is_member_of_guild %}
                 <form method="post" action="{% url 'hub_guild_join' guild.pk %}">
                     {% csrf_token %}
@@ -316,7 +336,11 @@
                 {% endif %}
                 {% if is_guilds_surface and products %}
                 {# No in-place cart on the guest surface — buyables live on the members hub. #}
-                <a href="{{ MEMBER_BASE_URL }}{% url 'hub_guild_detail' guild.slug %}" class="pl-btn pl-btn--secondary" style="width:100%;" hx-boost="false">{% if user.is_authenticated %}Buy this guild's items on the members hub{% else %}Log in on the members hub to shop{% endif %}</a>
+                {% if user.is_authenticated %}
+                <a href="{{ MEMBER_BASE_URL }}{% url 'hub_guild_detail' guild.slug %}" class="pl-btn pl-btn--secondary" style="width:100%;" hx-boost="false">Buy this guild's items on the members hub</a>
+                {% else %}
+                <a href="{{ guild_login_url }}" class="pl-btn pl-btn--secondary" style="width:100%;" hx-boost="false">Log in on the members hub to shop</a>
+                {% endif %}
                 {% endif %}
                 {% if user.is_authenticated and guild.guild_lead.primary_email %}
                 <a href="mailto:{{ guild.guild_lead.primary_email }}" class="pl-btn pl-btn--secondary" style="width:100%;">
@@ -329,13 +353,16 @@
                     Contact the Guild
                 </a>
                 {% endif %}
+                {% if not user.is_authenticated and not guild.contact_email and guild.guild_lead %}
+                <a href="{{ guild_login_url }}" class="pl-btn pl-btn--secondary" style="width:100%;" hx-boost="false">Log in to contact the guild lead</a>
+                {% endif %}
                 {% if guild.discord_url %}<a href="{{ guild.discord_url }}" target="_blank" rel="noopener" class="pl-btn pl-btn--secondary" style="width:100%;">Discord channel</a>{% endif %}
                 {% if guild.website_url %}<a href="{{ guild.website_url }}" target="_blank" rel="noopener" class="pl-btn pl-btn--secondary" style="width:100%;">Website</a>{% endif %}
             </div>
         </div>
 
-        {% if pulse and not is_guilds_surface %}
-        {# Suppressed on the guest surface — the activity feed names members who joined. #}
+        {% if pulse and user.is_authenticated and not is_guilds_surface %}
+        {# Suppressed for guests — the activity feed names members who joined. #}
         <div class="hub-card">
             <h3 class="hub-detail-label">Recent Activity</h3>
             <div style="display:flex; flex-direction:column; gap:0.6rem;">
@@ -408,7 +435,7 @@
 </div>
 {% endif %}
 
-{% if meeting_notes or can_edit_this_guild %}
+{% if user.is_authenticated and meeting_notes or can_edit_this_guild %}
 <div x-show="section === 'notes'" x-cloak>
     <section class="pl-guild-section">
         {% if can_edit_this_guild %}

--- a/templates/hub/guild_edit.html
+++ b/templates/hub/guild_edit.html
@@ -42,6 +42,8 @@
         {% include "components/form_field.html" with field=form.featured_class field_label="Featured class" %}
       </div>
       {% include "components/form_field.html" with field=form.show_members %}
+      {% include "components/form_field.html" with field=form.is_public %}
+      {% if not guild.is_public %}<p class="hub-text-muted" style="font-size:0.8125rem; margin:0.25rem 0 0;">While this is off, your short link, QR code, and printable flyer all land on a short "this page is private" note instead of the guild page.</p>{% endif %}
     </div>
   </div>
 

--- a/templates/hub/guild_private.html
+++ b/templates/hub/guild_private.html
@@ -1,0 +1,34 @@
+{% extends guilds_page_base %}
+{% block title %}This guild's page is private{% endblock %}
+
+{% comment %}
+Shown on the public guilds surface when a guild lead has switched their page off
+(Guild.is_public). Served with HTTP 403 — the page exists, it is simply withheld —
+plus noindex so a private page never lands in a search index. The guild's name is
+deliberately NOT printed: a lead who hid the page should not have it confirmed by
+URL guessing. The member hub is unaffected by this flag.
+{% endcomment %}
+
+{% block extra_head %}{{ block.super }}
+<meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block content %}
+<div class="pl-guild-private">
+    <div class="hub-card pl-guild-private__card">
+        <h1 class="pl-guild-private__title">This guild's page is private for now</h1>
+        <p class="pl-guild-private__body">
+            One of our guilds lives at this link, but they've chosen to keep their page in-house
+            for the moment. Nothing went wrong on your end.
+        </p>
+        <p class="pl-guild-private__body">
+            Past Lives members can find every guild inside the member hub — and if you're not a
+            member yet, you're very welcome to come see what we're about.
+        </p>
+        <div class="pl-guild-private__actions">
+            <a href="{% url 'hub_guild_directory' %}" class="pl-btn pl-btn--primary">Browse the other guilds</a>
+            <a href="https://pastlives.space/membership" class="pl-btn pl-btn--secondary" hx-boost="false">Become a member</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/hub/partials/guild_orientation.html
+++ b/templates/hub/partials/guild_orientation.html
@@ -53,7 +53,7 @@ Member-facing orientation section on the guild page. Context:
             {% url 'hub_orientation_book' slot.pk as book_url %}
             {% include "components/confirm_modal.html" with confirm_id="book-slot-"|add:pks confirm_title="Request this orientation?" confirm_message="We'll send your request to the guild lead to confirm. You can cancel any time." confirm_action_url=book_url confirm_button_text="Send request" confirm_button_style="primary" %}
             {% else %}
-            <a href="{% url 'account_login' %}?next={{ request.path|urlencode }}" class="hub-btn hub-btn--sm hub-btn--primary">Log in to book</a>
+            <a href="{{ guild_login_url }}" class="hub-btn hub-btn--sm hub-btn--primary" hx-boost="false">Log in to book</a>
             {% endif %}
           </span>
         </li>
@@ -90,7 +90,7 @@ Member-facing orientation section on the guild page. Context:
     </div>
     {% else %}
     <div style="margin-top:1rem; padding-top:1rem; border-top:1px solid var(--hub-border);">
-      <a href="{% url 'account_login' %}?next={{ request.path|urlencode }}" class="hub-btn hub-btn--sm hub-btn--ghost">Log in to request a custom time</a>
+      <a href="{{ guild_login_url }}" class="hub-btn hub-btn--sm hub-btn--ghost" hx-boost="false">Log in to request a custom time</a>
     </div>
     {% endif %}
     {% endif %}

--- a/tests/core/guild_vanity_spec.py
+++ b/tests/core/guild_vanity_spec.py
@@ -31,7 +31,8 @@ def describe_guild_vanity_redirect():
         guild = GuildFactory(name="Ceramics")
         resp = client.get(f"/g/{guild.slug}/")
         assert resp.status_code == 301
-        assert resp["Location"] == f"https://guilds.pastlives.app/guilds/{guild.slug}/"
+        # Straight to the canonical short public URL — the "-guild" suffix is dropped.
+        assert resp["Location"] == f"https://guilds.pastlives.app/{guild.public_slug}/"
 
     def it_reaches_the_view_without_login_on_the_member_host(client: Client):
         # Proves the view carries no @login_required — an anonymous GET yields the

--- a/tests/core/surface_middleware_spec.py
+++ b/tests/core/surface_middleware_spec.py
@@ -244,7 +244,6 @@ def describe_guilds_surface():
         "path",
         [
             "/guilds/",
-            "/guilds/woodworking/",
             "/guilds/1/",
             "/guilds/1/join/",
             "/guilds/1/leave/",
@@ -266,8 +265,6 @@ def describe_guilds_surface():
     @pytest.mark.parametrize(
         "path",
         [
-            "/settings/",  # hub_user_settings
-            "/members/",  # hub_member_directory
             "/guilds/1/edit/",  # guild editor
             "/guilds/1/products/add/",  # product admin
             "/guilds/1/cart/confirm/",  # cart
@@ -279,10 +276,36 @@ def describe_guilds_surface():
         with pytest.raises(Http404):
             middleware(request)
 
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/settings/",  # hub_user_settings
+            "/members/",  # hub_member_directory
+        ],
+    )
+    def it_404s_single_segment_member_views_that_are_not_a_guild(path):
+        # These share the shape of a public guild slug, so the middleware also checks
+        # whether they name a guild before giving up — hence the DB.
+        request, middleware = _build("guilds.pastlives.app", path)
+        with pytest.raises(Http404):
+            middleware(request)
+
     def it_404s_a_path_that_does_not_resolve():
         request, middleware = _build("guilds.pastlives.app", "/totally/unknown/xyz/")
         with pytest.raises(Http404):
             middleware(request)
+
+    @pytest.mark.django_db
+    def it_rewrites_a_bare_guild_slug_onto_the_shared_guild_detail_route():
+        from tests.membership.factories import GuildFactory
+
+        GuildFactory(name="Woodworking Guild")
+        request, middleware = _build("guilds.pastlives.app", "/woodworking/")
+        response = middleware(request)
+        assert response.status_code == 200
+        assert request.path_info == "/guilds/woodworking-guild/"
+        assert request.path == "/woodworking/"  # what the visitor asked for, for canonicalising
 
 
 def describe_signage_surface():

--- a/tests/hub/guest_login_flow_spec.py
+++ b/tests/hub/guest_login_flow_spec.py
@@ -11,6 +11,7 @@ import pytest
 from allauth.account.models import EmailAddress
 from django.contrib.auth.models import User
 from django.core import mail
+from django.conf import settings
 from django.test import Client, override_settings
 
 from tests.membership.factories import GuildFactory, MembershipPlanFactory
@@ -33,9 +34,11 @@ def describe_guest_login_flow():
             yield
 
     def it_offers_a_login_link_carrying_the_guild_page_as_next(client: Client):
+        # Session cookies are host-only in production, so the guest is handed to the
+        # member hub's login with a next back to the identical guild page there.
         guild = GuildFactory(name="Join Guild")
-        page = client.get(f"/guilds/{guild.slug}/", HTTP_HOST=GUILDS_HOST).content.decode()
-        assert f"/accounts/login/?next=/guilds/{guild.slug}/" in page
+        page = client.get(guild.public_path, HTTP_HOST=GUILDS_HOST).content.decode()
+        assert f"{settings.MEMBER_BASE_URL}/accounts/login/?next=/guilds/{guild.slug}/" in page
 
     def it_renders_a_hidden_next_on_the_login_form(client: Client):
         guild = GuildFactory(name="Join Guild")

--- a/tests/hub/guild_classes_link_spec.py
+++ b/tests/hub/guild_classes_link_spec.py
@@ -58,7 +58,7 @@ def describe_guild_detail_classes_link():
     def it_prefixes_book_base_url_on_the_guilds_surface(client: Client):
         with override_settings(**GUILDS_SETTINGS):
             guild = GuildFactory(name="Metals")
-            body = client.get(f"/guilds/{guild.slug}/", HTTP_HOST=GUILDS_HOST).content.decode()
+            body = client.get(guild.public_path, HTTP_HOST=GUILDS_HOST).content.decode()
 
         href = f"https://book.pastlives.space/classes/?guild={guild.slug}"
         assert f'<a href="{href}" target="_blank" rel="noopener">Metals Classes</a>' in body

--- a/tests/hub/guild_detail_head_spec.py
+++ b/tests/hub/guild_detail_head_spec.py
@@ -26,7 +26,7 @@ GUILDS_SETTINGS = dict(
 
 
 def _guest_head(client: Client, guild):
-    return client.get(f"/guilds/{guild.slug}/", HTTP_HOST=GUILDS_HOST).content.decode()
+    return client.get(guild.public_path, HTTP_HOST=GUILDS_HOST).content.decode()
 
 
 def describe_guild_page_head():
@@ -46,7 +46,7 @@ def describe_guild_page_head():
     def it_emits_absolute_open_graph_and_canonical_tags(client: Client):
         guild = GuildFactory(name="Head Guild", about="We turn bowls and spoons.")
         head = _guest_head(client, guild)
-        url = f"{GUILDS_BASE_URL}/guilds/{guild.slug}/"
+        url = guild.public_url  # the canonical short public URL, e.g. .../head/
         assert f'<link rel="canonical" href="{url}">' in head
         assert 'property="og:title" content="Head Guild — Past Lives Guilds"' in head
         assert "We turn bowls and spoons." in head  # og:description from about
@@ -64,4 +64,7 @@ def describe_guild_page_head():
         guild = GuildFactory(name="Head Guild")
         head = client.get(f"/guilds/{guild.slug}/").content.decode()  # default host -> members
         assert 'property="og:title"' not in head
+        # The canonical tag DOES stay: the member-hub copy must not compete in search
+        # with the public page it duplicates.
+        assert f'<link rel="canonical" href="{guild.public_url}">' in head
         assert "calendar.css" in head  # still present via the empty block.super on hub/base.html

--- a/tests/hub/guild_edit_spec.py
+++ b/tests/hub/guild_edit_spec.py
@@ -612,9 +612,37 @@ def describe_GuildEditForm():
         assert form.is_valid(), form.errors
         assert form.save().discord_welcome_message == ""
 
+    def describe_page_visibility():
+        def it_defaults_a_new_guild_to_a_public_page():
+            assert GuildFactory(name="Fresh").is_public is True
+
+        def it_turns_the_public_page_off_when_the_lead_unticks_it():
+            guild = GuildFactory(name="Quiet")
+            form = GuildEditForm(data={"name": "Quiet", "calendar_color": "#4B9FEE"}, instance=guild)
+            assert form.is_valid(), form.errors
+            assert form.save().is_public is False
+
+        def it_turns_the_public_page_back_on():
+            guild = GuildFactory(name="Loud", is_public=False)
+            form = GuildEditForm(
+                data={"name": "Loud", "calendar_color": "#4B9FEE", "is_public": "on"},
+                instance=guild,
+            )
+            assert form.is_valid(), form.errors
+            assert form.save().is_public is True
+
 
 @pytest.mark.django_db
 def describe_guild_edit_page():
+    def it_offers_the_page_visibility_toggle_on_the_basic_tab(client: Client):
+        _user_with_role("admin_vis", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory()
+        client.login(username="admin_vis", password="pass")
+        body = client.get(reverse("hub_guild_edit", args=[guild.pk])).content.decode()
+        assert 'id="id_is_public"' in body
+        assert "Share this guild&#x27;s page publicly" in body
+        assert "pl-toggle" in body  # rendered by components/toggle.html, not a raw checkbox
+
     def it_renders_the_edit_form_for_an_editor(client: Client):
         _user_with_role("admin_pg", fog_role=Member.FogRole.ADMIN)
         guild = GuildFactory()

--- a/tests/hub/guild_guest_surface_spec.py
+++ b/tests/hub/guild_guest_surface_spec.py
@@ -1,4 +1,4 @@
-"""BDD specs for the guest guild page rendered on the guilds surface (guilds.pastlives.app).
+"""BDD specs for the guest guild page rendered on the guilds surface (guilds.pastlives.space).
 
 Covers the reviewer MUST/SHOULD-FIXes: roster privacy (#1), absolute class links + no
 Teach button (#3), no editor affordances for a lead (#4), lead-contact privacy (#7),
@@ -16,7 +16,9 @@ from classes.factories import ClassOfferingFactory
 from membership.models import GuildMembership
 from tests.billing.factories import ProductFactory
 from tests.membership.factories import (
+    GuildAnnouncementFactory,
     GuildFactory,
+    GuildMeetingNoteFactory,
     GuildOrientationSettingsFactory,
     MemberFactory,
     MembershipPlanFactory,
@@ -25,11 +27,15 @@ from tests.membership.factories import (
 
 pytestmark = pytest.mark.django_db
 
-GUILDS_HOST = "guilds.pastlives.app"
+GUILDS_HOST = "guilds.pastlives.space"
+# Host-only session cookies mean a guest cannot act on the guilds host: every
+# logged-out call to action points at the member hub's login, returning them to the
+# identical guild page there.
+LOGIN = "https://members.pastlives.app/accounts/login/?next=/guilds/"
 GUILDS_SETTINGS = dict(
-    ALLOWED_HOSTS=["guilds.pastlives.app", "members.pastlives.space", "book.pastlives.space", "testserver"],
-    GUILDS_HOSTS=["guilds.pastlives.app"],
-    GUILDS_BASE_URL="https://guilds.pastlives.app",
+    ALLOWED_HOSTS=["guilds.pastlives.space", "members.pastlives.space", "book.pastlives.space", "testserver"],
+    GUILDS_HOSTS=["guilds.pastlives.space"],
+    GUILDS_BASE_URL="https://guilds.pastlives.space",
     MEMBER_BASE_URL="https://members.pastlives.app",
     BOOK_BASE_URL="https://book.pastlives.space",
 )
@@ -46,7 +52,8 @@ def _login_member(client: Client, *, username: str = "gm", name: str = "Viewer M
 
 
 def _guest_get(client: Client, guild):
-    return client.get(f"/guilds/{guild.slug}/", HTTP_HOST=GUILDS_HOST)
+    """GET the guild's canonical public URL — the short root-level slug on the guilds host."""
+    return client.get(guild.public_path, HTTP_HOST=GUILDS_HOST)
 
 
 def describe_guest_guild_page():
@@ -134,7 +141,7 @@ def describe_guest_guild_page():
             assert b"guildCart(" not in body
             assert b"cart/confirm" not in body
             assert b"Add to Cart" not in body
-            assert f"https://members.pastlives.app/guilds/{guild.slug}/".encode() in body
+            assert f"{LOGIN}{guild.slug}/".encode() in body  # anon: log in on the hub to shop
 
         def it_suppresses_cart_for_a_logged_in_member_too(client: Client):
             guild = GuildFactory(name="Shop Guild")
@@ -196,7 +203,9 @@ def describe_guest_guild_page():
             OrientationSlotFactory(guild=guild)
             body = _guest_get(client, guild).content.decode()
             assert "Log in to book" in body
-            assert f"?next=/guilds/{guild.slug}/" in body
+            # Host-only cookies: the login lives on the member hub and returns the
+            # visitor to the identical guild page there.
+            assert f"{LOGIN}{guild.slug}/" in body
 
         def it_wraps_the_member_custom_time_field_in_a_themed_form_group(client: Client):
             # MUST-FIX #5: the datetime field renders inside .pl-form-group, which
@@ -233,19 +242,124 @@ def describe_guest_guild_page():
             assert "://" not in resp["Location"]
             assert GuildMembership.objects.filter(guild=guild, member=member).exists()
 
+    def describe_meeting_notes_are_never_public():
+        """The blocker: meeting notes are internal, and the guest surface must not leak them."""
+
+        def it_omits_meeting_note_content_from_an_anonymous_guest(client: Client):
+            guild = GuildFactory(name="Notes Guild")
+            GuildMeetingNoteFactory(
+                guild=guild,
+                title="Budget argument, June",
+                body="We agreed to raise the kiln levy.",
+            )
+            body = _guest_get(client, guild).content
+            assert b"Budget argument, June" not in body
+            assert b"raise the kiln levy" not in body
+            assert b"section = 'notes'" not in body  # not even the tab button
+
+        def it_shows_meeting_notes_to_a_logged_in_member(client: Client):
+            guild = GuildFactory(name="Notes Guild")
+            GuildMeetingNoteFactory(guild=guild, title="Budget argument, June", body="Levy raised.")
+            _login_member(client)
+            body = _guest_get(client, guild).content
+            assert b"Budget argument, June" in body
+
+        def it_omits_meeting_notes_from_an_anonymous_visitor_on_the_members_host(client: Client):
+            # The guild page is reachable without a login on the member host too, so the
+            # gate is on authentication, not on the surface.
+            guild = GuildFactory(name="Notes Guild")
+            GuildMeetingNoteFactory(guild=guild, title="Budget argument, June", body="Levy raised.")
+            assert b"Budget argument, June" not in client.get(f"/guilds/{guild.slug}/").content
+
+    def describe_announcements_are_member_facing():
+        def it_hides_guild_announcements_from_anonymous_guests(client: Client):
+            guild = GuildFactory(name="News Guild")
+            GuildAnnouncementFactory(guild=guild, title="Door code changed", body="It is now 4321.")
+            body = _guest_get(client, guild).content
+            assert b"Door code changed" not in body
+            assert b"It is now 4321." not in body
+
+        def it_shows_guild_announcements_to_a_logged_in_member(client: Client):
+            guild = GuildFactory(name="News Guild")
+            GuildAnnouncementFactory(guild=guild, title="Door code changed", body="It is now 4321.")
+            _login_member(client)
+            assert b"Door code changed" in _guest_get(client, guild).content
+
+    def describe_activity_pulse():
+        def it_is_hidden_from_anonymous_visitors_on_the_members_host(client: Client):
+            # (Assert on the feed's own text, not the heading: the "what's new" widget
+            # echoes the changelog, which mentions the Recent Activity feature by name.)
+            guild = GuildFactory(name="Pulse Guild")
+            GuildMembership.objects.create(guild=guild, member=MemberFactory(full_legal_name="Pia Pulse"))
+            assert b"Pia Pulse joined" not in client.get(f"/guilds/{guild.slug}/").content
+
+        def it_is_shown_to_a_logged_in_member_on_the_members_host(client: Client):
+            guild = GuildFactory(name="Pulse Guild")
+            GuildMembership.objects.create(guild=guild, member=MemberFactory(full_legal_name="Pia Pulse"))
+            _login_member(client)
+            assert b"Pia Pulse joined" in client.get(f"/guilds/{guild.slug}/").content
+
+    def describe_logged_out_interactions():
+        def it_sends_join_to_the_member_hub_login_with_a_next_back_to_this_guild(client: Client):
+            guild = GuildFactory(name="Join Guild")
+            body = _guest_get(client, guild).content.decode()
+            assert f"{LOGIN}{guild.slug}/" in body
+
+        def it_sends_a_would_be_shopper_to_the_member_hub_login(client: Client):
+            guild = GuildFactory(name="Shop Guild")
+            ProductFactory(guild=guild, name="Kiln Time")
+            body = _guest_get(client, guild).content.decode()
+            assert "Log in on the members hub to shop" in body
+            assert f"{LOGIN}{guild.slug}/" in body
+
+        def it_offers_a_login_route_to_contact_a_lead_with_no_public_address(client: Client):
+            guild, _lead = _guild_with_contactable_lead(name="Quiet Guild")
+            body = _guest_get(client, guild).content.decode()
+            assert "Log in to contact the guild lead" in body
+
     def describe_guild_visibility():
-        # Every active guild is public and visible on every surface — the old
-        # is_public gate is gone, so the only way to hide a guild is is_active off.
-        def it_shows_an_active_guild_to_anonymous_guests(client: Client):
+        def it_shows_a_public_guild_to_anonymous_guests(client: Client):
             guild = GuildFactory(name="Open Guild")
             assert _guest_get(client, guild).status_code == 200
 
-        def it_shows_an_active_guild_to_a_logged_in_member_on_the_hub(client: Client):
+        def it_shows_a_public_guild_to_a_logged_in_member_on_the_hub(client: Client):
             guild = GuildFactory(name="Open Guild")
             _login_member(client)
             resp = client.get(f"/guilds/{guild.slug}/")  # default host -> members surface
             assert resp.status_code == 200
             assert b"Open Guild" in resp.content
+
+        def describe_when_the_lead_has_made_the_page_private():
+            def it_serves_a_friendly_403_notice_instead_of_the_page(client: Client):
+                guild = GuildFactory(name="Quiet Guild", is_public=False, about="Secret handshakes.")
+                resp = _guest_get(client, guild)
+                assert resp.status_code == 403
+                body = resp.content.decode()
+                assert "private for now" in body
+                assert "Secret handshakes." not in body
+                assert "Quiet Guild" not in body  # the name is not confirmed by URL guessing
+
+            def it_is_not_indexable(client: Client):
+                guild = GuildFactory(name="Quiet Guild", is_public=False)
+                assert 'content="noindex, nofollow"' in _guest_get(client, guild).content.decode()
+
+            def it_still_offers_a_way_onward(client: Client):
+                guild = GuildFactory(name="Quiet Guild", is_public=False)
+                body = _guest_get(client, guild).content.decode()
+                assert "Browse the other guilds" in body
+                assert "Become a member" in body
+
+            def it_leaves_the_members_host_page_untouched(client: Client):
+                guild = GuildFactory(name="Quiet Guild", is_public=False, about="Secret handshakes.")
+                _login_member(client)
+                resp = client.get(f"/guilds/{guild.slug}/")  # members surface
+                assert resp.status_code == 200
+                assert b"Secret handshakes." in resp.content
+
+            def it_advertises_no_canonical_public_url(client: Client):
+                guild = GuildFactory(name="Quiet Guild", is_public=False)
+                _login_member(client)
+                assert b'rel="canonical"' not in client.get(f"/guilds/{guild.slug}/").content
 
 
 def _guild_with_contactable_lead(name="Contact Guild"):

--- a/tests/hub/guild_public_slug_spec.py
+++ b/tests/hub/guild_public_slug_spec.py
@@ -25,6 +25,26 @@ GUILDS_SETTINGS = dict(
 )
 
 
+def _private_event(guild):
+    """An iCal event on ``guild`` whose title/description/location must never leak."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from membership.models import CalendarEvent
+
+    return CalendarEvent.objects.create(
+        guild=guild,
+        title="CONFIDENTIAL Lockpicking Social",
+        description="Members only, back room",
+        location="Back Room",
+        uid=f"probe-{guild.pk}",
+        start_dt=timezone.now() + timedelta(days=3),
+        end_dt=timezone.now() + timedelta(days=3, hours=2),
+        fetched_at=timezone.now(),
+    )
+
+
 def describe_Guild_public_slug():
     def it_drops_a_trailing_guild_suffix(db):
         guild = GuildFactory(name="Woodworking Guild")
@@ -190,3 +210,35 @@ def describe_the_public_directory():
         GuildFactory(name="Quiet Guild", is_public=False)
         body = client.get("/guilds/", HTTP_HOST="members.pastlives.space").content.decode()
         assert "Quiet Guild" in body
+
+
+def describe_the_guild_calendar_partial():
+    @pytest.fixture(autouse=True)
+    def _guilds_settings():
+        with override_settings(**GUILDS_SETTINGS):
+            yield
+
+    def it_withholds_a_private_guilds_events_from_the_public_surface(client: Client):
+        # The partial is reachable by sequential pk and is listed in
+        # GUILDS_ALLOWED_VIEW_NAMES, so without its own gate it served a private
+        # guild's whole calendar to anonymous callers.
+        guild = GuildFactory(name="Quiet Guild", is_public=False)
+        _private_event(guild)
+        resp = client.get(f"/guilds/{guild.pk}/calendar/events/", HTTP_HOST=GUILDS_HOST)
+        assert resp.status_code == 403
+        assert "CONFIDENTIAL Lockpicking Social" not in resp.content.decode()
+
+    def it_still_serves_a_public_guilds_events_on_the_public_surface(client: Client):
+        guild = GuildFactory(name="Loud Guild")
+        _private_event(guild)
+        resp = client.get(f"/guilds/{guild.pk}/calendar/events/", HTTP_HOST=GUILDS_HOST)
+        assert resp.status_code == 200
+        assert "CONFIDENTIAL Lockpicking Social" in resp.content.decode()
+
+    def it_still_serves_a_private_guilds_events_to_the_member_hub(client: Client):
+        # ``is_public`` scopes the public surface, not the hub — matching guild_detail.
+        guild = GuildFactory(name="Quiet Guild", is_public=False)
+        _private_event(guild)
+        resp = client.get(f"/guilds/{guild.pk}/calendar/events/", HTTP_HOST="members.pastlives.space")
+        assert resp.status_code == 200
+        assert "CONFIDENTIAL Lockpicking Social" in resp.content.decode()

--- a/tests/hub/guild_public_slug_spec.py
+++ b/tests/hub/guild_public_slug_spec.py
@@ -1,0 +1,192 @@
+"""BDD specs for the short public guild URL on the guilds surface.
+
+``guilds.pastlives.space/woodworking/`` serves the guild slugged ``woodworking-guild``:
+the redundant suffix is dropped from the public URL, an exact slug match always wins so
+a collision is deterministic, and every other spelling 301s to the one canonical URL.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.http import HttpResponse
+from django.test import Client, override_settings
+
+from membership.models import Guild
+from tests.membership.factories import GuildFactory
+
+pytestmark = pytest.mark.django_db
+
+GUILDS_HOST = "guilds.pastlives.space"
+GUILDS_SETTINGS = dict(
+    ALLOWED_HOSTS=[GUILDS_HOST, "members.pastlives.space", "testserver"],
+    GUILDS_HOSTS=[GUILDS_HOST],
+    GUILDS_BASE_URL=f"https://{GUILDS_HOST}",
+    MEMBER_BASE_URL="https://members.pastlives.space",
+)
+
+
+def describe_Guild_public_slug():
+    def it_drops_a_trailing_guild_suffix(db):
+        guild = GuildFactory(name="Woodworking Guild")
+        assert guild.slug == "woodworking-guild"
+        assert guild.public_slug == "woodworking"
+
+    def it_leaves_a_slug_without_the_suffix_alone(db):
+        guild = GuildFactory(name="Ceramics")
+        assert guild.public_slug == "ceramics"
+
+    def describe_when_the_short_slug_would_collide_with_a_reserved_path():
+        def it_keeps_the_full_slug(db):
+            guild = GuildFactory(name="Info Guild")
+            assert guild.slug == "info-guild"
+            assert guild.public_slug == "info-guild"
+
+        def it_falls_back_to_the_long_path_when_the_slug_itself_is_reserved(db):
+            guild = GuildFactory(name="Info")
+            assert guild.slug == "info"
+            assert guild.public_path == "/guilds/info/"
+
+    def describe_when_both_spellings_exist():
+        def it_gives_the_short_slug_to_the_guild_that_owns_it_outright(db):
+            short = GuildFactory(name="Woodworking")
+            suffixed = GuildFactory(name="Woodworking Guild")
+            assert short.slug == "woodworking"
+            assert suffixed.slug == "woodworking-guild"
+            # Exact matches win, so the suffixed guild keeps its full slug in public.
+            assert short.public_slug == "woodworking"
+            assert suffixed.public_slug == "woodworking-guild"
+
+        def it_resolves_the_short_slug_to_the_exact_match(db):
+            short = GuildFactory(name="Woodworking")
+            GuildFactory(name="Woodworking Guild")
+            assert Guild.objects.get_by_public_slug("woodworking") == short
+
+        def it_resolves_the_full_slug_to_the_suffixed_guild(db):
+            GuildFactory(name="Woodworking")
+            suffixed = GuildFactory(name="Woodworking Guild")
+            assert Guild.objects.get_by_public_slug("woodworking-guild") == suffixed
+
+
+def describe_GuildManager_get_by_public_slug():
+    def it_finds_a_guild_by_its_stripped_slug(db):
+        guild = GuildFactory(name="Metal Guild")
+        assert Guild.objects.get_by_public_slug("metal") == guild
+
+    def it_finds_a_guild_by_its_exact_slug(db):
+        guild = GuildFactory(name="Metal Guild")
+        assert Guild.objects.get_by_public_slug("metal-guild") == guild
+
+    def it_raises_does_not_exist_for_an_unknown_slug(db):
+        with pytest.raises(Guild.DoesNotExist):
+            Guild.objects.get_by_public_slug("nope")
+
+    def it_hides_a_soft_deleted_guild(db):
+        guild = GuildFactory(name="Gone Guild")
+        guild.soft_delete()
+        with pytest.raises(Guild.DoesNotExist):
+            Guild.objects.get_by_public_slug("gone")
+
+
+def describe_Guild_public_url():
+    @override_settings(GUILDS_BASE_URL="https://guilds.pastlives.space")
+    def it_is_absolute_and_uses_the_short_slug(db):
+        guild = GuildFactory(name="Fibre Guild")
+        assert guild.public_path == "/fibre/"
+        assert guild.public_url == "https://guilds.pastlives.space/fibre/"
+
+
+def describe_the_public_guild_url():
+    @pytest.fixture(autouse=True)
+    def _guilds_settings():
+        with override_settings(**GUILDS_SETTINGS):
+            yield
+
+    def it_serves_the_guild_page_at_the_short_root_level_slug(client: Client):
+        guild = GuildFactory(name="Woodworking Guild", about="We make sawdust.")
+        resp = client.get("/woodworking/", HTTP_HOST=GUILDS_HOST)
+        assert resp.status_code == 200
+        assert b"We make sawdust." in resp.content
+        assert resp.templates[0].name == "hub/guild_detail.html"
+        assert guild.slug == "woodworking-guild"
+
+    def it_301s_the_unstripped_slug_to_the_canonical_short_one(client: Client):
+        GuildFactory(name="Woodworking Guild")
+        resp = client.get("/woodworking-guild/", HTTP_HOST=GUILDS_HOST)
+        assert resp.status_code == 301
+        assert resp["Location"] == "/woodworking/"
+
+    def it_301s_the_long_members_style_path_to_the_canonical_short_one(client: Client):
+        GuildFactory(name="Woodworking Guild")
+        resp = client.get("/guilds/woodworking-guild/", HTTP_HOST=GUILDS_HOST)
+        assert resp.status_code == 301
+        assert resp["Location"] == "/woodworking/"
+
+    def it_301s_an_old_numeric_link_straight_to_the_canonical_short_one(client: Client):
+        guild = GuildFactory(name="Woodworking Guild")
+        resp = client.get(f"/guilds/{guild.pk}/", HTTP_HOST=GUILDS_HOST)
+        assert resp.status_code == 301
+        assert resp["Location"] == "/woodworking/"
+
+    def it_404s_a_root_slug_that_is_not_a_guild(rf):
+        # Asserted at the middleware, not through the test client: raising Http404 from
+        # SurfaceMiddleware (which runs before AuthenticationMiddleware) currently blows
+        # up the error template — a pre-existing guest-surface bug fixed separately.
+        from django.http import Http404
+
+        from core.middleware import SurfaceMiddleware
+
+        request = rf.get("/not-a-guild-at-all/", HTTP_HOST=GUILDS_HOST)
+        middleware = SurfaceMiddleware(lambda _r: HttpResponse("ok"))
+        with pytest.raises(Http404):
+            middleware(request)
+
+    def it_emits_one_canonical_url_on_the_page(client: Client):
+        GuildFactory(name="Woodworking Guild")
+        body = client.get("/woodworking/", HTTP_HOST=GUILDS_HOST).content.decode()
+        assert '<link rel="canonical" href="https://guilds.pastlives.space/woodworking/">' in body
+        assert 'content="https://guilds.pastlives.space/woodworking/"' in body  # og:url
+
+    def describe_on_the_member_hub():
+        def it_keeps_serving_the_long_path_without_redirecting(client: Client):
+            GuildFactory(name="Woodworking Guild", about="We make sawdust.")
+            resp = client.get("/guilds/woodworking-guild/", HTTP_HOST="members.pastlives.space")
+            assert resp.status_code == 200
+            assert b"We make sawdust." in resp.content
+
+        def it_points_its_canonical_tag_at_the_public_guilds_url(client: Client):
+            GuildFactory(name="Woodworking Guild")
+            body = client.get("/guilds/woodworking-guild/", HTTP_HOST="members.pastlives.space").content.decode()
+            assert '<link rel="canonical" href="https://guilds.pastlives.space/woodworking/">' in body
+
+        def it_does_not_serve_the_short_slug(client: Client):
+            GuildFactory(name="Woodworking Guild")
+            assert client.get("/woodworking/", HTTP_HOST="members.pastlives.space").status_code == 404
+
+
+def describe_the_public_directory():
+    @pytest.fixture(autouse=True)
+    def _guilds_settings():
+        with override_settings(**GUILDS_SETTINGS):
+            yield
+
+    def it_links_cards_at_the_short_slug(client: Client):
+        GuildFactory(name="Woodworking Guild")
+        body = client.get("/guilds/", HTTP_HOST=GUILDS_HOST).content.decode()
+        assert 'href="/woodworking/"' in body
+
+    def it_links_cards_at_the_hub_path_on_the_member_host(client: Client):
+        GuildFactory(name="Woodworking Guild")
+        body = client.get("/guilds/", HTTP_HOST="members.pastlives.space").content.decode()
+        assert 'href="/guilds/woodworking-guild/"' in body
+
+    def it_omits_a_private_guild_from_the_public_listing(client: Client):
+        GuildFactory(name="Quiet Guild", is_public=False)
+        GuildFactory(name="Loud Guild")
+        body = client.get("/guilds/", HTTP_HOST=GUILDS_HOST).content.decode()
+        assert "Loud Guild" in body
+        assert "Quiet Guild" not in body
+
+    def it_still_lists_a_private_guild_for_members_on_the_hub(client: Client):
+        GuildFactory(name="Quiet Guild", is_public=False)
+        body = client.get("/guilds/", HTTP_HOST="members.pastlives.space").content.decode()
+        assert "Quiet Guild" in body


### PR DESCRIPTION
Turns the (already-scaffolded but dead) guilds surface into something we can actually
point the public at: a short shareable URL per guild, a per-guild privacy switch, and —
the reason this can't wait — a fix for meeting notes that would have been published to
anonymous visitors the moment the host went live.

`VERSION` → `0.23.24`.

## 1. The blocker: Meeting Notes were ungated

`templates/hub/guild_detail.html` rendered the Meeting Notes tab **and** every note's
title, body and attachments with no auth check, contradicting the model's own docstring
("Members who can view the guild page can read these"). It was unreachable only because
`/guilds/` fails closed on public hosts — turning this surface on would have published
guild meeting notes to the open internet.

Both the tab button and the panel are now `{% if user.is_authenticated %}`-gated, and
`tests/hub/guild_guest_surface_spec.py::describe_meeting_notes_are_never_public` proves
an anonymous request contains neither the note title nor its body — on the guilds host
*and* on the member host (the guild page has no `@login_required` there either).

### Rest of the template audit

Walked every block asking "what does an anonymous visitor see":

| Block | Before | Now |
|---|---|---|
| **Meeting notes** | fully public | members only |
| **Guild announcements** | fully public | members only — these are internal comms mirrored to Discord/email, not press releases |
| **Recent Activity** (names who joined) | gated on *surface* only, so anon on the member host saw it | gated on authentication too |
| **Guild Calendar tab** | broken — `hub_guild_calendar_events` wasn't allowlisted, so the tab 404'd on the guilds host | allowlisted (read-only public event data, no member names) |
| **robots.txt** | 404 on the guilds host | allowlisted |
| Roster, lead contact modal (email/phone/Discord/bio), buyables/cart, editor buttons, "Teach a Class" | already gated | unchanged |
| Guild name, banner, about, lead + staff names/titles, member count, studio hours, next meeting, FAQ, gallery, links, the guild's own `contact_email` | public | unchanged — this is the shareable content |

## 2. Short public URLs, one canonical form

`guilds.pastlives.space/woodworking/` serves the guild slugged `woodworking-guild`.

- **Resolution** (`GuildManager.get_by_public_slug`): exact slug first, then `slug + "-guild"`. If both `woodworking` and `woodworking-guild` exist, the exact match wins and the suffixed guild keeps its full slug in public — deterministic, and spec'd.
- **Canonicalisation**: exactly one public URL per guild (`Guild.public_slug` / `public_path` / `public_url` — templates and emails never hand-build it). `/woodworking-guild/`, `/guilds/woodworking-guild/` and the legacy numeric `/guilds/<pk>/` all **301** to `/woodworking/` on that host. `<link rel="canonical">` points there from *both* hosts so the member-hub copy doesn't compete in search.
- **Same view, same template**: `SurfaceMiddleware` rewrites `request.path_info` onto the existing `hub_guild_detail` route rather than adding a second route/view/template. `request.path` keeps what the visitor asked for, which is what drives the canonical redirect.
- A guild whose short slug would collide with a reserved root path (`/info/`, `/guilds/`, …) keeps the longer URL instead of silently redirecting onto the wrong page.

Host default moved to **`guilds.pastlives.space`** (`GUILDS_HOSTS`, `GUILDS_BASE_URL`).
`PUBLIC_HOSTS` and `classes.pastlives.app` are untouched.

## 3. Per-guild privacy, default public

New `Guild.is_public` (default `True`, one additive migration `0099` — the default
backfills, no data migration). Editable by leads in **Guild Settings → Basic
Information**, right under "Show members roster", via `components/form_field.html`.

When off, the public URL answers a warm, non-judgemental notice — *"This guild's page is
private for now"* — with `noindex, nofollow` and two ways onward (browse other guilds /
become a member). The guild's **name is deliberately not printed**, so hiding a page
can't be undone by URL guessing. Private guilds also drop out of the public directory
and advertise no canonical URL.

**Status code: 403.** The page exists and is deliberately withheld — 404 would lie about
that, and 200 would invite crawlers to index the notice. 403 + `noindex` is honest to
both humans and robots. The member hub is entirely unaffected by the flag.

## 4. Logged-out interactions, given host-only cookies

Production leaves `COOKIE_DOMAIN` unset, so session cookies are host-only: a login on
`guilds.pastlives.space` is **not** shared with `members.pastlives.space`. The original
spec's "act in place" login is therefore not what we want — every gated action (join,
leave, buy, orientation, contacting a lead) lives on the hub anyway.

So Join / Buy / Contact / orientation booking now route through
`hub.views._guild_login_url`: on the guilds surface that is the **member hub's** login
carrying `next=/guilds/<slug>/` — the identical page, same view and template — so the
visitor lands exactly where they were. On the hub it stays the plain relative login URL.
The authenticated in-place branches are left intact, so nothing breaks if
`COOKIE_DOMAIN` is ever set (both hosts are now on `.pastlives.space`).

## Testing

`ruff format` + `ruff check` clean, `mypy` clean, `makemigrations --check` clean.
New/updated specs cover slug resolution + the collision + the reserved-path fallback,
every 301, anonymous vs authenticated rendering on both hosts, the private page (status,
copy, noindex, directory exclusion, member-host unaffected), meeting notes absent for
anonymous visitors, and the login routing with its `next`.

Verified in a browser on `guilds.pastlives.test` in **light and dark** and at 390px.

## OPS CHECKLIST — required before this surface can go live

This PR cannot do any of these:

1. **DNS**: `CNAME guilds.pastlives.space → plfog.onrender.com` (DNS is on Squarespace).
2. **Render**: add `guilds.pastlives.space` as a custom domain on `srv-d6j2331drdic73ak0s30` and wait for the cert.
3. **Env** on the Render web service:
   - add `guilds.pastlives.space` to `DJANGO_ALLOWED_HOSTS`
   - add `https://guilds.pastlives.space` to `CSRF_TRUSTED_ORIGINS`
   - (optional — the code defaults are already correct) `GUILDS_HOSTS=guilds.pastlives.space`, `GUILDS_BASE_URL=https://guilds.pastlives.space`
   - **Do NOT** add it to `PUBLIC_HOSTS` — that host serves the class catalog and redirects `/` to `/classes/`.
   - **Do NOT** set `COOKIE_DOMAIN` — it would log out all ~645 members.
4. Env writes need a manual redeploy to take effect.
5. Optional: `static/img/og-guild-default.png` is referenced as the Open-Graph fallback for a guild with no banner; produce it (~1200×630) or link previews for banner-less guilds fall back to nothing.
6. Note: `THEME_COOKIE_DOMAIN=.pastlives.app` no longer reaches this surface (it is on `.pastlives.space`), so guests start on the surface's light default. Cosmetic only.

## Known pre-existing issue, not fixed here

An `Http404` raised from `SurfaceMiddleware` (it runs before `AuthenticationMiddleware`)
blows up the error template into a 500 — that is PR #148's territory, so the "unknown
root slug" case is asserted at the middleware rather than through the test client.
