### PR TITLE
[map] Two-finger swipe pans the Spaces map (v0.23.41)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.40"
+VERSION = "0.23.41"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.41",
+        "date": "2026-07-27",
+        "title": "Two-finger swipe to move around the Spaces map",
+        "changes": [
+            "On the Spaces map, a two-finger trackpad swipe (or a scroll) now pans around the floor, "
+            "the way you'd expect on a Mac. Pinch or Ctrl+scroll still zooms, and the plus and minus "
+            "buttons work as before.",
+        ],
+    },
     {
         "version": "0.23.40",
         "date": "2026-07-27",

--- a/static/js/space_map.js
+++ b/static/js/space_map.js
@@ -166,11 +166,20 @@
             },
 
             onWheel: function (event) {
-                if (event.deltaY < 0) {
-                    this.zoomIn();
-                } else {
-                    this.zoomOut();
+                // Trackpad pinch (browsers report it as a ctrl-wheel) and Ctrl+wheel zoom;
+                // a plain two-finger swipe pans, matching native trackpad behaviour. The
+                // +/- buttons remain for explicit zoom. @wheel.prevent stops the page scroll.
+                if (event.ctrlKey) {
+                    if (event.deltaY < 0) {
+                        this.zoomIn();
+                    } else {
+                        this.zoomOut();
+                    }
+                    return;
                 }
+                this.tx -= event.deltaX;
+                this.ty -= event.deltaY;
+                this.clampPan();
             },
 
             // --- The accessible list ---


### PR DESCRIPTION
On the Spaces map, a trackpad two-finger swipe zoomed instead of panning, because `onWheel` treated every wheel event as zoom.

Now `onWheel` splits the two gestures the way native trackpad apps do:
- **Pinch / Ctrl+scroll** (`event.ctrlKey`) → zoom (unchanged behavior)
- **Plain two-finger swipe / scroll** → pan, translating by `deltaX`/`deltaY` and clamped by the existing `clampPan()`

The `@wheel.prevent` binding is already non-passive, so the page never scrolls. The +/- buttons and drag-to-pan are untouched. One-file JS change (`static/js/space_map.js`) plus the version bump.

**Testing note:** the map is Alpine JS with no JS test runner in this repo, so there's no automated test for the wheel behavior — verified by `node --check` (syntax) and by the logic. Worth a quick visual check on the Spaces page (trackpad swipe should pan, pinch should zoom). If the pan feels inverted for anyone's scroll settings, it's a one-line sign flip on the `deltaX/deltaY`.

https://claude.ai/code/session_01LbJb3Liykd4qBVLsHxU7iW