### PR TITLE
[fix] Review follow-ups from #148, #149 and #150 (v0.23.27)

### DIFF
--- a/classes/spec/views/legacy_image_spec.py
+++ b/classes/spec/views/legacy_image_spec.py
@@ -149,3 +149,41 @@ def describe_legacy_image_self_host_guard():
         request = RequestFactory().get("/_legacy-image/")
 
         assert _is_own_host("", request) is False
+
+    def it_arms_the_guard_from_a_wildcard_subdomain_entry(db, settings):
+        from classes.views_legacy_image import legacy_image
+
+        # ``*.pastlives.space`` covers classes.pastlives.space. The original guard
+        # collapsed the entry to the bare domain and compared for equality, so the
+        # subdomain that actually needed protecting never matched.
+        settings.ALLOWED_HOSTS = ["testserver", "*.pastlives.space"]
+        request = RequestFactory().get(
+            "/_legacy-image/",
+            {"url": "https://classes.pastlives.space/sites/default/files/img.jpg"},
+        )
+
+        with patch("classes.views_legacy_image._OPENER.open") as mock_fetch:
+            response = legacy_image(request)
+            mock_fetch.assert_not_called()
+
+        assert response.status_code == 404
+
+    def it_arms_the_guard_from_a_leading_dot_subdomain_entry(db, settings):
+        from classes.views_legacy_image import _is_own_host
+
+        # Django also accepts the ``.example.com`` spelling for the same wildcard.
+        settings.ALLOWED_HOSTS = ["testserver", ".pastlives.space"]
+        request = RequestFactory().get("/_legacy-image/")
+
+        assert _is_own_host("classes.pastlives.space", request) is True
+        assert _is_own_host("pastlives.space", request) is True
+
+    def it_does_not_treat_a_lookalike_domain_as_ours(db, settings):
+        from classes.views_legacy_image import _is_own_host
+
+        # Suffix matching must not be a bare ``endswith``: evilpastlives.space is not
+        # a subdomain of pastlives.space.
+        settings.ALLOWED_HOSTS = ["testserver", "*.pastlives.space"]
+        request = RequestFactory().get("/_legacy-image/")
+
+        assert _is_own_host("evilpastlives.space", request) is False

--- a/classes/views_legacy_image.py
+++ b/classes/views_legacy_image.py
@@ -54,12 +54,31 @@ def _is_own_host(hostname: str, request: HttpRequest) -> bool:
     fallbacks would fire two dozen HTTP requests from the app back into the app —
     self-inflicted worker starvation on a two-worker gunicorn. So the guard keys
     off exactly the fact that makes the fetch dangerous: the target is us.
+
+    Wildcard ``ALLOWED_HOSTS`` entries are matched as suffixes, following Django's own
+    semantics (``.example.com`` / ``*.example.com`` match ``example.com`` and any
+    subdomain). Collapsing them to a bare domain and comparing for equality — as this
+    did originally — meant a wildcard entry silently failed to arm the guard for the
+    subdomain that actually needed it.
     """
     if not hostname:
         return False
-    own = {request.get_host().split(":")[0].strip().lower()}
-    own |= {h.strip().lstrip("*.").lower() for h in settings.ALLOWED_HOSTS if h.strip() not in ("", "*")}
-    return hostname.strip().lower() in own
+    host = hostname.strip().lower()
+    exact = {request.get_host().split(":")[0].strip().lower()}
+    suffixes: set[str] = set()
+    for raw in settings.ALLOWED_HOSTS:
+        entry = raw.strip().lower()
+        if entry in ("", "*"):
+            continue
+        if entry.startswith("*."):
+            suffixes.add(entry[2:])
+        elif entry.startswith("."):
+            suffixes.add(entry[1:])
+        else:
+            exact.add(entry)
+    if host in exact:
+        return True
+    return any(host == suffix or host.endswith(f".{suffix}") for suffix in suffixes)
 
 
 def legacy_image(request: HttpRequest) -> HttpResponse:

--- a/core/files.py
+++ b/core/files.py
@@ -33,7 +33,11 @@ def delete_if_unreferenced(
     """
     if not name:
         return False
-    others = model._default_manager.filter(**{field_name: name})
+    # ``_base_manager``, not ``_default_manager``: on a soft-deleting model the default
+    # manager filters out deleted rows, so a soft-deleted sibling still pointing at this
+    # key would not count as a reference and the object would be deleted out from under
+    # it. Undeleting that row would then surface a broken image.
+    others = model._base_manager.filter(**{field_name: name})
     if exclude_pk is not None:
         others = others.exclude(pk=exclude_pk)
     if others.exists():

--- a/core/triggers.py
+++ b/core/triggers.py
@@ -3,8 +3,13 @@
 Each Trigger describes one notifiable event: its stable key (stored in
 Notification.trigger / NotificationPreference.trigger), display label and
 description for the settings UI, category grouping, audience (who sees the
-toggle), and defaults. `force_email` triggers always email and never show a
-toggle (e.g. security new-login).
+toggle), and defaults. `force_email` triggers always email (e.g. security
+new-login); the member cannot opt out.
+
+How they surface differs by UI: :func:`for_member` omits them entirely, while
+``core.events.settings_matrix.build_matrix`` lists them with the email cell
+rendered locked-on, so the member can see the event exists without being able
+to disable it.
 """
 
 from __future__ import annotations

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.25"
+VERSION = "0.23.27"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.23.25",
+        "version": "0.23.27",
         "date": "2026-07-22",
         "title": "Class photos now load faster",
         "changes": [

--- a/tests/core/public_surface_404_spec.py
+++ b/tests/core/public_surface_404_spec.py
@@ -66,7 +66,11 @@ def describe_member_only_paths_on_the_public_surface():
             assert b"We couldn't find that page." in response.content
 
     def describe_on_the_members_host():
-        def it_does_not_404_member_only_paths(db) -> None:
+        def it_serves_member_only_paths_normally(db) -> None:
+            # Asserts 200, not merely "not 404": this is the control proving the guest-host
+            # 404s above are surface-scoped rather than the path being broken everywhere.
+            # ``!= 404`` also passed on a 500, which is the exact failure this file exists
+            # to catch.
             client = Client(HTTP_HOST="members.pastlives.space", raise_request_exception=False)
             response = client.get("/guilds/")
-            assert response.status_code != 404
+            assert response.status_code == 200, f"members host returned {response.status_code}, expected 200"


### PR DESCRIPTION
Four non-blocking findings raised by PastLivesReviewBot while reviewing #148, #149 and #150. All three of those PRs are merged, so these are follow-ups against `main` rather than changes to work in flight.

No member-facing behaviour changes.

## 1. Wildcard `ALLOWED_HOSTS` silently disarmed the self-fetch guard

`classes/views_legacy_image.py::_is_own_host` did:

```python
own |= {h.strip().lstrip("*.").lower() for h in settings.ALLOWED_HOSTS if h.strip() not in ("", "*")}
return hostname.strip().lower() in own
```

`lstrip("*.")` collapses `*.pastlives.space` to `pastlives.space`, and the comparison is then an **equality** check — so a wildcard entry never matched `classes.pastlives.space`, which is the exact subdomain the guard exists to protect. The other half of the guard (`request.get_host()`) does not cover it either, because the current request's host is normally the members or catalog domain, not the image URL's host.

Unreachable as the app is operated today, since this repo uses explicit hostnames. But the failure mode is silent: adding a wildcard would quietly stop the guard protecting anything, and the symptom would be the app fetching itself once per card on a catalog page.

Now suffix-matched following Django's own semantics, accepting both the `*.example.com` and `.example.com` spellings.

Three specs. Two pin the wildcard forms; the third pins that suffix matching does **not** degrade into a bare `endswith` — `evilpastlives.space` must not read as ours.

**Red-green verified:** against the previous implementation the two wildcard specs fail and the lookalike-domain spec passes, so they pin the gap specifically rather than restating current behaviour.

## 2. A control assertion that passed on the failure it was guarding

`tests/core/public_surface_404_spec.py` asserted `response.status_code != 404` for the members host. That also passes on a **500** — which is precisely the failure #148 was written to prevent. The real response is 200, so the assertion is now `== 200`.

## 3. `delete_if_unreferenced` could delete a file still in use

`core/files.py` checked for other references via `model._default_manager`. On a soft-deleting model the default manager filters deleted rows out, so a soft-deleted sibling still pointing at a storage key would not count as a reference, and the object would be deleted out from under it. Undeleting that row would then surface a broken image.

Now uses `_base_manager`. Unreachable today (no soft-deleted model currently holds content-addressed keys), but strictly safer and a one-word fix.

## 4. Docstring contradicted the settings UI

`core/triggers.py` stated `force_email` triggers "never show a toggle". That is true of `for_member()`, which skips them, but `core.events.settings_matrix.build_matrix` lists them with the email cell rendered **locked-on** so the member can see the event exists without being able to disable it. The docstring now describes both surfaces.

## Verification

Full suite **6350 passed, 0 warnings**, coverage 98.28%. `ruff check`, `ruff format --check`, and `mypy plfog/ core/ membership/ hub/` all clean.

## Changelog

Internal and test-only, so no new entry. `VERSION` goes to 0.23.27 and the newest existing entry is carried forward so `announce_release` resolves. 0.23.26 belongs to #152, which is still open.

## Deliberately not included

- The `public_slug` N+1, the `theme` docstring contradiction, and the `/guilds/<pk>/` 301 leaking a private guild's slug in the `Location` header all live in **#152**, which is unmerged — `public_slug` does not exist on `main` yet. They belong on that branch.
- #150's note that `delete_if_unreferenced` checks a single model while `ClassOffering.image` and `ClassImage.image` share the `classes/images/` prefix. Spanning models is a design change rather than a cleanup, and it is unreachable today since only `ClassOffering` receives content-addressed keys.