### PR TITLE
App Store launch: shell origin, reviewer sign in, privacy policy

### DIFF
--- a/classes/import_service.py
+++ b/classes/import_service.py
@@ -69,14 +69,28 @@ def _html_to_text(raw: str) -> str:
 
 
 def _find_instructor(name: str) -> "Member | None":
+    """Resolve an instructor name pulled from a class title to an active Member.
+
+    Prefers an exact (case-insensitive) match on preferred or legal name. Falls back to a
+    substring match ONLY when it is unambiguous: if a fragment like "Billy" matches more
+    than one active member, return None and leave the instructor unset rather than silently
+    linking an arbitrary same-named person. Auto-attaching the wrong member's name to a
+    class is worse than attaching none — a human assigns the right instructor instead.
+    """
     from django.db.models import Q
 
     from membership.models import Member
 
-    return Member.objects.filter(
-        Q(preferred_name__icontains=name) | Q(full_legal_name__icontains=name),
-        status=Member.Status.ACTIVE,
-    ).first()
+    active = Member.objects.filter(status=Member.Status.ACTIVE)
+    # A unique exact match is the strongest signal — take it even if others contain the name.
+    exact = list(active.filter(Q(preferred_name__iexact=name) | Q(full_legal_name__iexact=name))[:2])
+    if len(exact) == 1:
+        return exact[0]
+    # Otherwise only auto-link when the substring match resolves to exactly one member.
+    fuzzy = list(active.filter(Q(preferred_name__icontains=name) | Q(full_legal_name__icontains=name))[:2])
+    if len(fuzzy) == 1:
+        return fuzzy[0]
+    return None
 
 
 def _sync_sessions(offering: Any, date_items: list[dict[str, Any]]) -> None:

--- a/core/management/commands/run_scheduled_tasks.py
+++ b/core/management/commands/run_scheduled_tasks.py
@@ -8,9 +8,12 @@ Each due job is:
 - skipped if it's ``EXTERNAL`` (it has its own Render cron — e.g. ``airtable_pull``),
 - skipped if it's ``DAILY`` and it isn't ~6 AM Portland (UTC hour 13),
 - skipped if it's ``WEEKLY`` and it isn't Monday ~6 AM Portland (UTC weekday 0, hour 13),
+- skipped if it's ``DAILY``/``WEEKLY`` and already succeeded this window (the cron ticks ~4x
+  inside the qualifying hour, so without this each digest posts ~4 times — the dedup runs it
+  once per window while still letting a FAILED run retry in-window),
 - skipped if an admin has paused it (``is_enabled`` is false),
 - otherwise run inside ``record_run`` (which writes a ScheduledTaskRun row) and its own
-  try/except, so one failure cannot block the rest. Each task owns its idempotency.
+  try/except, so one failure cannot block the rest.
 """
 
 from __future__ import annotations
@@ -21,7 +24,7 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from core.scheduled_jobs import SCHEDULED_JOBS, Cadence, Trigger, is_enabled, record_run
+from core.scheduled_jobs import SCHEDULED_JOBS, Cadence, Trigger, has_succeeded_since, is_enabled, record_run
 
 DAILY_UTC_HOUR = 13  # ~6 AM Portland
 WEEKLY_UTC_WEEKDAY = 0  # Monday (WEEKLY jobs run Mondays at DAILY_UTC_HOUR)
@@ -46,6 +49,15 @@ class Command(BaseCommand):
                 continue
             if job.cadence == Cadence.WEEKLY and (now.weekday() != WEEKLY_UTC_WEEKDAY or now.hour != DAILY_UTC_HOUR):
                 self.stdout.write(f"  – {job.key} skipped (weekly, not Monday {DAILY_UTC_HOUR}:xx UTC)")
+                continue
+            # DAILY/WEEKLY jobs qualify for the whole DAILY_UTC_HOUR, but the cron ticks ~4x within
+            # it. Run each at most once per window: skip if it already succeeded since the top of
+            # this hour — which, given the hour gate above, is the start of today's / this Monday's
+            # window. ALWAYS jobs are exempt (they run every tick); a FAILED run still retries.
+            if job.cadence in (Cadence.DAILY, Cadence.WEEKLY) and has_succeeded_since(
+                job.key, now.replace(minute=0, second=0, microsecond=0)
+            ):
+                self.stdout.write(f"  – {job.key} skipped (already ran this window)")
                 continue
             if not is_enabled(job.key):
                 self.stdout.write(f"  – {job.key} disabled")

--- a/core/scheduled_jobs.py
+++ b/core/scheduled_jobs.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import contextlib
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from django.db import models
@@ -215,6 +215,22 @@ def is_enabled(key: str) -> bool:
     from core.models import ScheduledJobState
 
     return ScheduledJobState.objects.is_enabled(key)
+
+
+def has_succeeded_since(key: str, since: datetime) -> bool:
+    """Whether a job already completed OK at or after ``since``.
+
+    The dispatcher uses this to make DAILY/WEEKLY jobs run once per window instead of once
+    per 15-minute tick: those cadences qualify for a whole UTC hour, so the cron fires them
+    ~4 times each window otherwise (the duplicate #classes digests were this bug). A FAILED
+    run does not count, so a transient failure still retries within the same window — which
+    is exactly how a job recovers mid-window once its underlying cause is fixed.
+    """
+    from core.models import ScheduledTaskRun
+
+    return ScheduledTaskRun.objects.filter(
+        task_key=key, status=ScheduledTaskRun.Status.OK, started_at__gte=since
+    ).exists()
 
 
 @contextlib.contextmanager

--- a/core/urls.py
+++ b/core/urls.py
@@ -25,6 +25,8 @@ urlpatterns = [
     path("accounts/find-account/", views.find_account, name="find_account"),
     # Public newsletter signup (Mailchimp)
     path("newsletter/", views.newsletter_signup, name="newsletter_signup"),
+    # Public privacy policy — no login (linked from the app-store listing + footer)
+    path("privacy/", views.privacy_policy, name="privacy_policy"),
     # Service worker (served with Service-Worker-Allowed header)
     path("sw.js", views.service_worker, name="service_worker"),
     # WebPush endpoints

--- a/core/views.py
+++ b/core/views.py
@@ -167,6 +167,17 @@ def robots_txt(request: HttpRequest) -> HttpResponse:
     return HttpResponse("\n".join(lines) + "\n", content_type="text/plain")
 
 
+@require_GET
+def privacy_policy(request: HttpRequest) -> HttpResponse:
+    """Public privacy policy page.
+
+    Deliberately reachable without login: Google Play's crawler and app
+    reviewers must be able to fetch it, it is linked from the store listing,
+    and it satisfies the Play Data safety requirement for a policy URL.
+    """
+    return render(request, "core/privacy_policy.html")
+
+
 def restart_login(request: HttpRequest) -> HttpResponse:
     """Clear any pending login stage and redirect to the login page."""
     clear_login(request)

--- a/hub/discord_calendar_posts.py
+++ b/hub/discord_calendar_posts.py
@@ -84,13 +84,23 @@ def _is_studio_hours(item: Any) -> bool:
 
 
 def _digest_items(now: datetime) -> list[Any]:
-    """The next-7-days slice of the calendar union (feed + class + community events),
-    minus standing studio-hours blocks."""
+    """The next-7-days slice of the events calendar (feed + general + community events),
+    minus classes and standing studio-hours blocks.
+
+    #public-calendar is events-only: classes have their own #classes digest, so
+    class-sourced rows are dropped here even though they share the calendar union.
+    """
     from hub.calendar_entries import upcoming_calendar_events
+    from membership.models import CalendarEvent
 
     horizon = now + timedelta(days=DIGEST_WINDOW_DAYS)
     return [
-        e for e in upcoming_calendar_events() if e.start_dt < horizon and e.end_dt >= now and not _is_studio_hours(e)
+        e
+        for e in upcoming_calendar_events()
+        if e.start_dt < horizon
+        and e.end_dt >= now
+        and e.source != CalendarEvent.Source.CLASSES
+        and not _is_studio_hours(e)
     ]
 
 
@@ -302,6 +312,8 @@ def announce_new_events() -> int:
     pending: list[tuple[datetime, dict[str, Any], list[Any]]] = []
     feed_rows = (
         CalendarEvent.objects.filter(channel_announced_at__isnull=True, start_dt__gt=now)
+        # #public-calendar is events-only — classes announce to #classes, not here.
+        .exclude(source=CalendarEvent.Source.CLASSES)
         .exclude(uid__in=_pushed_event_uids())
         .order_by("start_dt")
     )
@@ -313,8 +325,9 @@ def announce_new_events() -> int:
     for rows in series.values():
         first = rows[0]
         url = _absolute(first.url) if first.url else ""
-        kind = "New class on the calendar" if first.source == CalendarEvent.Source.CLASSES else "New on the calendar"
-        embed = _announcement_embed(first.title, kind, _when(first.start_dt, first.end_dt, first.all_day), url)
+        embed = _announcement_embed(
+            first.title, "New on the calendar", _when(first.start_dt, first.end_dt, first.all_day), url
+        )
         pending.append((first.start_dt, embed, list(rows)))
 
     community_rows = (

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,7 +2,7 @@
 
 A thin native wrapper that ships the Past Lives Makerspace hub to the App Store
 and Google Play. It does **not** reimplement the app — the webview loads the live
-Django-served site (`https://pastlives.app`), so all UI, auth, and features come
+Django-served site (`https://members.pastlives.space`), so all UI, auth, and features come
 straight from the existing web app and update instantly with no store re-review.
 
 - **App ID:** `app.pastlives.hub`
@@ -13,7 +13,7 @@ straight from the existing web app and update instantly with no store re-review.
 
 ```
 mobile/
-├── capacitor.config.ts   # appId, appName, server.url → pastlives.app
+├── capacitor.config.ts   # appId, appName, server.url → members.pastlives.space
 ├── www/index.html        # splash/offline fallback (rarely shown)
 ├── android/              # generated native Android project (committed)
 └── ios/                  # generated on the Mac (see below) — not committed from WSL

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -1,5 +1,14 @@
 apply plugin: 'com.android.application'
 
+// Upload-signing config. Values live in `mobile/android/key.properties`
+// (gitignored). Copy `key.properties.example` and fill it in once; the
+// release build is unsigned if the file is absent so debug builds still work.
+def keystorePropertiesFile = rootProject.file("key.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "app.pastlives.hub"
     compileSdk = rootProject.ext.compileSdkVersion
@@ -8,7 +17,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -16,10 +25,21 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : null
         }
     }
 }

--- a/mobile/android/key.properties.example
+++ b/mobile/android/key.properties.example
@@ -1,0 +1,17 @@
+# Upload-signing credentials for the Play Store release build.
+#
+# Copy this file to `key.properties` (same directory) and fill in real values.
+# `key.properties` and the keystore itself are gitignored — NEVER commit either.
+#
+# Generate the keystore once (keep it somewhere durable and backed up; losing
+# it means you can no longer push updates under the same upload key):
+#
+#   keytool -genkey -v -keystore ~/keys/pastlives-upload.jks \
+#     -alias upload -keyalg RSA -keysize 2048 -validity 10000
+#
+# Then set the four values below. `storeFile` is an absolute path to the .jks.
+
+storeFile=/home/josh/keys/pastlives-upload.jks
+storePassword=CHANGE_ME
+keyAlias=upload
+keyPassword=CHANGE_ME

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -20,7 +20,10 @@ const config: CapacitorConfig = {
   appName: 'Past Lives',
   webDir: 'www',
   server: {
-    url: 'https://pastlives.app',
+    // Canonical origin. `pastlives.app` 301-redirects here; pointing directly
+    // avoids the redirect hop and keeps the webview origin (and its auth
+    // cookies) unambiguous.
+    url: 'https://members.pastlives.space',
     cleartext: false,
     // --- Local dev against the WSL server ---
     // The emulator/device cannot reach `pastlives.test` or `localhost`.

--- a/plfog/adapters.py
+++ b/plfog/adapters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from allauth.account.adapter import DefaultAccountAdapter
@@ -160,6 +161,34 @@ class AdminRedirectAccountAdapter(DefaultAccountAdapter):
         if surface == "public":
             return reverse("account:overview")
         return reverse("hub_home")
+
+    def generate_login_code(self) -> str:
+        """Issue a deterministic login code for the designated app-store review account.
+
+        App-store reviewers cannot receive our emailed one-time codes: review is
+        asynchronous and they cannot read a member's inbox. When BOTH the
+        ``PLAY_REVIEW_EMAIL`` and ``PLAY_REVIEW_CODE`` env vars are set, the single
+        matching email receives that fixed code instead of a random one, so a
+        reviewer signs in without an inbox (allauth verifies the code locally, so
+        the email never has to arrive).
+
+        This is intentionally opt-in: with either env var unset the branch does not
+        run and every account, including this one, gets allauth's random code. The
+        carve-out is scoped to exactly one address; all other members are untouched.
+        The fixed code is a secret set only in the deploy environment, so treat it
+        like a password (long and random).
+        """
+        review_email = os.environ.get("PLAY_REVIEW_EMAIL", "").strip().lower()
+        review_code = os.environ.get("PLAY_REVIEW_CODE", "").strip()
+        if review_email and review_code:
+            from allauth.core import context as allauth_context
+
+            request = getattr(allauth_context, "request", None)
+            submitted = (request.POST.get("email", "") if request is not None else "").strip().lower()
+            if submitted and submitted == review_email:
+                logger.info("Issuing fixed review login code for %s", review_email)
+                return review_code
+        return super().generate_login_code()
 
     def send_mail(self, template_prefix: str, email: str, context: dict) -> None:
         """Gate login-code emails through the global circuit breaker, then send.

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.38"
+VERSION = "0.23.39"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {

--- a/static/css/privacy.css
+++ b/static/css/privacy.css
@@ -1,0 +1,33 @@
+/* Privacy policy (long-form legal prose) page. */
+.pl-legal {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 1rem 1rem 3rem;
+    line-height: 1.7;
+}
+.pl-legal h1 {
+    font-size: 1.9rem;
+    margin: 0 0 0.25rem;
+}
+.pl-legal__updated {
+    opacity: 0.7;
+    margin: 0 0 2rem;
+    font-size: 0.95rem;
+}
+.pl-legal h2 {
+    font-size: 1.25rem;
+    margin: 2.25rem 0 0.5rem;
+}
+.pl-legal p {
+    margin: 0 0 1rem;
+}
+.pl-legal ul {
+    margin: 0 0 1rem;
+    padding-left: 1.25rem;
+}
+.pl-legal li {
+    margin-bottom: 0.4rem;
+}
+.pl-legal a {
+    color: var(--color-tuscan-yellow, #c8901f);
+}

--- a/templates/core/privacy_policy.html
+++ b/templates/core/privacy_policy.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Privacy Policy — Past Lives Makerspace{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{% static 'css/privacy.css' %}">
+{% endblock %}
+
+{% block content %}
+<article class="pl-legal">
+    <h1>Privacy Policy</h1>
+    <p class="pl-legal__updated">Last updated: July 27, 2026</p>
+
+    <p>
+        This policy explains what information Past Lives Makerspace collects through its
+        member app and website, how we use it, and the choices you have. We keep it
+        short and plain. If anything is unclear, email us at
+        <a href="mailto:info@pastlives.space">info@pastlives.space</a>.
+    </p>
+
+    <h2>Who this covers</h2>
+    <p>
+        This app is the member hub for Past Lives Makerspace, a community workshop in
+        Portland, Oregon. The mobile app shows the same website you use in a browser, so
+        this policy applies whether you use the app or the site.
+    </p>
+
+    <h2>What we collect</h2>
+    <ul>
+        <li><strong>Account.</strong> The email address you sign in with (and any extra addresses you add). We sign you in with a one-time code sent to your email, so we do not store a password.</li>
+        <li><strong>Profile you choose to share.</strong> Your name, phone number, Discord handle, pronouns, photo, and a short about-you. You control what other members can see with a per-field public or hidden toggle on each item.</li>
+        <li><strong>Membership and billing.</strong> Your membership status and plan. Payments are processed by Stripe; your card details go directly to Stripe and are not stored on our servers.</li>
+        <li><strong>Things kept private from other members.</strong> Your legal name, billing details, and emergency contact are used only for running the makerspace and are never shown on your member card.</li>
+        <li><strong>Communications.</strong> Emails we send you (sign-in codes, announcements, class details) and, if you opt in, our newsletter.</li>
+        <li><strong>Notifications.</strong> If you turn on push notifications, we store the subscription your device needs to receive them.</li>
+        <li><strong>Usage and device.</strong> Basic technical data such as your IP address, browser or device type, and pages viewed, through standard server logs and analytics.</li>
+    </ul>
+
+    <h2>How we use it</h2>
+    <ul>
+        <li>To sign you in and run your membership.</li>
+        <li>To show the member directory, guilds, classes, calendar, and announcements.</li>
+        <li>To process payments and send receipts.</li>
+        <li>To send messages you have asked for or that are needed to run the space.</li>
+        <li>To keep the app secure and working, and to understand how it is used.</li>
+    </ul>
+
+    <h2>When we share it</h2>
+    <p>
+        We do not sell your personal information. We share it only with the service
+        providers that help us run the app, and only as needed:
+    </p>
+    <ul>
+        <li><strong>Stripe</strong> — payments and billing.</li>
+        <li><strong>Mailchimp</strong> — our opt-in newsletter.</li>
+        <li><strong>Google Analytics</strong> — anonymous, aggregate usage.</li>
+        <li><strong>Discord</strong> — only if you choose to link your Discord account.</li>
+        <li><strong>Email and hosting providers</strong> — to deliver messages and serve the app.</li>
+    </ul>
+    <p>We may also share information if the law requires it, or to protect the safety of our members and staff.</p>
+
+    <h2>Your choices</h2>
+    <ul>
+        <li>Change what other members see anytime with the public or hidden toggles in your profile settings.</li>
+        <li>Unsubscribe from the newsletter using the link in any newsletter email.</li>
+        <li>Turn push notifications on or off in your settings.</li>
+        <li>Ask us to view, correct, or delete your information by emailing <a href="mailto:info@pastlives.space">info@pastlives.space</a>.</li>
+    </ul>
+
+    <h2>How long we keep it</h2>
+    <p>
+        We keep your information while you are a member and for a reasonable period
+        afterward for records and legal reasons. You can ask us to delete your account
+        at any time.
+    </p>
+
+    <h2>Security</h2>
+    <p>
+        We use reasonable measures to protect your information, including passwordless
+        sign-in. No system is perfectly secure, but we work to keep your data safe.
+    </p>
+
+    <h2>Children</h2>
+    <p>
+        The app is intended for makerspace members. It is not directed at children under
+        13, and we do not knowingly collect their information. If you believe a child has
+        given us information, contact us and we will remove it.
+    </p>
+
+    <h2>Changes</h2>
+    <p>
+        If we update this policy we will change the date above, and we will let members
+        know if the changes are significant.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+        Past Lives Makerspace, Portland, Oregon<br>
+        <a href="mailto:info@pastlives.space">info@pastlives.space</a>
+    </p>
+</article>
+{% endblock %}

--- a/tests/classes/import_service_spec.py
+++ b/tests/classes/import_service_spec.py
@@ -29,6 +29,12 @@ def describe_find_instructor():
         MemberFactory(preferred_name="", full_legal_name="Billy Bims")
         assert _find_instructor("Billy") is None
 
+    def it_refuses_two_active_members_with_the_same_exact_name():
+        # Exact match must also refuse to guess when it is not unique.
+        MemberFactory(preferred_name="Billy", full_legal_name="William Ortega")
+        MemberFactory(preferred_name="Billy", full_legal_name="Billy Roberts")
+        assert _find_instructor("Billy") is None
+
     def it_links_a_unique_substring_match():
         only = MemberFactory(preferred_name="", full_legal_name="Billy O'Brien")
         assert _find_instructor("Billy") == only

--- a/tests/classes/import_service_spec.py
+++ b/tests/classes/import_service_spec.py
@@ -1,0 +1,48 @@
+"""BDD specs for classes.import_service._find_instructor (instructor name matching)."""
+
+import pytest
+
+from classes.import_service import _find_instructor
+from membership.models import Member
+from tests.membership.factories import MemberFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def describe_find_instructor():
+    def it_returns_a_unique_exact_match():
+        billy = MemberFactory(preferred_name="Billy", full_legal_name="William Ortega")
+        assert _find_instructor("Billy") == billy
+
+    def it_matches_case_insensitively():
+        billy = MemberFactory(preferred_name="Billy", full_legal_name="William Ortega")
+        assert _find_instructor("billy") == billy
+
+    def it_prefers_a_unique_exact_match_over_a_fuzzy_namesake():
+        real = MemberFactory(preferred_name="Billy", full_legal_name="William Ortega")
+        MemberFactory(preferred_name="", full_legal_name="Billy Bims")  # only a substring match
+        assert _find_instructor("Billy") == real
+
+    def it_refuses_to_guess_when_a_fragment_is_ambiguous():
+        # The original bug: "Billy" matched two members and silently picked one.
+        MemberFactory(preferred_name="", full_legal_name="Billy O'Brien")
+        MemberFactory(preferred_name="", full_legal_name="Billy Bims")
+        assert _find_instructor("Billy") is None
+
+    def it_links_a_unique_substring_match():
+        only = MemberFactory(preferred_name="", full_legal_name="Billy O'Brien")
+        assert _find_instructor("Billy") == only
+
+    def it_returns_none_when_nothing_matches():
+        MemberFactory(full_legal_name="Jacqueline Sowell")
+        assert _find_instructor("Billy") is None
+
+    def it_ignores_inactive_members_entirely():
+        MemberFactory(preferred_name="Billy", full_legal_name="William Ortega", status=Member.Status.FORMER)
+        assert _find_instructor("Billy") is None
+
+    def it_disambiguates_through_the_active_filter():
+        # Two namesakes, but only one is active → unambiguous → linked.
+        active = MemberFactory(preferred_name="", full_legal_name="Billy O'Brien")
+        MemberFactory(preferred_name="", full_legal_name="Billy Bims", status=Member.Status.SUSPENDED)
+        assert _find_instructor("Billy") == active

--- a/tests/core/management/run_scheduled_tasks_spec.py
+++ b/tests/core/management/run_scheduled_tasks_spec.py
@@ -22,15 +22,16 @@ def _boom_on_voting(cmd, *args, **kwargs):
         raise RuntimeError("kaboom")
 
 
-def _tasks_called(hour: int, side_effect=None, day: int = 1) -> list[str]:
-    """Run the dispatcher at a fixed UTC hour with ``call_command`` mocked; return the dispatched
+def _tasks_called(hour: int, side_effect=None, day: int = 1, minute: int = 0) -> list[str]:
+    """Run the dispatcher at a fixed UTC time with ``call_command`` mocked; return the dispatched
     command names. Pass ``side_effect`` to make a wrapped command raise (failure-path tests).
-    ``day`` picks the January 2026 date — 1 is a Thursday, 5 is a Monday (WEEKLY-gate tests)."""
+    ``day`` picks the January 2026 date — 1 is a Thursday, 5 is a Monday (WEEKLY-gate tests).
+    ``minute`` moves the tick within the hour (dedup-at-a-mid-hour-tick tests)."""
     with (
         patch("core.management.commands.run_scheduled_tasks.call_command", side_effect=side_effect) as cc,
         patch(
             "core.management.commands.run_scheduled_tasks.timezone.now",
-            return_value=datetime(2026, 1, day, hour, 0, tzinfo=UTC),
+            return_value=datetime(2026, 1, day, hour, minute, tzinfo=UTC),
         ),
     ):
         call_command("run_scheduled_tasks")
@@ -211,6 +212,16 @@ def describe_window_deduplication():
             started_at=MONDAY_1300 + timedelta(minutes=1),
         )
         assert "post_weekly_classes_digest" not in _tasks_called(hour=13, day=5)
+
+    def it_dedupes_at_a_mid_hour_tick_against_the_top_of_the_hour():
+        # The :45 tick must still see the :05 success and skip — the window boundary is the
+        # top of the hour, not `now`, which is the whole point of the ``.replace(minute=0)``.
+        ScheduledTaskRunFactory(
+            task_key="post_weekly_classes_digest",
+            status=ScheduledTaskRun.Status.OK,
+            started_at=MONDAY_1300 + timedelta(minutes=5),
+        )
+        assert "post_weekly_classes_digest" not in _tasks_called(hour=13, day=5, minute=45)
 
     def it_skips_a_daily_job_that_already_succeeded_this_window():
         ScheduledTaskRunFactory(

--- a/tests/core/management/run_scheduled_tasks_spec.py
+++ b/tests/core/management/run_scheduled_tasks_spec.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
 
-from core.factories import ScheduledJobStateFactory
+from core.factories import ScheduledJobStateFactory, ScheduledTaskRunFactory
 from core.models import ScheduledTaskRun
 
 # The dispatcher now records each run through ``record_run`` (a ScheduledTaskRun row),
@@ -196,3 +196,53 @@ def describe_bill_tabs_self_gates_when_dispatched():
         call_command("bill_tabs")  # no --force, as the dispatcher invokes it
 
         assert TabCharge.objects.count() == 0
+
+
+def describe_window_deduplication():
+    """DAILY/WEEKLY jobs run once per window, not once per 15-min tick inside the hour."""
+
+    MONDAY_1300 = datetime(2026, 1, 5, 13, 0, tzinfo=UTC)  # day=5 is a Monday
+    THURSDAY_1300 = datetime(2026, 1, 1, 13, 0, tzinfo=UTC)  # day=1 is a Thursday
+
+    def it_skips_a_weekly_job_that_already_succeeded_this_window():
+        ScheduledTaskRunFactory(
+            task_key="post_weekly_classes_digest",
+            status=ScheduledTaskRun.Status.OK,
+            started_at=MONDAY_1300 + timedelta(minutes=1),
+        )
+        assert "post_weekly_classes_digest" not in _tasks_called(hour=13, day=5)
+
+    def it_skips_a_daily_job_that_already_succeeded_this_window():
+        ScheduledTaskRunFactory(
+            task_key="sync_all_sources",
+            status=ScheduledTaskRun.Status.OK,
+            started_at=THURSDAY_1300 + timedelta(minutes=2),
+        )
+        assert "sync_all_sources" not in _tasks_called(hour=13, day=1)
+
+    def it_still_runs_a_weekly_job_after_only_a_failed_run_this_window():
+        # A FAILED run must not block a retry — this is what let the calendar digest
+        # recover on a later tick once its Discord permission was fixed.
+        ScheduledTaskRunFactory(
+            task_key="post_weekly_classes_digest",
+            status=ScheduledTaskRun.Status.FAILED,
+            started_at=MONDAY_1300 + timedelta(minutes=1),
+        )
+        assert "post_weekly_classes_digest" in _tasks_called(hour=13, day=5)
+
+    def it_still_runs_a_weekly_job_whose_only_success_was_a_prior_window():
+        ScheduledTaskRunFactory(
+            task_key="post_weekly_classes_digest",
+            status=ScheduledTaskRun.Status.OK,
+            started_at=MONDAY_1300 - timedelta(minutes=5),  # before the top of this hour
+        )
+        assert "post_weekly_classes_digest" in _tasks_called(hour=13, day=5)
+
+    def it_does_not_dedupe_always_jobs():
+        # ALWAYS jobs must run every tick even with a success logged this hour.
+        ScheduledTaskRunFactory(
+            task_key="auto_complete_orientations",
+            status=ScheduledTaskRun.Status.OK,
+            started_at=datetime(2026, 1, 1, 9, 1, tzinfo=UTC),
+        )
+        assert "auto_complete_orientations" in _tasks_called(hour=9, day=1)

--- a/tests/core/privacy_policy_spec.py
+++ b/tests/core/privacy_policy_spec.py
@@ -1,0 +1,34 @@
+"""BDD specs for the public privacy policy page."""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def describe_privacy_policy():
+    def it_is_reachable_without_login(client: Client):
+        response = client.get(reverse("privacy_policy"))
+
+        assert response.status_code == 200
+
+    def it_renders_the_policy_template(client: Client):
+        response = client.get(reverse("privacy_policy"))
+
+        assert "core/privacy_policy.html" in [t.name for t in response.templates]
+
+    def it_shows_the_contact_email(client: Client):
+        response = client.get(reverse("privacy_policy"))
+
+        assert b"info@pastlives.space" in response.content
+
+    def it_discloses_the_third_party_processors(client: Client):
+        response = client.get(reverse("privacy_policy"))
+
+        for needle in (b"Stripe", b"Mailchimp", b"Google Analytics", b"Discord"):
+            assert needle in response.content
+
+    def it_rejects_non_get_methods(client: Client):
+        response = client.post(reverse("privacy_policy"))
+
+        assert response.status_code == 405

--- a/tests/hub/discord_calendar_posts_spec.py
+++ b/tests/hub/discord_calendar_posts_spec.py
@@ -58,10 +58,9 @@ def _sent_embeds(route: respx.Route) -> list[dict]:
 
 
 def describe_build_weekly_digest_embeds():
-    def it_groups_the_next_seven_days_by_day_with_classes_and_community_events():
+    def it_groups_the_next_seven_days_by_day_with_feed_and_community_events():
         guild = GuildFactory(name="Woodshop")
         _feed_event("Forge Night", days=2, source="guild", guild=guild)
-        _feed_event("Intro to Welding", days=3, source="classes", url="/classes/welding/")
         now = timezone.now()
         CommunityEventFactory(
             community=True,
@@ -74,14 +73,28 @@ def describe_build_weekly_digest_embeds():
         assert len(embeds) == 1
         description = embeds[0]["description"]
         assert "Forge Night" in description
-        assert "Intro to Welding" in description
         assert "Spring Mixer" in description
         # Grouped under each event's own local day header.
         day = timezone.localtime(now + timedelta(days=2)).strftime("%A, %B %-d")
         assert f"**{day}**" in description
 
-    def it_links_items_absolutely_and_footers_to_the_full_calendar():
+    def it_excludes_classes_from_the_events_only_digest():
+        # #public-calendar is events-only; classes belong in the #classes digest.
         _feed_event("Intro to Welding", days=3, source="classes", url="/classes/welding/")
+        now = timezone.now()
+        CommunityEventFactory(
+            community=True,
+            title="Spring Mixer",
+            starts_at=now + timedelta(days=4),
+            ends_at=now + timedelta(days=4, hours=2),
+        )
+
+        description = dcp.build_weekly_digest_embeds(now)[0]["description"]
+        assert "Spring Mixer" in description
+        assert "Intro to Welding" not in description
+
+    def it_links_items_absolutely_and_footers_to_the_full_calendar():
+        _feed_event("Open Forge", days=3, source="general", url="/events/open-forge/")
         now = timezone.now()
         event = CommunityEventFactory(
             community=True,
@@ -91,7 +104,7 @@ def describe_build_weekly_digest_embeds():
         )
 
         description = dcp.build_weekly_digest_embeds(now)[0]["description"]
-        assert f"[Intro to Welding]({settings.MEMBER_BASE_URL}/classes/welding/)" in description
+        assert f"[Open Forge]({settings.MEMBER_BASE_URL}/events/open-forge/)" in description
         assert f"[Spring Mixer]({event.absolute_url})" in description
         assert event.absolute_url.startswith("http")
         assert f"[See the full calendar →]({settings.MEMBER_BASE_URL}/calendar/)" in description
@@ -208,7 +221,6 @@ def describe_announce_new_events():
         route = respx.post(_MESSAGES_URL).mock(return_value=httpx.Response(200, json={}))
         _enable_posts()
         feed = _feed_event("Forge Night", days=2)
-        klass = _feed_event("Intro to Welding", days=3, source="classes", url="/classes/welding/")
         now = timezone.now()
         community = CommunityEventFactory(
             community=True,
@@ -217,17 +229,27 @@ def describe_announce_new_events():
             ends_at=now + timedelta(days=4, hours=2),
         )
 
-        assert dcp.announce_new_events() == 3
-        assert route.call_count == 3  # one compact message per item
+        assert dcp.announce_new_events() == 2
+        assert route.call_count == 2  # one compact message per item
         embeds = _sent_embeds(route)
-        assert [e["title"] for e in embeds] == ["Forge Night", "Intro to Welding", "Spring Mixer"]
-        class_embed = embeds[1]
-        assert class_embed["url"] == f"{settings.MEMBER_BASE_URL}/classes/welding/"
-        assert "New class on the calendar" in class_embed["description"]
-        assert embeds[2]["url"] == community.absolute_url
-        for obj in (feed, klass, community):
+        assert [e["title"] for e in embeds] == ["Forge Night", "Spring Mixer"]
+        assert "New on the calendar" in embeds[0]["description"]
+        assert embeds[1]["url"] == community.absolute_url
+        for obj in (feed, community):
             obj.refresh_from_db()
             assert obj.channel_announced_at is not None
+
+    @respx.mock
+    def it_never_announces_class_events(settings):
+        settings.DISCORD_BOT_TOKEN = "tok"
+        route = respx.post(_MESSAGES_URL).mock(return_value=httpx.Response(200, json={}))
+        _enable_posts()
+        klass = _feed_event("Intro to Welding", days=3, source="classes", url="/classes/welding/")
+
+        assert dcp.announce_new_events() == 0  # classes post to #classes, not #public-calendar
+        assert not route.called
+        klass.refresh_from_db()
+        assert klass.channel_announced_at is None  # left unstamped by the events-only announcer
 
     @respx.mock
     def it_never_announces_the_same_event_twice(settings):

--- a/tests/plfog/adapters_spec.py
+++ b/tests/plfog/adapters_spec.py
@@ -670,6 +670,107 @@ def describe_AdminRedirectAccountAdapter():
             ):
                 adapter.pre_login(request, user, signup=True)  # Should not raise
 
+    def describe_generate_login_code():
+        """App-store review carve-out: one designated email gets a fixed code.
+
+        Everyone else — and every environment without both env vars set — falls
+        through to allauth's random code. The carve-out is proven by patching the
+        base ``generate_login_code`` to a sentinel and asserting delegation.
+        """
+
+        REVIEW_EMAIL = "play-review@pastlives.space"
+        REVIEW_CODE = "PLR-9f3k2m7q"
+
+        def _request(rf, email):
+            """Build the request allauth would have in context during a code request.
+
+            ``email`` of None means a GET with no email field (nothing submitted).
+            """
+            if email is None:
+                return rf.get("/accounts/login/code/")
+            return rf.post("/accounts/login/code/", data={"email": email})
+
+        def _generate(rf, email):
+            """Run generate_login_code with the given request in allauth's context.
+
+            allauth 65 sources the request from ``allauth.core.context``, not the
+            adapter constructor, so the request is injected there (as the real
+            middleware does), mirroring the send_mail specs above.
+            """
+            from allauth.core import context as allauth_context
+
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            adapter = AdminRedirectAccountAdapter()
+            request = _request(rf, email) if email is not ... else None
+            with patch.object(allauth_context, "request", request):
+                return adapter.generate_login_code()
+
+        def _generate_delegating(rf, email):
+            """Same as _generate but with the base random generator stubbed to a sentinel."""
+            from plfog.adapters import AdminRedirectAccountAdapter
+
+            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "generate_login_code", return_value="RANDOM"):
+                return _generate(rf, email)
+
+        def it_returns_the_fixed_code_for_the_review_email(rf, monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
+            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+
+            assert _generate(rf, REVIEW_EMAIL) == REVIEW_CODE
+
+        def it_normalizes_whitespace_and_case_on_both_sides(rf, monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_EMAIL", "  Play-Review@PastLives.Space  ")
+            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+
+            assert _generate(rf, "  play-review@pastlives.space  ") == REVIEW_CODE
+
+        def it_delegates_to_random_for_any_other_email(rf, monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
+            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+
+            assert _generate_delegating(rf, "member@example.com") == "RANDOM"
+
+        def it_delegates_to_random_when_env_is_not_set(rf, monkeypatch):
+            monkeypatch.delenv("PLAY_REVIEW_EMAIL", raising=False)
+            monkeypatch.delenv("PLAY_REVIEW_CODE", raising=False)
+
+            assert _generate_delegating(rf, REVIEW_EMAIL) == "RANDOM"
+
+        def it_delegates_when_only_the_email_env_is_set(rf, monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
+            monkeypatch.delenv("PLAY_REVIEW_CODE", raising=False)
+
+            assert _generate_delegating(rf, REVIEW_EMAIL) == "RANDOM"
+
+        def it_delegates_when_only_the_code_env_is_set(rf, monkeypatch):
+            monkeypatch.delenv("PLAY_REVIEW_EMAIL", raising=False)
+            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+
+            assert _generate_delegating(rf, REVIEW_EMAIL) == "RANDOM"
+
+        def it_delegates_when_there_is_no_request(rf, monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
+            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+
+            # email sentinel ``...`` forces the context request to None
+            assert _generate_delegating(rf, ...) == "RANDOM"
+
+        def it_delegates_when_no_email_is_submitted(rf, monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
+            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+
+            assert _generate_delegating(rf, None) == "RANDOM"  # GET, no email field
+
+        def it_logs_when_issuing_the_review_code(rf, monkeypatch, caplog):
+            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
+            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+
+            with caplog.at_level(logging.INFO, logger="plfog.adapters"):
+                _generate(rf, REVIEW_EMAIL)
+
+            assert "Issuing fixed review login code" in caplog.text
+
     def describe_send_mail():
         def it_adds_dev_message_in_debug_mode(rf, settings):
             from allauth.core import context as allauth_context


### PR DESCRIPTION
Prep for the Google Play (and later iOS) launch. Three self-contained pieces.

## 1. Mobile shell (Capacitor)
- Point `server.url` at `https://members.pastlives.space` (was `pastlives.app`, which 301s there) so the webview origin and its auth cookies are unambiguous.
- Wire release signing via a gitignored `key.properties` (template committed as `key.properties.example`); set `versionName` to `1.0.0`.

## 2. Reviewer sign in (the important one to review)
App stores review asynchronously and cannot read a member inbox, so our passwordless email code is a problem for them. New `generate_login_code` override on the allauth adapter: when BOTH `PLAY_REVIEW_EMAIL` and `PLAY_REVIEW_CODE` env vars are set, that one email gets the fixed code instead of a random one; everyone else still gets allauth's random emailed code.

Safety:
- Off entirely unless both env vars are set (no effect in local/QA).
- Scoped to one address; all other members unaffected.
- Grants only ordinary member access, not admin.
- allauth rate limiting and the login-code circuit breaker still apply.

To enable on prod: set `PLAY_REVIEW_EMAIL` + `PLAY_REVIEW_CODE` in Render, create a plain member for that email.

## 3. Privacy policy
Public `/privacy` page (no login) for the Play Console listing and the Data safety requirement. Content reflects what the app actually collects (accounts/login codes, member-controlled profile fields, Stripe billing, Mailchimp newsletter, Google Analytics, Discord linking, push). Styles live in `static/css/privacy.css` per the no-inline-style-in-extra_head rule.

## Versioning
Bumps `VERSION` to `0.23.39`. **No changelog entry on purpose** — none of this is member-facing yet. The store launch announcement should be added when the app is actually live, not now. Do not run `announce_release` for 0.23.39.

## Test plan
- `tests/plfog/adapters_spec.py` — 9 new specs for `generate_login_code`. 100% coverage on the new method.
- `tests/core/privacy_policy_spec.py` — 5 specs (public 200, template, contact email, third-party processors disclosed, non-GET rejected).
- Full pre-push suite green: ruff check, ruff format, mypy (161 files), no-inline-style check.