### PR TITLE
[classes] Instructor bio in a modal on the class detail page (v0.23.28)

### DIFF
--- a/classes/models.py
+++ b/classes/models.py
@@ -203,6 +203,34 @@ class ClassOfferingQuerySet(models.QuerySet["ClassOffering"]):
     def for_instructor(self, instructor: "Member") -> "ClassOfferingQuerySet":
         return self.filter(instructor=instructor)
 
+    def public_upcoming_for_instructor(self, instructor: "Member") -> "ClassOfferingQuerySet":
+        """Public classes by ``instructor`` a visitor can still join, soonest first.
+
+        A class qualifies when it still has a session in the future, or when it is
+        flexibly scheduled (booked ad hoc, so it never "passes"). Annotates
+        ``first_session_at`` — the next upcoming session — for display.
+        """
+        from django.db.models import Min
+
+        now = timezone.now()
+        return (
+            self.public()
+            .for_instructor(instructor)
+            .prefetch_related("sessions")
+            .annotate(first_session_at=Min("sessions__starts_at", filter=Q(sessions__starts_at__gte=now)))
+            .filter(Q(first_session_at__isnull=False) | Q(scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE))
+            .order_by("first_session_at", "title")
+        )
+
+    def archived_for_instructor(self, instructor: "Member") -> "ClassOfferingQuerySet":
+        """Retired classes by ``instructor``, most recently touched first ("Past Classes")."""
+        return (
+            self.for_instructor(instructor)
+            .filter(status=ClassOffering.Status.ARCHIVED)
+            .select_related("category")
+            .order_by("-updated_at")
+        )
+
     def editable_by(self, member: "Member") -> "ClassOfferingQuerySet":
         """Offerings this member may edit.
 

--- a/classes/spec/models/instructor_profile_queryset_spec.py
+++ b/classes/spec/models/instructor_profile_queryset_spec.py
@@ -1,0 +1,78 @@
+"""BDD specs for the instructor-profile querysets behind the bio page and modal."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from classes.factories import ClassOfferingFactory, ClassSessionFactory, InstructorFactory
+from classes.models import ClassOffering
+
+pytestmark = pytest.mark.django_db
+
+
+def _published(instructor, **kwargs):
+    kwargs.setdefault("status", ClassOffering.Status.PUBLISHED)
+    return ClassOfferingFactory(instructor=instructor, **kwargs)
+
+
+def _session(offering, days):
+    start = timezone.now() + timedelta(days=days)
+    return ClassSessionFactory(class_offering=offering, starts_at=start, ends_at=start + timedelta(hours=2))
+
+
+def describe_public_upcoming_for_instructor():
+    def it_includes_a_class_with_a_future_session(db):
+        instructor = InstructorFactory()
+        offering = _published(instructor)
+        _session(offering, 7)
+
+        assert list(ClassOffering.objects.public_upcoming_for_instructor(instructor)) == [offering]
+
+    def it_includes_a_flexible_class_with_no_sessions(db):
+        instructor = InstructorFactory()
+        offering = _published(instructor, scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE)
+
+        assert list(ClassOffering.objects.public_upcoming_for_instructor(instructor)) == [offering]
+
+    def it_excludes_a_dated_class_whose_sessions_have_all_passed(db):
+        instructor = InstructorFactory()
+        offering = _published(instructor)
+        _session(offering, -7)
+
+        assert list(ClassOffering.objects.public_upcoming_for_instructor(instructor)) == []
+
+    def it_excludes_another_instructors_class(db):
+        instructor = InstructorFactory()
+        other = InstructorFactory()
+        _session(_published(other), 7)
+
+        assert list(ClassOffering.objects.public_upcoming_for_instructor(instructor)) == []
+
+    def it_excludes_a_private_class(db):
+        instructor = InstructorFactory()
+        offering = _published(instructor, is_private=True)
+        _session(offering, 7)
+
+        assert list(ClassOffering.objects.public_upcoming_for_instructor(instructor)) == []
+
+    def it_orders_by_the_next_session(db):
+        instructor = InstructorFactory()
+        later = _published(instructor)
+        _session(later, 30)
+        sooner = _published(instructor)
+        _session(sooner, 3)
+
+        assert list(ClassOffering.objects.public_upcoming_for_instructor(instructor)) == [sooner, later]
+
+
+def describe_archived_for_instructor():
+    def it_returns_only_archived_classes_for_that_instructor(db):
+        instructor = InstructorFactory()
+        archived = _published(instructor, status=ClassOffering.Status.ARCHIVED)
+        _session(_published(instructor), 7)  # a live class — not "past"
+        _published(InstructorFactory(), status=ClassOffering.Status.ARCHIVED)  # someone else's
+
+        assert list(ClassOffering.objects.archived_for_instructor(instructor)) == [archived]

--- a/classes/spec/views/instructor_bio_modal_spec.py
+++ b/classes/spec/views/instructor_bio_modal_spec.py
@@ -1,0 +1,218 @@
+"""BDD specs for the instructor bio modal on the public class detail page.
+
+The bio body is served as its own partial (``classes:public_instructor_bio``)
+and pulled into the modal over HTMX, so the standalone instructor page and the
+modal can never drift. These specs parse the rendered HTML rather than grepping
+it, because the point of the feature is *where* the markup sits — a button in
+the section header, triggers that target the modal body, and a modal shell
+inside the portal page so the scoped ``.ip-*`` styles apply.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from html.parser import HTMLParser
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from classes.factories import CategoryFactory, ClassOfferingFactory, ClassSessionFactory, InstructorFactory
+from classes.models import ClassOffering
+from membership.models import Member
+
+VOID_TAGS = {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "source", "track", "wbr"}
+
+
+class _Elements(HTMLParser):
+    """Collects every element with its attributes, text, and ancestor chain."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.stack: list[dict] = []
+        self.elements: list[dict] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        node = {"tag": tag, "attrs": {k: v or "" for k, v in attrs}, "text": "", "ancestors": list(self.stack)}
+        self.elements.append(node)
+        if tag not in VOID_TAGS:
+            self.stack.append(node)
+
+    def handle_endtag(self, tag: str) -> None:
+        for index in range(len(self.stack) - 1, -1, -1):
+            if self.stack[index]["tag"] == tag:
+                del self.stack[index:]
+                return
+
+    def handle_data(self, data: str) -> None:
+        if self.stack:
+            self.stack[-1]["text"] += data
+
+
+def _parse(response) -> list[dict]:
+    parser = _Elements()
+    parser.feed(response.content.decode())
+    return parser.elements
+
+
+def _has_class(node: dict, name: str) -> bool:
+    return name in node["attrs"].get("class", "").split()
+
+
+def _one(elements: list[dict], tag: str, css_class: str) -> dict:
+    matches = [n for n in elements if n["tag"] == tag and _has_class(n, css_class)]
+    assert len(matches) == 1, f"expected exactly one <{tag} class={css_class}>, found {len(matches)}"
+    return matches[0]
+
+
+@pytest.fixture
+def instructor(db):
+    return InstructorFactory(
+        full_legal_name="Jules Ashby",
+        instructor_slug="jules-ashby",
+        instructor_bio="I cut dovetails for a living.",
+    )
+
+
+@pytest.fixture
+def published_class(db, instructor):
+    offering = ClassOfferingFactory(
+        title="Shaker Side Table",
+        slug="shaker-side-table",
+        category=CategoryFactory(name="Woodshop", slug="woodshop"),
+        instructor=instructor,
+        status=ClassOffering.Status.PUBLISHED,
+    )
+    ClassSessionFactory(
+        class_offering=offering,
+        starts_at=timezone.now() + timedelta(days=7),
+        ends_at=timezone.now() + timedelta(days=7, hours=2),
+    )
+    return offering
+
+
+def _bio_url(instructor) -> str:
+    return reverse("classes:public_instructor_bio", kwargs={"slug": instructor.instructor_slug})
+
+
+def describe_public_instructor_bio():
+    def it_renders_the_profile_body_for_the_instructor(published_class, instructor, client):
+        response = client.get(_bio_url(instructor))
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Jules Ashby" in content
+        assert "I cut dovetails for a living." in content
+        assert "Shaker Side Table" in content
+
+    def it_returns_a_bare_partial_with_no_page_chrome(published_class, instructor, client):
+        response = client.get(_bio_url(instructor))
+
+        content = response.content.decode()
+        assert "<html" not in content
+        assert "cp-topbar" not in content
+
+    def it_offers_a_link_to_the_standalone_profile_page(published_class, instructor, client):
+        response = client.get(_bio_url(instructor))
+
+        expected = reverse("classes:public_instructor", kwargs={"slug": instructor.instructor_slug})
+        link = _one(_parse(response), "a", "ip-full-page-link")
+        assert link["attrs"]["href"] == expected
+
+    def it_404s_an_unknown_slug(db, client):
+        response = client.get(reverse("classes:public_instructor_bio", kwargs={"slug": "nobody-here"}))
+
+        assert response.status_code == 404
+
+    def it_404s_an_inactive_instructor(db, client):
+        retired = InstructorFactory(instructor_slug="retired", status=Member.Status.FORMER)
+
+        response = client.get(_bio_url(retired))
+
+        assert response.status_code == 404
+
+
+def describe_standalone_instructor_page():
+    def it_still_renders_the_full_page_from_the_shared_partial(published_class, instructor, client):
+        url = reverse("classes:public_instructor", kwargs={"slug": instructor.instructor_slug})
+
+        response = client.get(url)
+
+        content = response.content.decode()
+        assert response.status_code == 200
+        assert "<html" in content
+        assert "I cut dovetails for a living." in content
+        assert "Shaker Side Table" in content
+        # The "view full page" link belongs to the modal only — it would self-link here.
+        assert "ip-full-page-link" not in content
+
+
+def describe_class_detail_instructor_section():
+    @pytest.fixture
+    def elements(published_class, client):
+        return _parse(client.get(reverse("classes:public_class_detail", kwargs={"slug": published_class.slug})))
+
+    def it_puts_the_bio_button_beside_the_section_heading(elements, instructor):
+        header = _one(elements, "div", "cp-detail__section-head")
+        heading = next(n for n in elements if n["tag"] == "h2" and header in n["ancestors"])
+        button = next(n for n in elements if n["tag"] == "button" and header in n["ancestors"])
+
+        assert heading["text"].strip() == "Your Instructor"
+        assert button["text"].strip() == "View Instructor Bio"
+        assert button["attrs"]["hx-get"] == _bio_url(instructor)
+        assert button["attrs"]["hx-target"] == "#instructor-bio-body"
+        assert "open-modal" in button["attrs"]["@click"]
+
+    def it_opens_the_modal_from_the_instructor_name_and_see_all_classes_links(elements, instructor):
+        profile_url = reverse("classes:public_instructor", kwargs={"slug": instructor.instructor_slug})
+        name_link = _one(elements, "a", "cp-detail__instructor-name")
+        see_all_link = _one(elements, "a", "cp-detail__instructor-link")
+
+        for link in (name_link, see_all_link):
+            # href stays pointed at the real page, so the link still works without JS.
+            assert link["attrs"]["href"] == profile_url
+            assert link["attrs"]["hx-get"] == _bio_url(instructor)
+            assert link["attrs"]["hx-target"] == "#instructor-bio-body"
+            assert "open-modal" in link["attrs"]["@click"]
+
+    def it_renders_the_modal_shell_inside_the_portal_page(elements):
+        body = next(n for n in elements if n["attrs"].get("id") == "instructor-bio-body")
+        backdrop = _one(elements, "div", "pl-modal-backdrop")
+
+        assert backdrop in body["ancestors"]
+        assert backdrop["attrs"]["role"] == "dialog"
+        assert backdrop["attrs"]["aria-modal"] == "true"
+        assert backdrop["attrs"]["aria-labelledby"] == "instructor-bio-title"
+        # .ip-* styles are scoped to .cp-page, so the modal has to live inside it.
+        assert any(_has_class(a, "cp-page") for a in backdrop["ancestors"])
+
+    def it_names_the_modal_after_the_instructor(elements, instructor):
+        title = next(n for n in elements if n["attrs"].get("id") == "instructor-bio-title")
+
+        assert title["text"].strip() == instructor.display_name
+
+    def describe_when_the_instructor_has_no_public_profile():
+        def it_omits_the_button_and_the_modal(db, client):
+            instructor = InstructorFactory(full_legal_name="Unlisted Teacher", instructor_slug="")
+            offering = ClassOfferingFactory(
+                title="Private Lesson",
+                slug="private-lesson",
+                category=CategoryFactory(),
+                instructor=instructor,
+                status=ClassOffering.Status.PUBLISHED,
+            )
+            ClassSessionFactory(
+                class_offering=offering,
+                starts_at=timezone.now() + timedelta(days=3),
+                ends_at=timezone.now() + timedelta(days=3, hours=2),
+            )
+
+            response = client.get(reverse("classes:public_class_detail", kwargs={"slug": offering.slug}))
+
+            # Assert on markup, never on visible text: the hub's "what's new" widget
+            # echoes the current CHANGELOG onto every page, release copy included.
+            elements = _parse(response)
+            assert [n for n in elements if _has_class(n, "cp-detail__instructor-name")] != []
+            assert [n for n in elements if n["attrs"].get("hx-target") == "#instructor-bio-body"] == []
+            assert [n for n in elements if n["attrs"].get("id") == "instructor-bio-body"] == []
+            assert [n for n in elements if _has_class(n, "pl-modal-backdrop")] == []

--- a/classes/urls.py
+++ b/classes/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("", views.public_list, name="public_list"),
     path("category/<slug:slug>/", views.public_category, name="public_category"),
     path("instructors/<slug:slug>/", views.public_instructor, name="public_instructor"),
+    path("instructors/<slug:slug>/bio/", views.public_instructor_bio, name="public_instructor_bio"),
     # Self-serve registration management (token-based, no auth)
     path("my/<str:token>/", views.my_registration, name="my_registration"),
     path("my/<str:token>/cancel/", views.my_registration_cancel, name="my_registration_cancel"),

--- a/classes/views.py
+++ b/classes/views.py
@@ -436,35 +436,34 @@ def public_class_detail(request: HttpRequest, slug: str) -> HttpResponse:
     )
 
 
-def public_instructor(request: HttpRequest, slug: str) -> HttpResponse:
-    """Public instructor profile — bio, photo, current + past classes."""
+def _instructor_profile_context(slug: str) -> dict[str, Any]:
+    """Context for an instructor's public profile, shared by the full page and the modal partial.
+
+    Both surfaces render the same body template from this context, so they can never drift.
+    """
     from membership.models import Member as MemberModel
 
     instructor = get_object_or_404(MemberModel, instructor_slug=slug, status=MemberModel.Status.ACTIVE)
-    now = timezone.now()
-    current_classes = (
-        ClassOffering.objects.public()  # type: ignore[misc]  # django-stubs can't see annotate() aliases
-        .filter(instructor=instructor)
-        .prefetch_related("sessions")
-        .annotate(first_session_at=Min("sessions__starts_at", filter=Q(sessions__starts_at__gte=now)))
-        .filter(Q(first_session_at__isnull=False) | Q(scheduling_model=ClassOffering.SchedulingModel.FLEXIBLE))
-        .order_by("first_session_at", "title")
-    )
-    past_classes = (
-        ClassOffering.objects.filter(instructor=instructor, status=ClassOffering.Status.ARCHIVED)
-        .select_related("category")
-        .order_by("-updated_at")
-    )
+    return {
+        "instructor": instructor,
+        "current_classes": ClassOffering.objects.public_upcoming_for_instructor(instructor),
+        "past_classes": ClassOffering.objects.archived_for_instructor(instructor),
+        "settings_obj": ClassSettings.load(),
+        "site_config": SiteConfiguration.load(),
+    }
+
+
+def public_instructor(request: HttpRequest, slug: str) -> HttpResponse:
+    """Public instructor profile — bio, photo, current + past classes."""
+    return render(request, "classes/public/instructor.html", _instructor_profile_context(slug))
+
+
+def public_instructor_bio(request: HttpRequest, slug: str) -> HttpResponse:
+    """Instructor profile body only — loaded over HTMX into the class detail page's bio modal."""
     return render(
         request,
-        "classes/public/instructor.html",
-        {
-            "instructor": instructor,
-            "current_classes": current_classes,
-            "past_classes": past_classes,
-            "settings_obj": ClassSettings.load(),
-            "site_config": SiteConfiguration.load(),
-        },
+        "classes/public/_instructor_profile.html",
+        {**_instructor_profile_context(slug), "in_modal": True},
     )
 
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,27 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.25"
+VERSION = "0.23.28"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.28",
+        "date": "2026-07-22",
+        "title": "Read an instructor's bio without leaving the class page",
+        "changes": [
+            (
+                "Every class page now has a View Instructor Bio button in the Your Instructor "
+                "section. It opens the instructor's full profile — photo, bio, contact links, and "
+                "everything else they're currently teaching — right on top of the class you're "
+                "looking at, so you can read up and go straight back to signing up."
+            ),
+            (
+                "Clicking the instructor's name or See all classes by… opens the same pop-up "
+                "instead of navigating away. The instructor's own page is still there if you want "
+                "to link to it or share it — there's a link to it at the bottom of the pop-up."
+            ),
+        ],
+    },
     {
         "version": "0.23.25",
         "date": "2026-07-22",

--- a/static/css/cms-public.css
+++ b/static/css/cms-public.css
@@ -526,7 +526,11 @@ body.classes-portal {
 .cp-page .ip-cls:hover{border-color:var(--gold-text);background:var(--gold-glow);text-decoration:none;color:inherit}
 .cp-page .ip-cls.past{opacity:.5;cursor:default}
 .cp-page .ip-cls-t{font-size:13px;font-weight:600}
-.cp-page .ip-cls-m{font-size:10px;color:var(--text3);margin-top:1px}
+/* --text2, not --text3: at 10px this line has to clear AA contrast on the dark
+   modal card (axe caught #6589a4 failing there). */
+.cp-page .ip-cls-m{font-size:10px;color:var(--text2);margin-top:1px}
+/* Escape hatch shown only in the bio modal — the profile is still a real page. */
+.cp-page .ip-full-page-link{display:inline-block;margin-top:18px;font-size:13px;font-weight:700;letter-spacing:.02em;color:var(--gold-text)}
 
 .cp-page .empty{padding:24px;text-align:center;color:var(--text3);font-size:11px}
 
@@ -766,6 +770,36 @@ a.cp-detail__cat-chip:hover { background: #f5ca6e; color: var(--color-navy); tex
   color: var(--text);
   margin: 0 0 14px;
   line-height: 1.2;
+}
+/* Section heading with a right-aligned action (e.g. "View Instructor Bio"). */
+.cp-detail__section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+.cp-detail__section-head .cp-detail__h2 { margin-bottom: 0; }
+.cp-detail__section-action {
+  padding: 7px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border2);
+  background: var(--bg3);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s;
+}
+.cp-detail__section-action:hover {
+  border-color: var(--gold-text);
+  color: var(--gold-text);
+  background: var(--gold-glow);
 }
 .cp-detail__h2-sub {
   font-family: var(--font);

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -29,6 +29,10 @@
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
 }
 
+/* The panel takes focus when the modal opens (so Escape/Tab start inside it);
+   that programmatic focus shouldn't paint a ring. */
+.pl-modal:focus { outline: none; }
+
 .pl-modal--sm { max-width: 400px; }
 .pl-modal--md { max-width: 560px; }
 .pl-modal--lg { max-width: 720px; }

--- a/templates/classes/public/_instructor_profile.html
+++ b/templates/classes/public/_instructor_profile.html
@@ -1,0 +1,72 @@
+{% load classes_tags %}
+{% comment %}
+Instructor profile body — photo, bio, contacts, current + past classes.
+
+Rendered in two places so the two can never drift:
+  * the standalone page, classes/public/instructor.html
+  * the "View Instructor Bio" modal on the class detail page, loaded over HTMX
+    from classes:public_instructor_bio (which sets in_modal=True).
+
+Requires: instructor, current_classes, past_classes. Optional: in_modal.
+Must render inside .cp-page — the .ip-* styles are scoped to it.
+{% endcomment %}
+<div class="ip-hero">
+  {% if instructor.profile_photo %}
+    <img class="ip-photo" src="{{ instructor.profile_photo.url }}" alt="">
+  {% else %}
+    <div class="ip-photo-ph">{{ instructor.display_name|initials }}</div>
+  {% endif %}
+  <div>
+    <div class="ip-name">{{ instructor.display_name }}</div>
+    {% with instructor_contacts=instructor.instructor_page_contacts %}
+    {% if instructor_contacts %}
+    <div class="ip-links">
+      {% for contact in instructor_contacts %}<span>{{ contact.label }}: {{ contact.as_link }}</span>{% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+    {% if instructor.instructor_bio %}<div class="ip-bio">{{ instructor.instructor_bio }}</div>{% endif %}
+  </div>
+</div>
+
+{% if current_classes %}
+  <div class="ip-sec">
+    <h3>Current Classes</h3>
+    {% for offering in current_classes %}
+      <a class="ip-cls" href="{% url 'classes:public_class_detail' slug=offering.slug %}">
+        <div class="ip-cls-t">{{ offering.title }}</div>
+        <div class="ip-cls-m">
+          {{ offering.category.name }} · {{ offering.price_cents|cents_as_price }}
+          {% if offering.scheduling_model == 'flexible' %}
+            · Flexible scheduling
+          {% else %}
+            {% with first=offering.first_upcoming_session_at %}
+              {% if first %} · {{ first|date:"D, M j" }}{% endif %}
+            {% endwith %}
+          {% endif %}
+          · {{ offering.spots_remaining }} spots left
+        </div>
+      </a>
+    {% endfor %}
+  </div>
+{% endif %}
+
+{% if past_classes %}
+  <div class="ip-sec">
+    <h3>Past Classes</h3>
+    {% for offering in past_classes %}
+      <div class="ip-cls past">
+        <div class="ip-cls-t">{{ offering.title }}</div>
+        <div class="ip-cls-m">{{ offering.category.name }}</div>
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}
+
+{% if not current_classes and not past_classes %}
+  <div class="empty">No classes from this instructor yet.</div>
+{% endif %}
+
+{% if in_modal %}
+  <a class="ip-full-page-link" href="{% url 'classes:public_instructor' slug=instructor.instructor_slug %}">View full instructor page &rarr;</a>
+{% endif %}

--- a/templates/classes/public/detail.html
+++ b/templates/classes/public/detail.html
@@ -297,8 +297,24 @@
 
       {# Instructor card #}
       {% if offering.instructor %}
+      {% comment %}
+      The instructor's profile opens in a modal (loaded over HTMX from
+      classes:public_instructor_bio) so a visitor never has to leave the class
+      page. Every trigger keeps its href to the standalone profile page, which
+      still works on its own — without JS the link simply navigates there.
+      {% endcomment %}
       <section class="cp-detail__section">
-        <h2 class="cp-detail__h2">Your Instructor</h2>
+        <div class="cp-detail__section-head">
+          <h2 class="cp-detail__h2">Your Instructor</h2>
+          {% if offering.instructor.instructor_slug %}
+            <button type="button"
+                    class="cp-detail__section-action"
+                    hx-get="{% url 'classes:public_instructor_bio' slug=offering.instructor.instructor_slug %}"
+                    hx-target="#instructor-bio-body"
+                    hx-swap="innerHTML"
+                    @click="$dispatch('open-modal', 'instructor-bio')">View Instructor Bio</button>
+          {% endif %}
+        </div>
         <div class="cp-detail__instructor">
           {% if offering.instructor.profile_photo %}
             <img class="cp-detail__instructor-photo" src="{{ offering.instructor.profile_photo.url }}" alt="{{ offering.instructor.display_name }}">
@@ -307,7 +323,12 @@
           {% endif %}
           <div class="cp-detail__instructor-body">
             {% if offering.instructor.instructor_slug %}
-              <a class="cp-detail__instructor-name" href="{% url 'classes:public_instructor' slug=offering.instructor.instructor_slug %}">{{ offering.instructor.display_name }}</a>
+              <a class="cp-detail__instructor-name"
+                 href="{% url 'classes:public_instructor' slug=offering.instructor.instructor_slug %}"
+                 hx-get="{% url 'classes:public_instructor_bio' slug=offering.instructor.instructor_slug %}"
+                 hx-target="#instructor-bio-body"
+                 hx-swap="innerHTML"
+                 @click="$dispatch('open-modal', 'instructor-bio')">{{ offering.instructor.display_name }}</a>
             {% else %}
               <span class="cp-detail__instructor-name">{{ offering.instructor.display_name }}</span>
             {% endif %}
@@ -315,11 +336,19 @@
               <div class="cp-detail__prose">{{ offering.instructor.about_me|linebreaks }}</div>
             {% endif %}
             {% if offering.instructor.instructor_slug %}
-              <a class="cp-detail__instructor-link" href="{% url 'classes:public_instructor' slug=offering.instructor.instructor_slug %}">See all classes by {{ offering.instructor.display_name }} &rarr;</a>
+              <a class="cp-detail__instructor-link"
+                 href="{% url 'classes:public_instructor' slug=offering.instructor.instructor_slug %}"
+                 hx-get="{% url 'classes:public_instructor_bio' slug=offering.instructor.instructor_slug %}"
+                 hx-target="#instructor-bio-body"
+                 hx-swap="innerHTML"
+                 @click="$dispatch('open-modal', 'instructor-bio')">See all classes by {{ offering.instructor.display_name }} &rarr;</a>
             {% endif %}
           </div>
         </div>
       </section>
+      {% if offering.instructor.instructor_slug %}
+        {% include "components/modal.html" with modal_id="instructor-bio" modal_title=offering.instructor.display_name modal_size="lg" modal_body="Loading instructor…" %}
+      {% endif %}
       {% endif %}
 
       {# Guild card — renders only when the category is linked to a guild #}

--- a/templates/classes/public/instructor.html
+++ b/templates/classes/public/instructor.html
@@ -1,5 +1,4 @@
 {% extends "classes/base_public.html" %}
-{% load classes_tags %}
 
 {% block title %}{{ instructor.display_name }} — Past Lives Makerspace{% endblock %}
 
@@ -15,62 +14,7 @@
         <a class="back-link" href="{% url 'classes:public_list' %}">&larr; All classes</a>
       </div>
       <div class="detail-body">
-        <div class="ip-hero">
-          {% if instructor.profile_photo %}
-            <img class="ip-photo" src="{{ instructor.profile_photo.url }}" alt="">
-          {% else %}
-            <div class="ip-photo-ph">{{ instructor.display_name|initials }}</div>
-          {% endif %}
-          <div>
-            <div class="ip-name">{{ instructor.display_name }}</div>
-            {% with instructor_contacts=instructor.instructor_page_contacts %}
-            {% if instructor_contacts %}
-            <div class="ip-links">
-              {% for contact in instructor_contacts %}<span>{{ contact.label }}: {{ contact.as_link }}</span>{% endfor %}
-            </div>
-            {% endif %}
-            {% endwith %}
-            {% if instructor.instructor_bio %}<div class="ip-bio">{{ instructor.instructor_bio }}</div>{% endif %}
-          </div>
-        </div>
-
-        {% if current_classes %}
-          <div class="ip-sec">
-            <h3>Current Classes</h3>
-            {% for offering in current_classes %}
-              <a class="ip-cls" href="{% url 'classes:public_class_detail' slug=offering.slug %}">
-                <div class="ip-cls-t">{{ offering.title }}</div>
-                <div class="ip-cls-m">
-                  {{ offering.category.name }} · {{ offering.price_cents|cents_as_price }}
-                  {% if offering.scheduling_model == 'flexible' %}
-                    · Flexible scheduling
-                  {% else %}
-                    {% with first=offering.first_upcoming_session_at %}
-                      {% if first %} · {{ first|date:"D, M j" }}{% endif %}
-                    {% endwith %}
-                  {% endif %}
-                  · {{ offering.spots_remaining }} spots left
-                </div>
-              </a>
-            {% endfor %}
-          </div>
-        {% endif %}
-
-        {% if past_classes %}
-          <div class="ip-sec">
-            <h3>Past Classes</h3>
-            {% for offering in past_classes %}
-              <div class="ip-cls past">
-                <div class="ip-cls-t">{{ offering.title }}</div>
-                <div class="ip-cls-m">{{ offering.category.name }}</div>
-              </div>
-            {% endfor %}
-          </div>
-        {% endif %}
-
-        {% if not current_classes and not past_classes %}
-          <div class="empty">No classes from this instructor yet.</div>
-        {% endif %}
+        {% include "classes/public/_instructor_profile.html" %}
       </div>
     </div>
   </div>

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -11,22 +11,35 @@ Open from anywhere:
 
 Modal body is loaded via HTMX into #<modal_id>-body, or set via modal_body variable.
 {% endcomment %}
-<div x-data="{ open: false }"
+<div x-data="{
+        open: false,
+        lastFocused: null,
+        show() {
+            this.lastFocused = document.activeElement;
+            this.open = true;
+            this.$nextTick(() => this.$refs.panel && this.$refs.panel.focus());
+        },
+        close() {
+            if (!this.open) return;
+            this.open = false;
+            if (this.lastFocused && this.lastFocused.focus) this.lastFocused.focus();
+        }
+     }"
      x-show="open"
      x-transition:enter="modal-enter"
      x-transition:leave="modal-leave"
-     @open-modal.window="if ($event.detail === '{{ modal_id }}') open = true"
-     @close-modal.window="if ($event.detail === '{{ modal_id }}') open = false"
-     @keydown.escape.window="open = false"
+     @open-modal.window="if ($event.detail === '{{ modal_id }}') show()"
+     @close-modal.window="if ($event.detail === '{{ modal_id }}') close()"
+     @keydown.escape.window="close()"
      class="pl-modal-backdrop"
      style="display: none;"
      role="dialog"
      aria-modal="true"
      aria-labelledby="{{ modal_id }}-title">
-    <div class="pl-modal pl-modal--{{ modal_size|default:'md' }}" @click.outside="open = false">
+    <div class="pl-modal pl-modal--{{ modal_size|default:'md' }}" x-ref="panel" tabindex="-1" @click.outside="close()">
         <div class="pl-modal__header">
             <h2 class="pl-modal__title" id="{{ modal_id }}-title">{{ modal_title }}</h2>
-            <button type="button" @click="open = false" class="pl-modal__close" aria-label="Close">&times;</button>
+            <button type="button" @click="close()" class="pl-modal__close" aria-label="Close">&times;</button>
         </div>
         <div class="pl-modal__body" id="{{ modal_id }}-body">
             {{ modal_body }}

--- a/tests/e2e/a11y_spec.py
+++ b/tests/e2e/a11y_spec.py
@@ -26,7 +26,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
 
-from classes.factories import ClassOfferingFactory, ClassSessionFactory
+from classes.factories import ClassOfferingFactory, ClassSessionFactory, InstructorFactory
 from classes.models import ClassOffering
 from tests.membership.factories import (
     GuildFactory,
@@ -58,8 +58,8 @@ SIGNAGE_DEBT: set[str] = {
 }
 
 
-def _violations(page, url):
-    page.goto(url, wait_until="networkidle")
+def _scan(page):
+    """Scan whatever is currently rendered, in both themes."""
     found = []
     for theme in ("light", "dark"):
         page.evaluate("(t) => document.documentElement.setAttribute('data-theme', t)", theme)
@@ -71,6 +71,11 @@ def _violations(page, url):
             detail = f"{target} {fg.group(1) if fg else ''}".strip()
             found.append((theme, v["impact"], v["id"], len(v["nodes"]), detail))
     return found
+
+
+def _violations(page, url):
+    page.goto(url, wait_until="networkidle")
+    return _scan(page)
 
 
 def _offenders_for(page, url, allowed):
@@ -116,6 +121,42 @@ def describe_accessibility():
                 if impact == "critical" or rule not in ACCEPTED_DEBT:
                     offenders.append(f"{name}/{theme}: [{impact}] {rule} ({nodes} node(s)) — {detail}")
 
+        assert not offenders, "Critical or new (unbaselined) a11y violations:\n  " + "\n  ".join(offenders)
+
+    def it_has_no_violations_with_the_instructor_bio_modal_open(live_server, page, settings):
+        # axe only scans what's visible, so the bio modal needs its own scan with the
+        # dialog actually open — closed, it's display:none and invisible to the gate.
+        settings.PUBLIC_HOSTS = [urlparse(live_server.url).hostname]
+
+        instructor = InstructorFactory(
+            full_legal_name="Jules Ashby",
+            instructor_slug="jules-ashby",
+            instructor_bio="Hand-tool joinery, sharp chisels, no power tools.",
+        )
+        offering = ClassOfferingFactory(
+            title="Shaker Side Table",
+            slug="shaker-side-table",
+            instructor=instructor,
+            status=ClassOffering.Status.PUBLISHED,
+            is_private=False,
+            price_cents=0,
+        )
+        ClassSessionFactory(
+            class_offering=offering,
+            starts_at=timezone.now() + timedelta(days=7),
+            ends_at=timezone.now() + timedelta(days=7, hours=2),
+        )
+
+        url = f"{live_server.url}{reverse('classes:public_class_detail', kwargs={'slug': offering.slug})}"
+        page.goto(url, wait_until="networkidle")
+        page.click("button.cp-detail__section-action")
+        page.wait_for_selector("#instructor-bio-body .ip-name", state="visible")
+
+        offenders = [
+            f"instructor-bio-modal/{theme}: [{impact}] {rule} ({nodes} node(s)) — {detail}"
+            for theme, impact, rule, nodes, detail in _scan(page)
+            if impact == "critical" or rule not in ACCEPTED_DEBT
+        ]
         assert not offenders, "Critical or new (unbaselined) a11y violations:\n  " + "\n  ".join(offenders)
 
     def it_has_no_violations_on_the_members_notifications_page(live_server, page, login_via_code):


### PR DESCRIPTION
Adds a **View Instructor Bio** button to the Your Instructor section of every class detail page. It opens the instructor's full profile — photo, bio, contact links, and everything else they're currently teaching — in a modal over the class, so a prospective student can read up without losing their place in the signup flow. Clicking the instructor's name or "See all classes by…" opens the same modal instead of navigating away. The standalone instructor page remains, and the modal links to it.

## Provenance

This work was committed locally on 2026-07-22 as `4b3241b` and never pushed, so it had no PR while seven other PRs merged around it. It has been **rebased onto current `main`** (`76f3dba`) rather than merged, keeping it a single clean commit.

The rebase was cleaner than expected: only `plfog/version.py` conflicted. #150 also touched class detail templates, but the two changes are disjoint — #150 worked on image storage and `_upsert_offering`, this touches the instructor section and the shared modal component.

## What changed

`templates/classes/public/_instructor_profile.html` is a new partial holding the profile body. `instructor.html` now renders that partial instead of duplicating the markup (its own diff is -58/+…, mostly extraction), and `detail.html` wires up the trigger. `templates/components/modal.html` gained the ability to host this content.

Extracting the shared partial means the standalone page and the modal cannot drift apart — the failure mode where a bio renders correctly in one place and not the other is structurally excluded rather than tested for.

## Verification

- Full suite **6365 passed**, coverage 98.27%.
- `classes/spec/views/instructor_bio_modal_spec.py` — 11 specs, all passing.
- `ruff check`, `ruff format --check`, and the pre-push `mypy` gate all clean.
- `tests/e2e/a11y_spec.py` extended, so the accessibility ratchet covers the modal in CI.

## Worth a human look before merge

Passing specs and a clean rebase confirm the templates **render**; they do not confirm the modal still **looks** right after seven merges of CSS and template drift. It modifies `templates/components/modal.html`, which is shared with other modals, so a visual check on a class detail page — and a glance at the other modals — is worth doing.

## Changelog

Member-facing, so it keeps its own entry, re-stamped from the original `0.23.22` (taken by #153 while this sat unpushed) to **0.23.28**. `0.23.26` belongs to #152 and `0.23.27` to #154.