### PR TITLE
[members] Direct Add-member + tidy expired invites (v0.23.41)

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -517,6 +517,19 @@ class InviteManager(models.Manager["Invite"]):
             models.Q(accepted_at__isnull=True) | models.Q(accepted_at__gte=recent_accept)
         ).select_related("invited_by", "member")
 
+    def clear_expired(self) -> int:
+        """Revoke every currently-expired invite in one pass; return how many were cleared.
+
+        Each invite goes through :meth:`Invite.revoke`, so its placeholder Member is
+        cleaned up and a ``MEMBER_INVITE_REVOKED`` activity is logged, exactly as a
+        one-off revoke would. Expired invites are un-accepted by definition, so revoke
+        never raises here.
+        """
+        expired = list(self.expired())
+        for invite in expired:
+            invite.revoke()
+        return len(expired)
+
 
 class Invite(models.Model):
     """Tracks email invitations sent by admins for invite-only registration."""

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -306,6 +306,12 @@ urlpatterns = [
     path("manage/voting/settings/", views.voting_settings, name="hub_admin_voting_settings"),
     path("manage/members/", views.admin_members, name="hub_admin_members"),
     path("manage/members/invite/", views.admin_member_invite, name="hub_admin_member_invite"),
+    path("manage/members/create/", views.admin_member_create, name="hub_admin_member_create"),
+    path(
+        "manage/members/invites/clear-expired/",
+        views.admin_invite_clear_expired,
+        name="hub_admin_invite_clear_expired",
+    ),
     path(
         "manage/members/invites/<int:pk>/resend/",
         views.admin_invite_resend,

--- a/hub/views.py
+++ b/hub/views.py
@@ -3997,8 +3997,7 @@ def admin_members(request: HttpRequest) -> HttpResponse:
     """
     from django.core.paginator import Paginator
 
-    from core.models import Invite
-    from membership.forms import InviteMemberForm
+    from membership.forms import AddMemberForm, InviteMemberForm
 
     ctx = _get_hub_context(request)
     status_filter = request.GET.get("status", "active")
@@ -4069,8 +4068,9 @@ def admin_members(request: HttpRequest) -> HttpResponse:
             "status_choices": Member.Status.choices,
             "role_choices": Member.FogRole.choices,
             "type_choices": Member.MemberType.choices,
-            "invites": Invite.objects.for_management_panel(),
             "invite_form": InviteMemberForm(),
+            "add_form": AddMemberForm(),
+            **_invites_panel_context(),
         },
     )
 
@@ -4372,15 +4372,26 @@ def admin_user_email_toggle_verified(request: HttpRequest, user_pk: int, email_p
     return redirect("hub_admin_user_edit", user_pk=user.pk)
 
 
-def _render_invites_panel(request: HttpRequest) -> HttpResponse:
-    """Render the swappable outstanding-invites panel with a fresh queryset."""
+def _invites_panel_context() -> dict[str, Any]:
+    """Split the invites card into its default rows and the collapsed expired ones.
+
+    ``invites`` are what show by default (pending + recently-accepted); ``expired_invites``
+    are un-accepted invites past the expiry window, hidden behind a count so the panel
+    isn't a wall of dead invites. Both derive from the one ``for_management_panel`` query,
+    partitioned in Python via the cheap ``is_expired`` property (no extra DB hits).
+    """
     from core.models import Invite
 
-    return render(
-        request,
-        "hub/admin/_invites_panel.html",
-        {"invites": Invite.objects.for_management_panel()},
-    )
+    panel = list(Invite.objects.for_management_panel())
+    return {
+        "invites": [invite for invite in panel if not invite.is_expired],
+        "expired_invites": [invite for invite in panel if invite.is_expired],
+    }
+
+
+def _render_invites_panel(request: HttpRequest) -> HttpResponse:
+    """Render the swappable outstanding-invites panel with a fresh queryset."""
+    return render(request, "hub/admin/_invites_panel.html", _invites_panel_context())
 
 
 @fog_admin_required
@@ -4417,6 +4428,30 @@ def admin_member_invite(request: HttpRequest) -> HttpResponse:
 
 @fog_admin_required
 @require_POST
+def admin_member_create(request: HttpRequest) -> HttpResponse:
+    """Create a member directly (HTMX), no invite and no email.
+
+    Mirrors the invite flow's gating and POST-only shape. On a valid form the member
+    is created and we hand the browser a full navigation back to the members list
+    (``HX-Redirect``) carrying a success message, so the new person shows up in the
+    table straight away. On a validation error we re-render just the form partial
+    (200, swaps itself) so the typed values and field errors survive.
+    """
+    from membership.forms import AddMemberForm
+
+    form = AddMemberForm(request.POST)
+    if not form.is_valid():
+        return render(request, "hub/admin/_add_member_form.html", {"add_form": form})
+
+    member = form.create_member()
+    messages.success(request, f"Added {member.display_name} to the roster.")
+    response = HttpResponse(status=204)
+    response["HX-Redirect"] = reverse("hub_admin_members")
+    return response
+
+
+@fog_admin_required
+@require_POST
 def admin_invite_resend(request: HttpRequest, pk: int) -> HttpResponse:
     """Re-fire the invite email for an un-accepted invite (HTMX) — refreshed panel + toast."""
     from core.models import Invite
@@ -4447,6 +4482,19 @@ def admin_invite_revoke(request: HttpRequest, pk: int) -> HttpResponse:
     except ValueError as exc:
         messages.error(request, str(exc))
     return redirect("hub_admin_members")
+
+
+@fog_admin_required
+@require_POST
+def admin_invite_clear_expired(request: HttpRequest) -> HttpResponse:
+    """Revoke every expired invite at once (HTMX) — refreshed panel + toast."""
+    from core.models import Invite
+
+    count = Invite.objects.clear_expired()
+    response = _render_invites_panel(request)
+    noun = "invite" if count == 1 else "invites"
+    trigger_toast(response, f"Cleared {count} expired {noun}.", "success")
+    return response
 
 
 def _legacy_instructor_sync_status() -> tuple[list[dict[str, object]], int]:

--- a/membership/forms.py
+++ b/membership/forms.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ValidationError
 
 from core.models import Invite
 
-from .models import Member
+from .models import Member, MembershipPlan
 
 
 class MemberAdminForm(forms.ModelForm):
@@ -38,6 +38,67 @@ class InviteMemberForm(forms.Form):
         if Invite.objects.filter(email__iexact=email, accepted_at__isnull=True).exists():
             raise ValidationError("A pending invite for this email already exists.")
         return email
+
+
+class AddMemberForm(forms.Form):
+    """Create a member directly, without the invite-plus-email flow.
+
+    Staff use this to add someone straight to the roster. No invite is created and
+    no email is sent; the person signs in later with a passwordless login code (an
+    ACTIVE member is given a login-ready account automatically on save, and any
+    other status has its User auto-created from this email on first sign-in — see
+    ``plfog.adapters.AutoCreateUserLoginCodeForm``).
+    """
+
+    full_legal_name = forms.CharField(
+        max_length=255,
+        label="Full legal name",
+        help_text="The name on their membership record.",
+        error_messages={"required": "Enter the member's full legal name."},
+    )
+    email = forms.EmailField(
+        label="Email",
+        help_text="Where their one-time login code will be sent. No invite email goes out.",
+    )
+    membership_plan = forms.ModelChoiceField(
+        queryset=MembershipPlan.objects.all(),
+        label="Membership plan",
+        help_text="Which plan this member is on.",
+    )
+    preferred_name = forms.CharField(
+        max_length=255,
+        required=False,
+        label="Preferred name",
+        help_text="What they like to be called, if different (optional).",
+    )
+    status = forms.ChoiceField(
+        choices=Member.Status.choices,
+        initial=Member.Status.ACTIVE,
+        label="Status",
+        help_text="Membership status. Active members get a login-ready account right away.",
+    )
+
+    def clean_email(self) -> str:
+        email = self.cleaned_data["email"]
+        if Member.objects.filter(_pre_signup_email__iexact=email).exclude(status=Member.Status.INVITED).exists():
+            raise ValidationError("A member with this email already exists.")
+        return email
+
+    def create_member(self) -> Member:
+        """Create and return the Member from validated data.
+
+        Must be called only after ``is_valid()``. The email is stored on
+        ``_pre_signup_email``; an ACTIVE member is auto-provisioned a linked,
+        passwordless User by the ``auto_provision_member_user`` signal (silently,
+        no email), so no invite flow is involved.
+        """
+        return Member.objects.create(
+            full_legal_name=self.cleaned_data["full_legal_name"],
+            _pre_signup_email=self.cleaned_data["email"],
+            preferred_name=self.cleaned_data["preferred_name"],
+            membership_plan=self.cleaned_data["membership_plan"],
+            status=self.cleaned_data["status"],
+        )
 
 
 class AddEmailAliasForm(forms.Form):

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,26 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.40"
+VERSION = "0.23.41"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.41",
+        "date": "2026-07-27",
+        "title": "Add members directly, and a tidier invites list",
+        "changes": [
+            (
+                "Organizers can now add a new member straight from Manage Members, without sending an "
+                "invite first. The new person can sign in right away with a one-time login code emailed "
+                "to them; there's no password to set and no invite step to wait on."
+            ),
+            (
+                "The invites list stays tidy: expired invites are tucked behind a count instead of piling "
+                "up, and a single Clear expired button clears them all at once. Resend and Revoke still "
+                "work for anything shown."
+            ),
+        ],
+    },
     {
         "version": "0.23.40",
         "date": "2026-07-27",

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -450,6 +450,11 @@ a:hover { color: var(--hub-link-hover); }
     gap: 0.75rem;
     margin-bottom: 1rem;
 }
+.pl-invite-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
 .pl-invite-form {
     margin-bottom: 1.25rem;
 }
@@ -457,6 +462,30 @@ a:hover { color: var(--hub-link-hover); }
     display: flex;
     gap: 0.5rem;
     margin-top: 0.75rem;
+}
+.pl-invite-hint {
+    margin: 0.75rem 0 0;
+    font-size: 0.8125rem;
+    color: var(--hub-text-muted);
+    line-height: 1.5;
+}
+.pl-invite-expired {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+}
+.pl-invite-expired__bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+.pl-invite-expired__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 }
 .pl-invite-list {
     display: flex;

--- a/templates/hub/admin/_add_member_form.html
+++ b/templates/hub/admin/_add_member_form.html
@@ -1,0 +1,24 @@
+{% comment %}
+Direct "Add member" form for the Manage Members page. HTMX form that targets and
+swaps itself (outerHTML): on a validation error the view re-renders this partial so
+typed values + field errors survive; on success the view returns HX-Redirect back to
+the members list with a success message. Lives inside the card's x-data, so the
+Cancel button's `showAdd = false` still resolves after an afterSettle re-init.
+{% endcomment %}
+<form class="pl-invite-form" hx-post="{% url 'hub_admin_member_create' %}"
+      hx-target="this" hx-swap="outerHTML">
+  {% csrf_token %}
+  {% include "components/form_field.html" with field=add_form.full_legal_name %}
+  {% include "components/form_field.html" with field=add_form.preferred_name %}
+  {% include "components/form_field.html" with field=add_form.email %}
+  {% include "components/form_field.html" with field=add_form.membership_plan %}
+  {% include "components/form_field.html" with field=add_form.status %}
+  <p class="pl-invite-hint">
+    No invite email is sent. The member signs in with a one-time code emailed to them,
+    and their login is set up automatically the first time they sign in.
+  </p>
+  <div class="pl-invite-form__actions">
+    <button type="submit" class="hub-btn hub-btn--sm hub-btn--primary" hx-disabled-elt="this">Add member</button>
+    <button type="button" class="hub-btn hub-btn--sm hub-btn--ghost" @click="showAdd = false">Cancel</button>
+  </div>
+</form>

--- a/templates/hub/admin/_invite_row.html
+++ b/templates/hub/admin/_invite_row.html
@@ -1,0 +1,40 @@
+{% comment %}
+One invite row for the Manage Members invites panel. Used for both the default
+(pending + recently-accepted) rows and the collapsed expired rows — the Resend /
+Revoke actions render for any un-accepted invite (``is_pending``), so an expired
+invite keeps them. Expects ``invite`` in context.
+{% endcomment %}
+<div class="pl-invite-row">
+  <div class="pl-invite-row__main">
+    <span class="pl-invite-row__email">{{ invite.email }}</span>
+    <span class="pl-invite-row__meta">
+      Sent {{ invite.sent_at|timesince }} ago
+      {% if not invite.is_pending %}<span class="pl-invite-row__joined">· Joined {{ invite.accepted_at|timesince }} ago</span>{% endif %}
+    </span>
+  </div>
+  {% if invite.status == 'accepted' %}
+  <span class="hub-pill hub-pill--ok">{{ invite.status_label }}</span>
+  {% elif invite.status == 'expired' %}
+  <span class="hub-pill hub-pill--danger">{{ invite.status_label }}</span>
+  {% else %}
+  <span class="hub-pill hub-pill--neutral">{{ invite.status_label }}</span>
+  {% endif %}
+  {% if invite.is_pending %}
+  {% with pk_s=invite.pk|stringformat:"s" %}
+  {% url 'hub_admin_invite_revoke' invite.pk as revoke_url %}
+  <div class="pl-invite-row__actions">
+    <button type="button" class="hub-btn hub-btn--sm"
+            hx-post="{% url 'hub_admin_invite_resend' invite.pk %}"
+            hx-target="#invites-list" hx-swap="outerHTML"
+            hx-disabled-elt="this">
+      Resend
+    </button>
+    <button type="button" class="hub-btn hub-btn--sm hub-btn--danger"
+            @click="$dispatch('open-confirm', 'revoke-invite-{{ invite.pk }}')">
+      Revoke
+    </button>
+  </div>
+  {% include "components/confirm_modal.html" with confirm_id="revoke-invite-"|add:pk_s confirm_title="Revoke invite?" confirm_message="Revoke the invite for "|add:invite.email|add:"? Their signup link will stop working and you can re-invite them later." confirm_action_url=revoke_url confirm_button_text="Revoke invite" %}
+  {% endwith %}
+  {% endif %}
+</div>

--- a/templates/hub/admin/_invites_panel.html
+++ b/templates/hub/admin/_invites_panel.html
@@ -1,47 +1,42 @@
 {% comment %}
 Outstanding-invites list for the Manage Members page. Swappable HTMX region:
-the root #invites-list is replaced (outerHTML) on every send/resend so the new,
-removed, or refreshed row appears. Flex rows (not a table) so it reflows on mobile
-with no horizontal scroll. Status pill + per-row Resend (non-destructive, no modal)
-and Revoke (destructive, confirm_modal) come straight off the Invite model.
+the root #invites-list is replaced (outerHTML) on every send/resend/clear so the
+new, removed, or refreshed row appears. Flex rows (not a table) so it reflows on
+mobile with no horizontal scroll.
+
+Default rows (`invites`) are pending + recently-accepted; expired invites are kept
+out of the default wall and collapsed behind a count, still each with Resend/Revoke,
+plus a one-click "Clear expired" that revokes them all. Per-row markup lives in
+_invite_row.html so both lists stay identical.
 {% endcomment %}
 <div id="invites-list" class="pl-invite-list">
   {% for invite in invites %}
-  <div class="pl-invite-row">
-    <div class="pl-invite-row__main">
-      <span class="pl-invite-row__email">{{ invite.email }}</span>
-      <span class="pl-invite-row__meta">
-        Sent {{ invite.sent_at|timesince }} ago
-        {% if not invite.is_pending %}<span class="pl-invite-row__joined">· Joined {{ invite.accepted_at|timesince }} ago</span>{% endif %}
-      </span>
-    </div>
-    {% if invite.status == 'accepted' %}
-    <span class="hub-pill hub-pill--ok">{{ invite.status_label }}</span>
-    {% elif invite.status == 'expired' %}
-    <span class="hub-pill hub-pill--danger">{{ invite.status_label }}</span>
-    {% else %}
-    <span class="hub-pill hub-pill--neutral">{{ invite.status_label }}</span>
+    {% include "hub/admin/_invite_row.html" %}
+  {% empty %}
+    {% if not expired_invites %}
+    <p class="pl-invite-empty">No outstanding invites. Use <strong>+ Invite a member</strong> to send one.</p>
     {% endif %}
-    {% if invite.is_pending %}
-    {% with pk_s=invite.pk|stringformat:"s" %}
-    {% url 'hub_admin_invite_revoke' invite.pk as revoke_url %}
-    <div class="pl-invite-row__actions">
-      <button type="button" class="hub-btn hub-btn--sm"
-              hx-post="{% url 'hub_admin_invite_resend' invite.pk %}"
-              hx-target="#invites-list" hx-swap="outerHTML"
-              hx-disabled-elt="this">
-        Resend
+  {% endfor %}
+
+  {% if expired_invites %}
+  <div class="pl-invite-expired" x-data="{ showExpired: false }">
+    <div class="pl-invite-expired__bar">
+      <button type="button" class="hub-btn hub-btn--sm hub-btn--ghost" @click="showExpired = !showExpired">
+        <span x-show="!showExpired">Show {{ expired_invites|length }} expired invite{{ expired_invites|length|pluralize }}</span>
+        <span x-show="showExpired" x-cloak>Hide expired invites</span>
       </button>
       <button type="button" class="hub-btn hub-btn--sm hub-btn--danger"
-              @click="$dispatch('open-confirm', 'revoke-invite-{{ invite.pk }}')">
-        Revoke
+              @click="$dispatch('open-confirm', 'clear-expired-invites')">
+        Clear expired
       </button>
     </div>
-    {% include "components/confirm_modal.html" with confirm_id="revoke-invite-"|add:pk_s confirm_title="Revoke invite?" confirm_message="Revoke the invite for "|add:invite.email|add:"? Their signup link will stop working and you can re-invite them later." confirm_action_url=revoke_url confirm_button_text="Revoke invite" %}
-    {% endwith %}
-    {% endif %}
+    <div x-show="showExpired" x-cloak class="pl-invite-expired__list">
+      {% for invite in expired_invites %}
+        {% include "hub/admin/_invite_row.html" %}
+      {% endfor %}
+    </div>
+    {% url 'hub_admin_invite_clear_expired' as clear_url %}
+    {% include "components/confirm_modal.html" with confirm_id="clear-expired-invites" confirm_title="Clear expired invites?" confirm_message="This permanently removes every expired invite. You can invite anyone again later." confirm_hx_post=clear_url confirm_hx_target="#invites-list" confirm_button_text="Clear expired" %}
   </div>
-  {% empty %}
-  <p class="pl-invite-empty">No outstanding invites. Use <strong>+ Invite a member</strong> to send one.</p>
-  {% endfor %}
+  {% endif %}
 </div>

--- a/templates/hub/admin/members.html
+++ b/templates/hub/admin/members.html
@@ -37,10 +37,17 @@
 {% endblock %}
 
 {% block content %}
-<div class="hub-card" x-data="{ showInvite: false }">
+<div class="hub-card" x-data="{ showInvite: false, showAdd: false }">
   <div class="pl-invite-card__header">
-    <h2 class="hub-detail-label" style="margin:0;">Invites</h2>
-    <button type="button" class="hub-btn hub-btn--sm hub-btn--primary" @click="showInvite = !showInvite">+ Invite a member</button>
+    <h2 class="hub-detail-label" style="margin:0;">Members &amp; invites</h2>
+    <div class="pl-invite-card__actions">
+      <button type="button" class="hub-btn hub-btn--sm hub-btn--primary" @click="showAdd = !showAdd; showInvite = false">+ Add member</button>
+      <button type="button" class="hub-btn hub-btn--sm" @click="showInvite = !showInvite; showAdd = false">+ Invite a member</button>
+    </div>
+  </div>
+
+  <div x-show="showAdd" x-cloak>
+    {% include "hub/admin/_add_member_form.html" %}
   </div>
 
   <form class="pl-invite-form" x-show="showInvite" x-cloak

--- a/tests/core/models_spec.py
+++ b/tests/core/models_spec.py
@@ -347,6 +347,49 @@ def describe_Invite():
             assert accepted not in Invite.objects.pending()
             assert accepted not in Invite.objects.expired()
 
+    def describe_clear_expired():
+        def it_revokes_every_expired_invite_and_returns_the_count(admin_user):
+            expired_a = Invite.objects.create(email="ea@example.com", invited_by=admin_user)
+            expired_b = Invite.objects.create(email="eb@example.com", invited_by=admin_user)
+            Invite.objects.filter(pk__in=[expired_a.pk, expired_b.pk]).update(
+                created_at=timezone.now() - timedelta(days=30)
+            )
+            fresh = Invite.objects.create(email="fresh@example.com", invited_by=admin_user)
+
+            cleared = Invite.objects.clear_expired()
+
+            assert cleared == 2
+            assert not Invite.objects.filter(pk=expired_a.pk).exists()
+            assert not Invite.objects.filter(pk=expired_b.pk).exists()
+            assert Invite.objects.filter(pk=fresh.pk).exists()
+
+        def it_returns_zero_when_nothing_is_expired(admin_user):
+            Invite.objects.create(email="fresh@example.com", invited_by=admin_user)
+            assert Invite.objects.clear_expired() == 0
+
+        def it_leaves_accepted_invites_untouched(admin_user):
+            accepted = Invite.objects.create(email="acc@example.com", invited_by=admin_user)
+            Invite.objects.filter(pk=accepted.pk).update(created_at=timezone.now() - timedelta(days=30))
+            accepted.refresh_from_db()
+            accepted.mark_accepted()
+            assert Invite.objects.clear_expired() == 0
+            assert Invite.objects.filter(pk=accepted.pk).exists()
+
+        def it_deletes_the_placeholder_member_and_logs_activity(admin_user):
+            MembershipPlanFactory()
+            with patch("core.email.send_mail"):
+                invite = Invite.create_and_send(email="ghost@example.com", invited_by=admin_user)
+            aged = timezone.now() - timedelta(days=30)
+            Invite.objects.filter(pk=invite.pk).update(created_at=aged, last_sent_at=aged)
+            member_pk = invite.member_id
+            SiteActivity.objects.all().delete()
+
+            cleared = Invite.objects.clear_expired()
+
+            assert cleared == 1
+            assert not Member.objects.filter(pk=member_pk).exists()
+            assert SiteActivity.objects.filter(kind=SiteActivity.Kind.MEMBER_INVITE_REVOKED).exists()
+
     def describe_for_management_panel():
         def it_includes_un_accepted(admin_user):
             invite = Invite.objects.create(email="u@example.com", invited_by=admin_user)

--- a/tests/hub/admin_views_spec.py
+++ b/tests/hub/admin_views_spec.py
@@ -80,7 +80,7 @@ def describe_admin_members():
     def it_renders_the_invites_card(client):
         _create_superuser(client)
         response = client.get(reverse("hub_admin_members"))
-        assert b"Invites" in response.content
+        assert b"Members &amp; invites" in response.content
         assert b'id="invites-list"' in response.content
         assert "invites" in response.context
         assert "invite_form" in response.context
@@ -278,6 +278,80 @@ def describe_admin_members():
         with django_assert_max_num_queries(budget):
             client.get(reverse("hub_admin_members") + "?status=all")
 
+    def it_shows_the_add_member_affordance(client):
+        _create_superuser(client, username="addaff")
+        response = client.get(reverse("hub_admin_members"))
+        assert b"+ Add member" in response.content
+        assert b'name="full_legal_name"' in response.content
+
+    def it_collapses_expired_invites_behind_a_count(client):
+        admin = _create_superuser(client, username="expcol")
+        expired = Invite.objects.create(email="stale@x.com", invited_by=admin)
+        Invite.objects.filter(pk=expired.pk).update(created_at=timezone.now() - timedelta(days=30))
+        response = client.get(reverse("hub_admin_members"))
+        assert b"Show 1 expired invite" in response.content
+        assert b"Clear expired" in response.content
+
+
+def describe_admin_member_create():
+    def _valid_post(plan, **overrides):
+        data = {
+            "full_legal_name": "New Member",
+            "email": "created@x.com",
+            "membership_plan": str(plan.pk),
+            "preferred_name": "",
+            "status": Member.Status.ACTIVE,
+        }
+        data.update(overrides)
+        return data
+
+    def it_requires_login(client):
+        response = client.post(reverse("hub_admin_member_create"), {})
+        assert response.status_code == 302
+
+    def it_forbids_plain_members(client):
+        user = _create_member_user(username="mc1")
+        client.login(username=user.username, password="p")
+        response = client.post(reverse("hub_admin_member_create"), {})
+        assert response.status_code == 403
+
+    def it_rejects_get(client):
+        _create_superuser(client, username="createadmin")
+        response = client.get(reverse("hub_admin_member_create"))
+        assert response.status_code == 405
+
+    def it_creates_a_member_and_redirects_to_the_list(client):
+        plan = MembershipPlanFactory()
+        _create_superuser(client, username="createadmin")
+        response = client.post(reverse("hub_admin_member_create"), _valid_post(plan))
+        assert response.status_code == 204
+        assert response["HX-Redirect"] == reverse("hub_admin_members")
+        member = Member.objects.get(_pre_signup_email="created@x.com")
+        assert member.full_legal_name == "New Member"
+        assert member.status == Member.Status.ACTIVE
+
+    def it_does_not_send_any_email(client, mailoutbox):
+        plan = MembershipPlanFactory()
+        _create_superuser(client, username="createadmin")
+        client.post(reverse("hub_admin_member_create"), _valid_post(plan))
+        assert len(mailoutbox) == 0
+
+    def it_re_renders_the_form_with_errors_for_a_duplicate_email(client):
+        plan = MembershipPlanFactory()
+        _create_superuser(client, username="createadmin")
+        MemberFactory(_pre_signup_email="dupe@x.com", status=Member.Status.ACTIVE)
+        response = client.post(reverse("hub_admin_member_create"), _valid_post(plan, email="dupe@x.com"))
+        assert response.status_code == 200
+        assert b"A member with this email already exists." in response.content
+        assert not Member.objects.filter(_pre_signup_email="dupe@x.com", full_legal_name="New Member").exists()
+
+    def it_re_renders_the_form_with_errors_for_a_blank_name(client):
+        plan = MembershipPlanFactory()
+        _create_superuser(client, username="createadmin")
+        response = client.post(reverse("hub_admin_member_create"), _valid_post(plan, full_legal_name="   "))
+        assert response.status_code == 200
+        assert b"Enter the member" in response.content
+
 
 def describe_admin_member_invite():
     def it_requires_login(client):
@@ -385,6 +459,43 @@ def describe_admin_invite_revoke():
         response = client.post(reverse("hub_admin_invite_revoke", args=[invite.pk]), follow=True)
         assert Invite.objects.filter(pk=invite.pk).exists()
         assert b"already been accepted" in response.content
+
+
+def describe_admin_invite_clear_expired():
+    def it_requires_login(client):
+        response = client.post(reverse("hub_admin_invite_clear_expired"))
+        assert response.status_code == 302
+
+    def it_forbids_plain_members(client):
+        user = _create_member_user(username="ce1")
+        client.login(username=user.username, password="p")
+        response = client.post(reverse("hub_admin_invite_clear_expired"))
+        assert response.status_code == 403
+
+    def it_rejects_get(client):
+        _create_superuser(client, username="clearadmin")
+        response = client.get(reverse("hub_admin_invite_clear_expired"))
+        assert response.status_code == 405
+
+    def it_clears_expired_invites_and_returns_the_panel(client):
+        admin = _create_superuser(client, username="clearadmin")
+        expired = Invite.objects.create(email="old@x.com", invited_by=admin)
+        Invite.objects.filter(pk=expired.pk).update(created_at=timezone.now() - timedelta(days=30))
+        fresh = Invite.objects.create(email="fresh@x.com", invited_by=admin)
+        response = client.post(reverse("hub_admin_invite_clear_expired"))
+        assert response.status_code == 200
+        assert "Cleared 1 expired invite" in response["HX-Trigger"]
+        assert not Invite.objects.filter(pk=expired.pk).exists()
+        assert Invite.objects.filter(pk=fresh.pk).exists()
+        assert b"fresh@x.com" in response.content
+
+    def it_pluralizes_the_toast_for_multiple_expired(client):
+        admin = _create_superuser(client, username="clearadmin")
+        a = Invite.objects.create(email="a@x.com", invited_by=admin)
+        b = Invite.objects.create(email="b@x.com", invited_by=admin)
+        Invite.objects.filter(pk__in=[a.pk, b.pk]).update(created_at=timezone.now() - timedelta(days=30))
+        response = client.post(reverse("hub_admin_invite_clear_expired"))
+        assert "Cleared 2 expired invites" in response["HX-Trigger"]
 
 
 def describe_admin_member_edit_role_dispatch():

--- a/tests/membership/forms_spec.py
+++ b/tests/membership/forms_spec.py
@@ -1,15 +1,104 @@
-"""BDD-style tests for membership.forms — InviteMemberForm."""
+"""BDD-style tests for membership.forms — InviteMemberForm and AddMemberForm."""
 
 from __future__ import annotations
 
 import pytest
 
 from core.models import Invite
-from membership.forms import InviteMemberForm
+from membership.forms import AddMemberForm, InviteMemberForm
 from membership.models import Member
 from tests.membership.factories import MemberFactory, MembershipPlanFactory
 
 pytestmark = pytest.mark.django_db
+
+
+def describe_AddMemberForm():
+    def _valid_data(plan, **overrides):
+        data = {
+            "full_legal_name": "Jane Maker",
+            "email": "jane@example.com",
+            "membership_plan": str(plan.pk),
+            "preferred_name": "",
+            "status": Member.Status.ACTIVE,
+        }
+        data.update(overrides)
+        return data
+
+    def it_accepts_valid_data():
+        plan = MembershipPlanFactory()
+        form = AddMemberForm(data=_valid_data(plan))
+        assert form.is_valid(), form.errors
+
+    def it_defaults_status_to_active():
+        assert AddMemberForm().fields["status"].initial == Member.Status.ACTIVE
+
+    def it_requires_a_membership_plan():
+        MembershipPlanFactory()
+        form = AddMemberForm(data=_valid_data(MembershipPlanFactory(), membership_plan=""))
+        assert not form.is_valid()
+        assert "membership_plan" in form.errors
+
+    def it_rejects_a_blank_name():
+        plan = MembershipPlanFactory()
+        form = AddMemberForm(data=_valid_data(plan, full_legal_name="   "))
+        assert not form.is_valid()
+        assert "Enter the member's full legal name." in form.errors["full_legal_name"]
+
+    def it_strips_whitespace_from_the_name():
+        plan = MembershipPlanFactory()
+        form = AddMemberForm(data=_valid_data(plan, full_legal_name="  Jane Maker  "))
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["full_legal_name"] == "Jane Maker"
+
+    def it_rejects_an_existing_active_member_email():
+        plan = MembershipPlanFactory()
+        MemberFactory(_pre_signup_email="taken@example.com", status=Member.Status.ACTIVE)
+        form = AddMemberForm(data=_valid_data(plan, email="taken@example.com"))
+        assert not form.is_valid()
+        assert "A member with this email already exists." in form.errors["email"]
+
+    def it_rejects_an_existing_member_email_case_insensitively():
+        plan = MembershipPlanFactory()
+        MemberFactory(_pre_signup_email="taken@example.com", status=Member.Status.ACTIVE)
+        form = AddMemberForm(data=_valid_data(plan, email="TAKEN@example.com"))
+        assert not form.is_valid()
+        assert "email" in form.errors
+
+    def it_allows_an_email_only_held_by_an_invited_placeholder():
+        plan = MembershipPlanFactory()
+        MemberFactory(_pre_signup_email="invited@example.com", status=Member.Status.INVITED, user=None)
+        form = AddMemberForm(data=_valid_data(plan, email="invited@example.com"))
+        assert form.is_valid(), form.errors
+
+    def describe_create_member():
+        def it_creates_a_member_from_cleaned_data():
+            plan = MembershipPlanFactory()
+            form = AddMemberForm(data=_valid_data(plan, preferred_name="Janey"))
+            assert form.is_valid(), form.errors
+            member = form.create_member()
+            assert member.pk is not None
+            assert member.full_legal_name == "Jane Maker"
+            assert member.preferred_name == "Janey"
+            assert member._pre_signup_email == "jane@example.com"
+            assert member.membership_plan == plan
+            assert member.status == Member.Status.ACTIVE
+
+        def it_provisions_a_login_ready_user_for_an_active_member_without_sending_email(mailoutbox):
+            plan = MembershipPlanFactory()
+            form = AddMemberForm(data=_valid_data(plan))
+            assert form.is_valid(), form.errors
+            member = form.create_member()
+            member.refresh_from_db()
+            assert member.user is not None
+            assert len(mailoutbox) == 0
+
+        def it_leaves_a_non_active_member_unlinked():
+            plan = MembershipPlanFactory()
+            form = AddMemberForm(data=_valid_data(plan, email="later@example.com", status=Member.Status.SUSPENDED))
+            assert form.is_valid(), form.errors
+            member = form.create_member()
+            member.refresh_from_db()
+            assert member.user is None
 
 
 def describe_InviteMemberForm():


### PR DESCRIPTION
Two staff-facing fixes to the Manage Members page — the gaps that turned up while trying to add a reviewer account.

## 1. Add a member directly
An "+ Add member" form (beside "+ Invite a member") takes full legal name, email, membership plan, optional preferred name, and a status defaulting to Active. Creates the member with **no invite and no email**; redirects back to the list with a success toast. An Active member is auto-provisioned a passwordless, login-ready account by the existing `auto_provision_member_user` signal (silent, no email); other statuses get their user on first login-code sign-in. Validation errors re-render inline with typed values preserved.

## 2. Tidy the expired-invites list
The panel no longer piles up dead invites: pending (and recently-accepted) show by default; expired collapse behind a "Show N expired invites" toggle (Resend/Revoke still available), plus a "Clear expired" button (confirm modal, HTMX) that bulk-revokes via a new `Invite.objects.clear_expired()` — routed through the existing `revoke()` so placeholder members are cleaned up and activity is logged.

## Tests / quality
Full BDD specs for both features (form, manager, both views); 100% new-code coverage; ruff + mypy clean; full hub/core/membership suite green (4551). Bumps VERSION to 0.23.41 + one member-facing changelog entry.

### Notes for merge
- **Version collision:** this bumped to 0.23.41, same as PR #164 (map pan). Whichever merges first keeps it; the other rebases to the next number and reconciles the changelog.
- This is the PR to land first when you resume — merging + deploying it is how the `play-review@…` reviewer member finally gets created (through the new Add-member form), closing the Play-submission checklist.
- `AddMemberForm` blocks on an existing non-INVITED member but not on a pending invite for the same email — deliberate per scope; follow-up if you want add/invite fully mutually exclusive.

https://claude.ai/code/session_01LbJb3Liykd4qBVLsHxU7iW