### PR TITLE
[discord] Recurring events push the UTC weekday, not local (v0.23.45)

### DIFF
--- a/core/integrations/discord_events.py
+++ b/core/integrations/discord_events.py
@@ -195,13 +195,6 @@ def _build_description(event: CommunityEvent) -> str:
     return "\n\n".join(parts)
 
 
-def _occurrence_n(event: CommunityEvent) -> int:
-    """Discord ``by_n_weekday.n`` (1–5) for a monthly-by-weekday event — the model's
-    ``-1`` ('last') maps to Discord's ``5``."""
-    ordinal = event._occurrence_ordinal()
-    return 5 if ordinal == -1 else ordinal
-
-
 def _recurrence_rule_for(event: CommunityEvent) -> dict[str, Any] | None:
     """Map a :class:`CommunityEvent` recurrence to a Discord ``recurrence_rule`` dict.
 
@@ -211,20 +204,30 @@ def _recurrence_rule_for(event: CommunityEvent) -> dict[str, Any] | None:
     to the single-next-occurrence fallback (§5.3). Weekday encoding is ``0=Monday … 6=Sunday``
     (Python ``weekday()`` == Discord's convention). See the module docstring: these limits
     are build-time-verify.
+
+    Both halves of the rule are computed from the **UTC** start, never local time: Discord
+    evaluates ``by_weekday``/``by_n_weekday`` against the UTC ``scheduled_start_time`` it is
+    sent, and a Portland evening event from 5 PM PDT onward crosses the UTC date line, so
+    its UTC weekday is one day later than its local weekday. Sending the local weekday made
+    Discord snap the whole series a day early (a Thursday 5–8 PM meeting displayed as
+    Wednesday 5–8 PM). The monthly ordinal has the same failure mode (a 2nd-Friday evening
+    is a 2nd-Saturday in UTC), so it comes from the UTC calendar day too.
     """
+    from datetime import UTC
+
     from membership.models import CommunityEvent as CE
-    from django.utils import timezone
 
     if event.recurrence == CE.Recurrence.NONE:
         return None
-    weekday = timezone.localtime(event.starts_at).weekday()
+    utc_start = event.starts_at.astimezone(UTC)
+    weekday = utc_start.weekday()
     if event.recurrence == CE.Recurrence.WEEKLY:
         return {"frequency": _FREQUENCY_WEEKLY, "interval": 1, "by_weekday": [weekday]}
     if event.recurrence == CE.Recurrence.MONTHLY:
         return {
             "frequency": _FREQUENCY_MONTHLY,
             "interval": 1,
-            "by_n_weekday": [{"n": _occurrence_n(event), "day": weekday}],
+            "by_n_weekday": [{"n": (utc_start.day - 1) // 7 + 1, "day": weekday}],
         }
     return None
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.44"
+VERSION = "0.23.45"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.45",
+        "date": "2026-07-28",
+        "title": "Discord events now show the right day",
+        "changes": [
+            "Evening events in the Discord server's Events tab could appear one day early. "
+            "Parallel Play showed Wednesday when it actually meets Thursday 5 to 8 PM. "
+            "Recurring evening events now land on the correct day.",
+        ],
+    },
     {
         "version": "0.23.44",
         "date": "2026-07-28",

--- a/tests/core/integrations/discord_events_spec.py
+++ b/tests/core/integrations/discord_events_spec.py
@@ -285,6 +285,28 @@ def describe__recurrence_rule_for():
         event = _anchored(CommunityEvent.Recurrence.WEEKLY, 2026, 7, 8)
         assert de._recurrence_rule_for(event) == {"frequency": 2, "interval": 1, "by_weekday": [2]}
 
+    def it_uses_the_utc_weekday_for_an_evening_event_that_crosses_the_utc_date_line() -> None:
+        # Thu 2026-07-16 17:00 PDT == Fri 2026-07-17 00:00 UTC. Discord evaluates the rule
+        # against the UTC scheduled_start_time it is sent, so the rule must say Friday (4).
+        # Sending the local weekday (Thursday, 3) made Discord snap the series to Thursday
+        # 00:00 UTC — Wednesday 5 PM in Portland — showing every weekly evening meeting a
+        # day early (the live "Parallel Play on Wednesday" bug, 2026-07-28).
+        start = timezone.make_aware(datetime(2026, 7, 16, 17, 0))
+        event = _event(CommunityEvent.Recurrence.WEEKLY, starts_at=start, ends_at=start + timedelta(hours=3))
+        assert de._recurrence_rule_for(event) == {"frequency": 2, "interval": 1, "by_weekday": [4]}
+
+    def it_uses_the_utc_calendar_day_for_a_monthly_evening_event_that_crosses_the_utc_date_line() -> None:
+        # Fri 2026-07-10 18:00 PDT == Sat 2026-07-11 01:00 UTC — the 2nd Friday locally is
+        # the 2nd Saturday in UTC. Both halves of the rule (n AND day) must come from the
+        # same UTC instant, or Discord anchors the series to the wrong day.
+        start = timezone.make_aware(datetime(2026, 7, 10, 18, 0))
+        event = _event(CommunityEvent.Recurrence.MONTHLY, starts_at=start, ends_at=start + timedelta(hours=1))
+        assert de._recurrence_rule_for(event) == {
+            "frequency": 1,
+            "interval": 1,
+            "by_n_weekday": [{"n": 2, "day": 5}],
+        }
+
     @pytest.mark.parametrize(
         ("day", "expected_n", "expected_weekday"),
         [
@@ -305,9 +327,10 @@ def describe__recurrence_rule_for():
         }
 
     def it_maps_a_last_weekday_ordinal_to_discord_5() -> None:
-        # Wed 2026-07-29 is the 5th (and last) Wednesday → model ordinal -1 → Discord n=5.
-        # Discord documents by_n_weekday.n as an int in 1–5 with no negative "last" form, so
-        # the model's -1 MUST be re-encoded; passing -1 straight through would be a hard 400.
+        # Wed 2026-07-29 is the 5th (and last) Wednesday — the model calls that ordinal -1,
+        # but Discord documents by_n_weekday.n as an int in 1–5 with no negative "last"
+        # form; the rule (computed from the UTC calendar day) must land on 5, never -1
+        # (which would be a hard 400).
         event = _anchored(CommunityEvent.Recurrence.MONTHLY, 2026, 7, 29)
         assert event._occurrence_ordinal() == -1
         assert de._recurrence_rule_for(event)["by_n_weekday"][0]["n"] == 5


### PR DESCRIPTION
## What

Recurring Discord Scheduled Events were anchored to the wrong day for evening events. Parallel Play (Thursday 5 to 8 PM) displayed as Wednesday on the Discord server.

## Why

Discord evaluates recurrence_rule against the UTC scheduled_start_time it is sent. A Portland event starting 5 PM PDT or later crosses the UTC date line, so its UTC weekday is one day later than its local weekday. The mapper computed by_weekday from local time while sending the start in UTC; Discord resolved the contradiction by snapping the series to the rule's weekday in UTC, which is one day early in Portland. The monthly by_n_weekday mapping had the same failure mode (a 2nd Friday evening is a 2nd Saturday in UTC).

## Fix

_recurrence_rule_for now derives the weekday, and for monthly the ordinal n, from the UTC start. The dead _occurrence_n helper is removed. The model's local time semantics (occurrences_in, _occurrence_ordinal) are untouched; only the Discord mapping layer changes.

Note: the live Parallel Play Discord event was already corrected by hand via the API on 2026-07-28. This fix stops the next FOG save of that meeting from reverting it to Wednesday.

## Tests

Two new regression specs cover the cross midnight cases (weekly and monthly). Full related suites pass: discord_events, calendar_service, backfill and retry commands (101 specs). Ruff and mypy clean via pre-push.

https://claude.ai/code/session_01XJKEkdaf1RZw87MPwKvgqj