### PR TITLE
[tests] Silence the whole test-suite warning backlog, 2620 to 0 (v0.23.22)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,12 +8,21 @@ def pytest_configure():
 
 
 def pytest_sessionstart(session):
+    from pathlib import Path
+
     from django.conf import settings as django_settings
 
     django_settings.STORAGES = {
         "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
         "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
     }
+
+    # STATIC_ROOT is a collectstatic build artifact, absent in a fresh checkout and in
+    # CI. WhiteNoise's middleware warns "No directory at: .../staticfiles/" every time
+    # the handler is built — once per test client — which buried the suite in thousands
+    # of identical UserWarnings. An empty directory silences it; tests serve static
+    # assets through StaticFilesStorage above, not from STATIC_ROOT.
+    Path(django_settings.STATIC_ROOT).mkdir(parents=True, exist_ok=True)
 
 
 @pytest.fixture(autouse=True)

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.20"
+VERSION = "0.23.22"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.23.20",
+        "version": "0.23.22",
         "date": "2026-07-22",
         "title": "Guild and account links from the class site now show a proper 'page not found'",
         "changes": [
@@ -20,7 +20,7 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
         ],
     },
     {
-        "version": "0.23.20",
+        "version": "0.23.22",
         "date": "2026-07-22",
         "title": "Picked a guild on Discord but not linked yet? The bot now gives you a heads-up",
         "changes": [

--- a/tests/billing/factories.py
+++ b/tests/billing/factories.py
@@ -41,6 +41,9 @@ class BillingSettingsFactory(factory.django.DjangoModelFactory):
 class ProductFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Product
+        # ``with_default_splits`` only creates related rows; it never mutates the
+        # Product, so factory-boy's extraneous post-hook save is not needed.
+        skip_postgeneration_save = True
 
     name = factory.Sequence(lambda n: f"Product {n}")
     price = Decimal("10.00")

--- a/tests/core/management/run_scheduled_tasks_spec.py
+++ b/tests/core/management/run_scheduled_tasks_spec.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -29,7 +29,8 @@ def _tasks_called(hour: int, side_effect=None, day: int = 1) -> list[str]:
     with (
         patch("core.management.commands.run_scheduled_tasks.call_command", side_effect=side_effect) as cc,
         patch(
-            "core.management.commands.run_scheduled_tasks.timezone.now", return_value=datetime(2026, 1, day, hour, 0)
+            "core.management.commands.run_scheduled_tasks.timezone.now",
+            return_value=datetime(2026, 1, day, hour, 0, tzinfo=UTC),
         ),
     ):
         call_command("run_scheduled_tasks")
@@ -82,7 +83,10 @@ def describe_run_scheduled_tasks():
         # command's own schedule gate, never a forced run).
         with (
             patch("core.management.commands.run_scheduled_tasks.call_command") as cc,
-            patch("core.management.commands.run_scheduled_tasks.timezone.now", return_value=datetime(2026, 1, 1, 9, 0)),
+            patch(
+                "core.management.commands.run_scheduled_tasks.timezone.now",
+                return_value=datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+            ),
         ):
             call_command("run_scheduled_tasks")
         bill_calls = [c for c in cc.call_args_list if c.args[0] == "bill_tabs"]

--- a/tests/core/pull_prod_db_spec.py
+++ b/tests/core/pull_prod_db_spec.py
@@ -8,6 +8,11 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 from django.core.management import CommandError, call_command
 
+# Swapping DATABASES is exactly what these specs assert on — the command must refuse a
+# sqlite local DB and accept a PostgreSQL one — and no connection is ever opened, so
+# Django's generic "this can lead to unexpected behavior" warning is noise here.
+pytestmark = pytest.mark.filterwarnings("ignore:Overriding setting DATABASES:UserWarning")
+
 
 def describe_pull_prod_db():
     def describe_guard_rails():

--- a/tests/membership/factories.py
+++ b/tests/membership/factories.py
@@ -304,6 +304,9 @@ class GuildStaffMembershipFactory(factory.django.DjangoModelFactory):
 class VotePreferenceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = VotePreference
+        # ``signed_up`` saves the linked Member itself; the VotePreference is never
+        # mutated, so factory-boy's extraneous post-hook save is not needed.
+        skip_postgeneration_save = True
 
     member = factory.SubFactory(MemberFactory)
     guild_1st = factory.SubFactory(GuildFactory)


### PR DESCRIPTION
The test suite emitted **2620 warnings**. They collapse to four distinct causes, all fixed here. Test-only: no application code changes.

## Counts

Measured by running the suite at the merge base under a `pytest_warning_recorded` plugin that tallies every recorded warning individually. Pytest's own warnings summary groups duplicates per test file and cannot be summed, so it is not a usable source for these numbers.

| Cause | Count | Fix |
|---|---|---|
| WhiteNoise `No directory at: .../staticfiles/` | 2019 | `conftest.py` creates the empty `STATIC_ROOT` at session start |
| factory-boy `_after_postgeneration` on `VotePreferenceFactory` | 495 | `skip_postgeneration_save = True` |
| factory-boy `_after_postgeneration` on `ProductFactory` | 60 | `skip_postgeneration_save = True` |
| `ScheduledTaskRun` naive datetime | 40 | mocked clock returns a UTC-aware datetime |
| `Overriding setting DATABASES` | 6 | scoped `filterwarnings` |
| **Total** | **2620** | |

### Correction

An earlier revision of this description reported these counts as ~2580 / 30 / 5 / 6. Those were estimates read off the grouped summary and presented as if measured. They were wrong, and wrong in the direction that flattered the change: the two factory-boy causes are **555 warnings combined**, not 5. That makes factory-boy the second-largest cause and the only one with a real upstream deadline, rather than the footnote the original table implied. The table above is measured.

## staticfiles

`STATIC_ROOT` is a `collectstatic` build artifact, absent in a fresh checkout and in CI. WhiteNoise's middleware warns once per handler build, which is once per test client, so this alone was the large majority. An empty directory silences it. Tests already serve static assets through `StaticFilesStorage` (swapped in `pytest_sessionstart`), not from `STATIC_ROOT`, and nothing in the suite references `STATIC_ROOT`, WhiteNoise, or `collectstatic`. The production guarantee that static files are actually collected is enforced at build time by `render.yaml` and the `Dockerfile`, so this hides nothing CI needs to know.

## Naive datetime

The only cause that was a genuine correctness smell.

`run_scheduled_tasks_spec` patched `core.management.commands.run_scheduled_tasks.timezone.now` with a naive datetime. That module imports `timezone` as a module (`from django.utils import timezone`), so the patch rebinds `now` on the shared `django.utils.timezone` object and the naive value escapes the command under test entirely.

It does **not** reach `ScheduledTaskRun`'s field defaults. `started_at = models.DateTimeField(default=timezone.now, ...)` captures the function object at import time, so the already-bound reference is immune to the later patch; under the patch, `objects.create()` stores an aware `started_at` and emits no warning.

The 40 warnings come from two call-time lookups instead, evenly split:

* **`finished_at` (20)** — `ScheduledTaskRun.mark_ok()` and `mark_failed()` assign `self.finished_at = timezone.now()`, resolving the patched attribute at call time and writing a naive value.
* **`started_at` (20)** — `_prune_run_history()` computes `cutoff = timezone.now() - timedelta(days=RUN_HISTORY_RETENTION_DAYS)` and runs `.filter(task_key=key, started_at__lt=cutoff)`. This warns on **query preparation**, not on a write, which is why an aware field default gives it no protection. `RUN_HISTORY_RETENTION_DAYS` is 90, which is why these warnings report dates 90 days behind the mocked clock (`2025-10-03` for a mocked `2026-01-01`).

The fix returns a UTC-aware datetime.

### Why `tzinfo=UTC` and not `timezone.make_aware()`

An earlier revision of this description claimed `make_aware` would have "shifted the hour and changed what the tests assert." **That was false.** `make_aware` is `value.replace(tzinfo=tz)`; it attaches a timezone and shifts nothing, so `.hour` stays 13 and `.weekday()` stays 0 either way, and the gating tests pass under either construction.

The actual reason to prefer `tzinfo=UTC` is the stored value, not the assertions. Production `timezone.now()` returns UTC-aware datetimes and the dispatcher's gates are documented and named in UTC (`DAILY_UTC_HOUR`, `WEEKLY_UTC_WEEKDAY`). `TIME_ZONE` is `America/Los_Angeles`, so `make_aware` would stamp `ScheduledTaskRun.started_at` and `finished_at` eight hours away from what production writes, making the fixture unfaithful to the thing it stands in for.

The gating tests are not vacuous under the fix: mutating `DAILY_UTC_HOUR` 13 to 14, mutating `WEEKLY_UTC_WEEKDAY` 0 to 3, and dropping either half of the weekly gate each produce failures.

## Factories

Neither hook mutates the instance being built. `ProductFactory.with_default_splits` creates related `ProductRevenueSplit` rows; `VotePreferenceFactory.signed_up` mutates and saves the linked `Member`, never the `VotePreference` itself. Neither class defines another post-generation hook. So factory-boy's extraneous post-hook save is safe to drop, and both opt-out paths (`with_default_splits=False`, `signed_up=False`) still behave. Two other factories in the repo already use this flag.

This is the cause with an actual deadline: factory-boy will stop saving after postgeneration hooks in its next major release, so this is forward-compatibility work, not just noise reduction.

## DATABASES override

Swapping `DATABASES` is the assertion in `pull_prod_db_spec` (the command must refuse a sqlite local DB and accept PostgreSQL), the module has no `django_db` marker, and the command only reads the dict with `subprocess` mocked, so no connection is ever opened. Scoped to a module-level `filterwarnings` rather than changing the test.

## Verification

Full suite at this head: **6304 passed, 0 warnings**, coverage **98.26%**. `ruff check`, `ruff format --check`, and `mypy` all clean.

(An earlier revision cited 6286 passed / 98.27%. That was measured before this branch was merged with `main`; #149 landed 18 additional tests in between. The figures above are measured at head.)

## Changelog

Test-only and invisible to members, so it gets no new entry. `VERSION` goes to **0.23.25** and the newest existing entry is carried forward so `announce_release` still resolves, matching what #151 did for its test-only change.

This started at 0.23.22. #150 then merged and took `main` to 0.23.23, which would have made 0.23.22 a backwards move, so it was renumbered. 0.23.24 belongs to #152, making 0.23.25 safe whichever of the two lands first.

Note for whoever cuts the next release: entries below the current `VERSION` do not get announced, and the unannounced backlog now spans 0.20 through 0.23. That wants a deliberate combined release-notes pass (as `6b094fb` did for 0.20/0.21) rather than being solved sideways by a test-only PR.
