### PR TITLE
Filter feed-based studio hours off #public-calendar (v0.23.40)

### DIFF
--- a/hub/discord_calendar_posts.py
+++ b/hub/discord_calendar_posts.py
@@ -19,6 +19,7 @@ Google-pushed events are excluded (same UID set the grid uses), and a run posts 
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -74,11 +75,24 @@ def _when(start: datetime, end: datetime, all_day: bool) -> str:
     return f"{day} {_time_of(start)} – {local_end.strftime('%A, %B %-d')} {_time_of(end)}"
 
 
+# Studio hours are ambient noise, never events. A typed CommunityEvent carries the
+# STUDIO_HOURS event type, but a guild's Google-calendar "open studio hours" block comes
+# through as a plain feed event with no type — so match the title too.
+_STUDIO_HOURS_TITLE = "studio hours"
+_STUDIO_HOURS_TITLE_RE = re.compile(re.escape(_STUDIO_HOURS_TITLE), re.IGNORECASE)
+
+
 def _is_studio_hours(item: Any) -> bool:
     """Whether a calendar entry is a standing studio-hours block — ambient noise the
-    digest skips, exactly as the announcer (and the Discord Events sync) skip them."""
+    digest skips, exactly as the announcer (and the Discord Events sync) skip them.
+
+    Catches the typed CommunityEvent (event_type == STUDIO_HOURS) and any feed event whose
+    title reads as studio hours (feed rows carry no event type to key off).
+    """
     from membership.models import CommunityEvent
 
+    if _STUDIO_HOURS_TITLE_RE.search(getattr(item, "title", "") or ""):
+        return True
     backing = getattr(item, "community_event", None)  # CalendarEvent rows have no such attr
     return backing is not None and backing.event_type == CommunityEvent.EventType.STUDIO_HOURS
 
@@ -314,6 +328,8 @@ def announce_new_events() -> int:
         CalendarEvent.objects.filter(channel_announced_at__isnull=True, start_dt__gt=now)
         # #public-calendar is events-only — classes announce to #classes, not here.
         .exclude(source=CalendarEvent.Source.CLASSES)
+        # Feed-based "open studio hours" blocks carry no event type; drop them by title.
+        .exclude(title__icontains=_STUDIO_HOURS_TITLE)
         .exclude(uid__in=_pushed_event_uids())
         .order_by("start_dt")
     )

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.39"
+VERSION = "0.23.40"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.23.39",
+        "version": "0.23.40",
         "date": "2026-07-27",
         "title": "Cleaner Discord posts and event calendar",
         "changes": [
             "The weekly class and calendar digests no longer repeat several times on Monday mornings.",
-            "The community calendar Discord channel now lists events only. Classes stay in the classes channel.",
+            "The community calendar Discord channel now shows events only, so classes and open studio hours no longer clutter it.",
             "Fixed a class that was showing the wrong instructor's name.",
         ],
     },

--- a/tests/hub/discord_calendar_posts_spec.py
+++ b/tests/hub/discord_calendar_posts_spec.py
@@ -143,6 +143,21 @@ def describe_build_weekly_digest_embeds():
         assert "Forge Night" in description
         assert "Wood Guild Studio Hours" not in description
 
+    def it_excludes_a_feed_event_titled_studio_hours():
+        # A guild's Google-calendar "open studio hours" block arrives as a feed event with
+        # no event type — filter it by title so #public-calendar stays real events only.
+        now = timezone.now()
+        _feed_event("Art Framing open studio hours", days=2)
+        CommunityEventFactory(
+            community=True,
+            title="Spring Mixer",
+            starts_at=now + timedelta(days=3),
+            ends_at=now + timedelta(days=3, hours=2),
+        )
+        description = dcp.build_weekly_digest_embeds(now)[0]["description"]
+        assert "Spring Mixer" in description
+        assert "Art Framing open studio hours" not in description
+
 
 def describe_batch_embeds():
     def it_splits_batches_under_the_combined_six_thousand_char_message_cap():
@@ -284,6 +299,18 @@ def describe_announce_new_events():
 
         assert dcp.announce_new_events() == 0
         assert not route.called
+
+    @respx.mock
+    def it_never_announces_a_feed_event_titled_studio_hours(settings):
+        settings.DISCORD_BOT_TOKEN = "tok"
+        route = respx.post(_MESSAGES_URL).mock(return_value=httpx.Response(200, json={}))
+        _enable_posts()
+        hours = _feed_event("Woodshop open studio hours", days=2)
+
+        assert dcp.announce_new_events() == 0
+        assert not route.called
+        hours.refresh_from_db()
+        assert hours.channel_announced_at is None
 
     @respx.mock
     def it_caps_at_ten_posts_and_silently_stamps_the_overflow(settings):


### PR DESCRIPTION
Follow-up to the events-only #public-calendar fix. The studio-hours filter only caught CommunityEvents typed STUDIO_HOURS; a guild's Google-calendar open-studio-hours block comes through as a plain feed event with no type, so it still landed on the members calendar digest and the per-event announcer. Match the title too, so both drop feed-based studio hours. Re-stamps the events-only changelog entry to 0.23.40. Verified locally: 29 calendar-post specs plus the release-published tests pass.