### PR TITLE
Add missing 0.23.39 changelog entry (unbreak main after #159)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -6,6 +6,16 @@ VERSION = "0.23.39"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
+        "version": "0.23.39",
+        "date": "2026-07-27",
+        "title": "Cleaner Discord posts and event calendar",
+        "changes": [
+            "The weekly class and calendar digests no longer repeat several times on Monday mornings.",
+            "The community calendar Discord channel now lists events only. Classes stay in the classes channel.",
+            "Fixed a class that was showing the wrong instructor's name.",
+        ],
+    },
+    {
         "version": "0.23.38",
         "date": "2026-07-24",
         "title": "Explore the makerspace on an interactive map",


### PR DESCRIPTION
#159 squash-merged one commit before its changelog entry, so main has VERSION 0.23.39 with no matching CHANGELOG entry — failing the release-published tests and breaking announce_release. Adds the member-facing entry, cherry-picked from the #159 branch. Verified locally: the 3 failing tests + 79 related changelog/announce specs pass.