### PR TITLE
[copy-review] Put the comment widget on the live email gallery (fix wrong injection target)

### DIFF
--- a/docs/superpowers/plans/2026-07-27-copy-review-comments.md
+++ b/docs/superpowers/plans/2026-07-27-copy-review-comments.md
@@ -1,5 +1,7 @@
 # Copy-review gallery — anonymous comments (TEMPORARY, remove on/after 2026-08-10)
 
+> **Correction (2026-07-28):** the live page at copy-review.pastlives.space is the **email** gallery (`tests/e2e/email_gallery/build.py`), not the retired CMS screenshot gallery. The comment widget lives in `tests/e2e/email_gallery/comment_widget.py` and is injected by `build.py` onto each email card (`data-section-key` == `email.key`). Section 6 below describes the original, wrong target (`screenshots_spec.py::_write_index`), which no longer publishes anything.
+
 **Status:** spec + implementation plan
 **Author:** Josh (via assistant)
 **Date:** 2026-07-27

--- a/tests/e2e/email_gallery/build.py
+++ b/tests/e2e/email_gallery/build.py
@@ -17,6 +17,7 @@ from datetime import date
 from pathlib import Path
 
 from tests.e2e.email_gallery import context as ctx_module
+from tests.e2e.email_gallery.comment_widget import COPY_REVIEW_WIDGET  # TEMPORARY — remove on/after 2026-08-10
 from tests.e2e.email_gallery.context import ORIENTATION_SUBJECTS, SampleData
 from tests.e2e.email_gallery.registry import (
     NO_EMAIL_SECTION,
@@ -185,7 +186,7 @@ def _card_html(rendered: RenderedEmail) -> str:
             '<p class="card-note">This email is plain-text only — the text below is the whole message.</p>'
             f'<pre class="card-plain">{_esc(rendered.text)}</pre>'
         )
-    return f"""<article class="card" id="{_esc(email.key)}">
+    return f"""<article class="card" id="{_esc(email.key)}" data-section-key="{_esc(email.key)}">
   <h3>{_esc(email.name)}</h3>
   <p class="inbox-row"><span class="from">From: Past Lives</span> · <strong>{_esc(rendered.subject)}</strong></p>
   <dl class="card-meta">
@@ -368,6 +369,7 @@ def build_site(out_dir: Path, data: SampleData) -> list[RenderedEmail]:
 {chr(10).join(sections_html)}
 </main>
 </div>
+{COPY_REVIEW_WIDGET}
 </body></html>
 """
     (out_dir / "index.html").write_text(doc, encoding="utf-8")

--- a/tests/e2e/email_gallery/comment_widget.py
+++ b/tests/e2e/email_gallery/comment_widget.py
@@ -1,0 +1,226 @@
+"""TEMPORARY — remove on/after 2026-08-10.
+
+Vanilla-JS comment widget injected into the email copy-review gallery
+(tests/e2e/email_gallery/build.py). One thread per email card, keyed by the
+card's data-section-key (== email.key), talking to the public /copy-review/
+comments API on book.pastlives.space. XSS-safe (textContent only), degrades to
+"Comments unavailable" if the API is unreachable. See
+docs/superpowers/plans/2026-07-27-copy-review-comments.md.
+"""
+
+COPY_REVIEW_WIDGET = """<!-- TEMPORARY — remove on/after 2026-08-10: copy-review comment widget -->
+<style>
+  .crc { margin-top: 14px; border-top: 1px solid #e2e2e2; padding-top: 10px; font-size: 14px; }
+  .crc-head { font-weight: 600; color: #444; margin-bottom: 8px; }
+  .crc-muted { color: #999; font-weight: 400; font-style: italic; }
+  .crc-list { display: flex; flex-direction: column; gap: 8px; }
+  .crc-item { border: 1px solid #ddd; border-radius: 6px; padding: 8px 10px; background: #fafafa; }
+  .crc-meta { display: flex; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+  .crc-author { font-weight: 600; color: #222; }
+  .crc-time { color: #999; font-size: 12px; white-space: nowrap; }
+  .crc-body { margin: 0; white-space: pre-wrap; color: #222; }
+  .crc-actions, .crc-confirm { display: flex; gap: 10px; margin-top: 6px; align-items: center; }
+  .crc-link { background: none; border: none; padding: 0; color: #06c; cursor: pointer; font-size: 13px; }
+  .crc-link:hover { text-decoration: underline; }
+  .crc-danger { color: #b00; }
+  .crc-editor, .crc-form { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+  .crc-input, .crc-textarea { font: inherit; padding: 6px 8px; border: 1px solid #ccc; border-radius: 6px; width: 100%; box-sizing: border-box; }
+  .crc-textarea { min-height: 60px; resize: vertical; }
+  .crc-btn { align-self: flex-start; font: inherit; padding: 6px 14px; border: 1px solid #06c; background: #06c; color: #fff; border-radius: 6px; cursor: pointer; }
+  .crc-btn:disabled { opacity: 0.6; cursor: default; }
+</style>
+<script>
+(function () {
+  "use strict";
+  var params = new URLSearchParams(window.location.search);
+  var API_BASE = params.get("api") || "https://book.pastlives.space";
+  var LIST_URL = API_BASE + "/copy-review/comments/";
+
+  function readTokens() {
+    try { return JSON.parse(window.localStorage.getItem("crc_tokens") || "{}"); }
+    catch (e) { return {}; }
+  }
+  function writeTokens(map) {
+    try { window.localStorage.setItem("crc_tokens", JSON.stringify(map)); } catch (e) {}
+  }
+  function tokenFor(id) { return readTokens()[id]; }
+  function rememberToken(id, token) { var m = readTokens(); m[id] = token; writeTokens(m); }
+  function forgetToken(id) { var m = readTokens(); delete m[id]; writeTokens(m); }
+  function readName() { try { return window.localStorage.getItem("crc_name") || ""; } catch (e) { return ""; } }
+  function writeName(name) { try { window.localStorage.setItem("crc_name", name); } catch (e) {} }
+
+  function fmtTime(iso) { try { return new Date(iso).toLocaleString(); } catch (e) { return iso || ""; } }
+  function make(tag, cls, text) {
+    var node = document.createElement(tag);
+    if (cls) { node.className = cls; }
+    if (text !== undefined && text !== null) { node.textContent = text; }
+    return node;
+  }
+  function request(method, url, payload) {
+    var opts = { method: method, headers: { "Content-Type": "application/json" } };
+    if (payload) { opts.body = JSON.stringify(payload); }
+    return fetch(url, opts).then(function (res) {
+      return res.json().catch(function () { return null; }).then(function (data) {
+        return { ok: res.ok, status: res.status, data: data };
+      });
+    });
+  }
+  function updateCount(head, count) { head.textContent = "Comments (" + count + ")"; }
+
+  function commentNode(sectionKey, c, head, list) {
+    var item = make("div", "crc-item");
+    item.setAttribute("data-id", c.id);
+    var meta = make("div", "crc-meta");
+    meta.appendChild(make("span", "crc-author", c.author_name));
+    meta.appendChild(make("span", "crc-time", fmtTime(c.updated_at || c.created_at)));
+    item.appendChild(meta);
+    var body = make("p", "crc-body", c.body);
+    item.appendChild(body);
+
+    if (tokenFor(c.id)) {
+      var actions = make("div", "crc-actions");
+      var editBtn = make("button", "crc-link", "Edit");
+      var delBtn = make("button", "crc-link", "Delete");
+      actions.appendChild(editBtn);
+      actions.appendChild(delBtn);
+      item.appendChild(actions);
+      editBtn.addEventListener("click", function () { startEdit(c, item, body, meta, actions); });
+      delBtn.addEventListener("click", function () { startDelete(c, item, actions, head, list); });
+    }
+    return item;
+  }
+
+  function startEdit(c, item, body, meta, actions) {
+    actions.style.display = "none";
+    body.style.display = "none";
+    var editor = make("div", "crc-editor");
+    var nameInput = make("input", "crc-input");
+    nameInput.value = c.author_name;
+    var textArea = make("textarea", "crc-textarea");
+    textArea.value = c.body;
+    var save = make("button", "crc-btn", "Save");
+    var cancel = make("button", "crc-link", "Cancel");
+    editor.appendChild(nameInput);
+    editor.appendChild(textArea);
+    editor.appendChild(save);
+    editor.appendChild(cancel);
+    item.insertBefore(editor, actions);
+    function done() { editor.remove(); body.style.display = ""; actions.style.display = ""; }
+    cancel.addEventListener("click", done);
+    save.addEventListener("click", function () {
+      request("POST", API_BASE + "/copy-review/comments/" + c.id + "/edit/", {
+        edit_token: tokenFor(c.id), author_name: nameInput.value, body: textArea.value
+      }).then(function (r) {
+        if (r.ok && r.data && r.data.comment) {
+          c.author_name = r.data.comment.author_name;
+          c.body = r.data.comment.body;
+          body.textContent = c.body;
+          meta.querySelector(".crc-author").textContent = c.author_name;
+          meta.querySelector(".crc-time").textContent = fmtTime(r.data.comment.updated_at);
+          done();
+        } else { save.textContent = "Save failed"; }
+      }).catch(function () { save.textContent = "Save failed"; });
+    });
+  }
+
+  function startDelete(c, item, actions, head, list) {
+    actions.style.display = "none";
+    var confirm = make("div", "crc-confirm");
+    confirm.appendChild(make("span", null, "Delete?"));
+    var yes = make("button", "crc-link crc-danger", "yes");
+    var no = make("button", "crc-link", "no");
+    confirm.appendChild(yes);
+    confirm.appendChild(no);
+    item.appendChild(confirm);
+    function done() { confirm.remove(); actions.style.display = ""; }
+    no.addEventListener("click", done);
+    yes.addEventListener("click", function () {
+      request("POST", API_BASE + "/copy-review/comments/" + c.id + "/delete/", {
+        edit_token: tokenFor(c.id)
+      }).then(function (r) {
+        if (r.ok) {
+          forgetToken(c.id);
+          item.remove();
+          updateCount(head, list.querySelectorAll(".crc-item").length);
+        } else { done(); }
+      }).catch(done);
+    });
+  }
+
+  function formNode(sectionKey, head, list) {
+    var form = make("form", "crc-form");
+    var nameInput = make("input", "crc-input");
+    nameInput.placeholder = "Your name";
+    nameInput.value = readName();
+    var textArea = make("textarea", "crc-textarea");
+    textArea.placeholder = "Leave a comment on this email";
+    var submit = make("button", "crc-btn", "Post");
+    submit.type = "submit";
+    form.appendChild(nameInput);
+    form.appendChild(textArea);
+    form.appendChild(submit);
+    form.addEventListener("submit", function (ev) {
+      ev.preventDefault();
+      var name = nameInput.value.trim();
+      var text = textArea.value.trim();
+      if (!name || !text) { return; }
+      submit.disabled = true;
+      request("POST", LIST_URL, {
+        section: sectionKey, author_name: name, body: text, website: ""
+      }).then(function (r) {
+        submit.disabled = false;
+        if (r.status === 201 && r.data && r.data.comment) {
+          rememberToken(r.data.comment.id, r.data.edit_token);
+          writeName(name);
+          list.appendChild(commentNode(sectionKey, r.data.comment, head, list));
+          updateCount(head, list.querySelectorAll(".crc-item").length);
+          textArea.value = "";
+        } else {
+          submit.textContent = "Try again";
+          window.setTimeout(function () { submit.textContent = "Post"; }, 2000);
+        }
+      }).catch(function () {
+        submit.disabled = false;
+        submit.textContent = "Try again";
+        window.setTimeout(function () { submit.textContent = "Post"; }, 2000);
+      });
+    });
+    return form;
+  }
+
+  function mountSection(sectionEl, sectionKey, comments) {
+    var box = make("div", "crc");
+    var head = make("div", "crc-head");
+    updateCount(head, comments.length);
+    box.appendChild(head);
+    var list = make("div", "crc-list");
+    comments.forEach(function (c) { list.appendChild(commentNode(sectionKey, c, head, list)); });
+    box.appendChild(list);
+    box.appendChild(formNode(sectionKey, head, list));
+    sectionEl.appendChild(box);
+  }
+
+  function mountUnavailable(sectionEl) {
+    var box = make("div", "crc");
+    box.appendChild(make("div", "crc-head crc-muted", "Comments unavailable"));
+    sectionEl.appendChild(box);
+  }
+
+  function init() {
+    var sections = Array.prototype.slice.call(document.querySelectorAll("[data-section-key]"));
+    request("GET", LIST_URL, null).then(function (r) {
+      if (!r.ok || !r.data || !r.data.sections) { sections.forEach(mountUnavailable); return; }
+      var grouped = r.data.sections;
+      sections.forEach(function (sectionEl) {
+        var key = sectionEl.getAttribute("data-section-key");
+        mountSection(sectionEl, key, grouped[key] || []);
+      });
+    }).catch(function () { sections.forEach(mountUnavailable); });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else { init(); }
+})();
+</script>
+<!-- END TEMPORARY (copy-review comment widget) -->"""

--- a/tests/e2e/screenshots_spec.py
+++ b/tests/e2e/screenshots_spec.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import html
 import os
-import re
 from datetime import timedelta
 from pathlib import Path
 from urllib.parse import urlparse
@@ -330,244 +329,6 @@ def _members_pages(d: dict[str, object]) -> list[tuple[str, str]]:
     ]
 
 
-# ── TEMPORARY — remove on/after 2026-08-10 ─────────────────────────────────────
-# Anonymous copy-review comments. Each gallery <section> gets a stable slug key and
-# a vanilla-JS widget that talks to the plfog comment API. A ~2-week review aid, NOT
-# a member-facing feature. See docs/superpowers/plans/2026-07-27-copy-review-comments.md.
-def _section_key(surface: str, label: str) -> str:
-    """Stable slug used as the comment section_key AND the <section> id/anchor.
-
-    ``slug(surface + "--" + label)``: lowercase, every run of non-alphanumeric
-    characters collapses to a single ``-``, leading/trailing ``-`` stripped. The
-    server just stores this string; it stays stable across rebuilds while a page
-    keeps its label. TEMPORARY — remove on/after 2026-08-10.
-    """
-    return re.sub(r"[^a-z0-9]+", "-", f"{surface}--{label}".lower()).strip("-")
-
-
-# Self-contained CSS + vanilla-JS comment widget injected before </body>. No external
-# libraries (the gallery is standalone). It fetches the comment API once, renders a
-# per-section thread + add form, and degrades to "Comments unavailable" if the API is
-# unreachable (e.g. the bundled offline file) — it must never break the gallery.
-_COPY_REVIEW_WIDGET = """<!-- TEMPORARY — remove on/after 2026-08-10: copy-review comment widget -->
-<style>
-  .crc { margin-top: 14px; border-top: 1px solid #e2e2e2; padding-top: 10px; font-size: 14px; }
-  .crc-head { font-weight: 600; color: #444; margin-bottom: 8px; }
-  .crc-muted { color: #999; font-weight: 400; font-style: italic; }
-  .crc-list { display: flex; flex-direction: column; gap: 8px; }
-  .crc-item { border: 1px solid #ddd; border-radius: 6px; padding: 8px 10px; background: #fafafa; }
-  .crc-meta { display: flex; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
-  .crc-author { font-weight: 600; color: #222; }
-  .crc-time { color: #999; font-size: 12px; white-space: nowrap; }
-  .crc-body { margin: 0; white-space: pre-wrap; color: #222; }
-  .crc-actions, .crc-confirm { display: flex; gap: 10px; margin-top: 6px; align-items: center; }
-  .crc-link { background: none; border: none; padding: 0; color: #06c; cursor: pointer; font-size: 13px; }
-  .crc-link:hover { text-decoration: underline; }
-  .crc-danger { color: #b00; }
-  .crc-editor, .crc-form { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
-  .crc-input, .crc-textarea { font: inherit; padding: 6px 8px; border: 1px solid #ccc; border-radius: 6px; width: 100%; box-sizing: border-box; }
-  .crc-textarea { min-height: 60px; resize: vertical; }
-  .crc-btn { align-self: flex-start; font: inherit; padding: 6px 14px; border: 1px solid #06c; background: #06c; color: #fff; border-radius: 6px; cursor: pointer; }
-  .crc-btn:disabled { opacity: 0.6; cursor: default; }
-</style>
-<script>
-(function () {
-  "use strict";
-  var params = new URLSearchParams(window.location.search);
-  var API_BASE = params.get("api") || "https://book.pastlives.space";
-  var LIST_URL = API_BASE + "/copy-review/comments/";
-
-  function readTokens() {
-    try { return JSON.parse(window.localStorage.getItem("crc_tokens") || "{}"); }
-    catch (e) { return {}; }
-  }
-  function writeTokens(map) {
-    try { window.localStorage.setItem("crc_tokens", JSON.stringify(map)); } catch (e) {}
-  }
-  function tokenFor(id) { return readTokens()[id]; }
-  function rememberToken(id, token) { var m = readTokens(); m[id] = token; writeTokens(m); }
-  function forgetToken(id) { var m = readTokens(); delete m[id]; writeTokens(m); }
-  function readName() { try { return window.localStorage.getItem("crc_name") || ""; } catch (e) { return ""; } }
-  function writeName(name) { try { window.localStorage.setItem("crc_name", name); } catch (e) {} }
-
-  function fmtTime(iso) { try { return new Date(iso).toLocaleString(); } catch (e) { return iso || ""; } }
-  function make(tag, cls, text) {
-    var node = document.createElement(tag);
-    if (cls) { node.className = cls; }
-    if (text !== undefined && text !== null) { node.textContent = text; }
-    return node;
-  }
-  function request(method, url, payload) {
-    var opts = { method: method, headers: { "Content-Type": "application/json" } };
-    if (payload) { opts.body = JSON.stringify(payload); }
-    return fetch(url, opts).then(function (res) {
-      return res.json().catch(function () { return null; }).then(function (data) {
-        return { ok: res.ok, status: res.status, data: data };
-      });
-    });
-  }
-  function updateCount(head, count) { head.textContent = "Comments (" + count + ")"; }
-
-  function commentNode(sectionKey, c, head, list) {
-    var item = make("div", "crc-item");
-    item.setAttribute("data-id", c.id);
-    var meta = make("div", "crc-meta");
-    meta.appendChild(make("span", "crc-author", c.author_name));
-    meta.appendChild(make("span", "crc-time", fmtTime(c.updated_at || c.created_at)));
-    item.appendChild(meta);
-    var body = make("p", "crc-body", c.body);
-    item.appendChild(body);
-
-    if (tokenFor(c.id)) {
-      var actions = make("div", "crc-actions");
-      var editBtn = make("button", "crc-link", "Edit");
-      var delBtn = make("button", "crc-link", "Delete");
-      actions.appendChild(editBtn);
-      actions.appendChild(delBtn);
-      item.appendChild(actions);
-      editBtn.addEventListener("click", function () { startEdit(c, item, body, meta, actions); });
-      delBtn.addEventListener("click", function () { startDelete(c, item, actions, head, list); });
-    }
-    return item;
-  }
-
-  function startEdit(c, item, body, meta, actions) {
-    actions.style.display = "none";
-    body.style.display = "none";
-    var editor = make("div", "crc-editor");
-    var nameInput = make("input", "crc-input");
-    nameInput.value = c.author_name;
-    var textArea = make("textarea", "crc-textarea");
-    textArea.value = c.body;
-    var save = make("button", "crc-btn", "Save");
-    var cancel = make("button", "crc-link", "Cancel");
-    editor.appendChild(nameInput);
-    editor.appendChild(textArea);
-    editor.appendChild(save);
-    editor.appendChild(cancel);
-    item.insertBefore(editor, actions);
-    function done() { editor.remove(); body.style.display = ""; actions.style.display = ""; }
-    cancel.addEventListener("click", done);
-    save.addEventListener("click", function () {
-      request("POST", API_BASE + "/copy-review/comments/" + c.id + "/edit/", {
-        edit_token: tokenFor(c.id), author_name: nameInput.value, body: textArea.value
-      }).then(function (r) {
-        if (r.ok && r.data && r.data.comment) {
-          c.author_name = r.data.comment.author_name;
-          c.body = r.data.comment.body;
-          body.textContent = c.body;
-          meta.querySelector(".crc-author").textContent = c.author_name;
-          meta.querySelector(".crc-time").textContent = fmtTime(r.data.comment.updated_at);
-          done();
-        } else { save.textContent = "Save failed"; }
-      }).catch(function () { save.textContent = "Save failed"; });
-    });
-  }
-
-  function startDelete(c, item, actions, head, list) {
-    actions.style.display = "none";
-    var confirm = make("div", "crc-confirm");
-    confirm.appendChild(make("span", null, "Delete?"));
-    var yes = make("button", "crc-link crc-danger", "yes");
-    var no = make("button", "crc-link", "no");
-    confirm.appendChild(yes);
-    confirm.appendChild(no);
-    item.appendChild(confirm);
-    function done() { confirm.remove(); actions.style.display = ""; }
-    no.addEventListener("click", done);
-    yes.addEventListener("click", function () {
-      request("POST", API_BASE + "/copy-review/comments/" + c.id + "/delete/", {
-        edit_token: tokenFor(c.id)
-      }).then(function (r) {
-        if (r.ok) {
-          forgetToken(c.id);
-          item.remove();
-          updateCount(head, list.querySelectorAll(".crc-item").length);
-        } else { done(); }
-      }).catch(done);
-    });
-  }
-
-  function formNode(sectionKey, head, list) {
-    var form = make("form", "crc-form");
-    var nameInput = make("input", "crc-input");
-    nameInput.placeholder = "Your name";
-    nameInput.value = readName();
-    var textArea = make("textarea", "crc-textarea");
-    textArea.placeholder = "Leave a comment on this area";
-    var submit = make("button", "crc-btn", "Post");
-    submit.type = "submit";
-    form.appendChild(nameInput);
-    form.appendChild(textArea);
-    form.appendChild(submit);
-    form.addEventListener("submit", function (ev) {
-      ev.preventDefault();
-      var name = nameInput.value.trim();
-      var text = textArea.value.trim();
-      if (!name || !text) { return; }
-      submit.disabled = true;
-      request("POST", LIST_URL, {
-        section: sectionKey, author_name: name, body: text, website: ""
-      }).then(function (r) {
-        submit.disabled = false;
-        if (r.status === 201 && r.data && r.data.comment) {
-          rememberToken(r.data.comment.id, r.data.edit_token);
-          writeName(name);
-          list.appendChild(commentNode(sectionKey, r.data.comment, head, list));
-          updateCount(head, list.querySelectorAll(".crc-item").length);
-          textArea.value = "";
-        } else {
-          submit.textContent = "Try again";
-          window.setTimeout(function () { submit.textContent = "Post"; }, 2000);
-        }
-      }).catch(function () {
-        submit.disabled = false;
-        submit.textContent = "Try again";
-        window.setTimeout(function () { submit.textContent = "Post"; }, 2000);
-      });
-    });
-    return form;
-  }
-
-  function mountSection(sectionEl, sectionKey, comments) {
-    var box = make("div", "crc");
-    var head = make("div", "crc-head");
-    updateCount(head, comments.length);
-    box.appendChild(head);
-    var list = make("div", "crc-list");
-    comments.forEach(function (c) { list.appendChild(commentNode(sectionKey, c, head, list)); });
-    box.appendChild(list);
-    box.appendChild(formNode(sectionKey, head, list));
-    sectionEl.appendChild(box);
-  }
-
-  function mountUnavailable(sectionEl) {
-    var box = make("div", "crc");
-    box.appendChild(make("div", "crc-head crc-muted", "Comments unavailable"));
-    sectionEl.appendChild(box);
-  }
-
-  function init() {
-    var sections = Array.prototype.slice.call(document.querySelectorAll("section[data-section-key]"));
-    request("GET", LIST_URL, null).then(function (r) {
-      if (!r.ok || !r.data || !r.data.sections) { sections.forEach(mountUnavailable); return; }
-      var grouped = r.data.sections;
-      sections.forEach(function (sectionEl) {
-        var key = sectionEl.getAttribute("data-section-key");
-        mountSection(sectionEl, key, grouped[key] || []);
-      });
-    }).catch(function () { sections.forEach(mountUnavailable); });
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else { init(); }
-})();
-</script>
-<!-- END TEMPORARY (copy-review comment widget) -->"""
-# ── END TEMPORARY (copy-review comments) ───────────────────────────────────────
-
-
 def _write_index(out_dir: Path, results: list[dict[str, object]]) -> None:
     """Write a single scrollable index.html that labels every captured page."""
     rows: list[str] = []
@@ -584,11 +345,7 @@ def _write_index(out_dir: Path, results: list[dict[str, object]]) -> None:
             body = f'<a href="{img}"><img loading="lazy" src="{img}" alt="{label}"></a>'
         else:
             body = f'<p class="err">Could not capture: {html.escape(str(r["note"]))}</p>'
-        # TEMPORARY — remove on/after 2026-08-10: data-section-key/id anchor the comment widget.
-        key = _section_key(section, str(r["label"]))
-        rows.append(
-            f'<section data-section-key="{key}" id="{key}"><h3>{label}</h3><p class="path">{path}</p>{body}</section>'
-        )
+        rows.append(f'<section><h3>{label}</h3><p class="path">{path}</p>{body}</section>')
 
     ok = sum(1 for r in results if r["ok"])
     doc = f"""<!doctype html>
@@ -611,8 +368,6 @@ def _write_index(out_dir: Path, results: list[dict[str, object]]) -> None:
 {chr(10).join(rows)}
 </body></html>
 """
-    # TEMPORARY — remove on/after 2026-08-10: inject the copy-review comment widget.
-    doc = doc.replace("</body></html>", f"{_COPY_REVIEW_WIDGET}\n</body></html>")
     (out_dir / "index.html").write_text(doc, encoding="utf-8")
 
 


### PR DESCRIPTION
## Why

#166 shipped the copy-review comment widget into `tests/e2e/screenshots_spec.py::_write_index` — the old CMS *screenshot* gallery. But `copy-review.pastlives.space` was migrated on `main` to publish the **email** gallery (`tests/e2e/email_gallery/build.py`); the CMS gallery no longer runs in `copy-review.yml`. So the widget landed in dead code and never appeared on the live page. (The spec was anchored to a stale, pre-migration copy of the workflow.)

The **backend API is already live and correct** — this is a frontend-only fix.

## What

- New shared module `tests/e2e/email_gallery/comment_widget.py` holding the (unchanged, reviewed, XSS-safe) widget. Only functional change vs #166: the selector is now `document.querySelectorAll("[data-section-key]")` so it matches the email gallery's `<article>` cards, and the placeholder reads "Leave a comment on this email".
- `build.py` now stamps each email card with `data-section-key="{email.key}"` and injects the widget before `</body>`. Each **email card** gets one comment thread, keyed by `email.key`, which maps straight to the API's `section_key`.
- Removed the dead widget (and its now-unused `_section_key` helper) from `screenshots_spec.py`, so there is a single source of truth. `screenshots_spec.py` still imports cleanly for the retained R2 feature-shot capture step.
- Spec doc annotated with the correction.

## Verification

- Browserless build (`email_gallery_spec.py`, `BUILD_EMAIL_GALLERY=1`): **9 passed**. The generated `index.html` carries `data-section-key` on all **51 email cards**, the `[data-section-key]` selector, and the API base — the widget renders once per card.
- `screenshots_spec.py` parses/collects cleanly (R2 step safe).
- No `VERSION` bump and no changelog entry — same intentional decision as #166 (internal, temporary tool); `version.py` is untouched.

## On merge

`copy-review.yml` rebuilds the email gallery with the widget, so comments appear on the live page. No env/secrets changes. Same `# TEMPORARY — remove on/after 2026-08-10` teardown markers throughout.
