### PR TITLE
[map] Pan works on every floor; smaller viewport pans at 1x (v0.23.46)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.45"
+VERSION = "0.23.46"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.46",
+        "date": "2026-07-29",
+        "title": "Moving around the Spaces map now works everywhere",
+        "changes": [
+            "Dragging the Spaces map (mouse or finger) now pans on every floor. Before, panning "
+            "silently did nothing on some floors no matter how far you zoomed in.",
+            "The map sits in a shorter frame, so a tall floor starts cropped and you can drag or "
+            "two-finger swipe around it right away, no zooming first.",
+            "On a phone or tablet, a two-finger swipe now moves the map while a pinch zooms it, "
+            "the way a maps app behaves.",
+        ],
+    },
     {
         "version": "0.23.45",
         "date": "2026-07-28",

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -4655,10 +4655,20 @@ html:not(.dark) .admin-table-wrap tbody tr:nth-child(even) {
   background: var(--hub-surface);
   touch-action: none;
   cursor: grab;
+  /* Cap the frame so a tall floor (the 2nd floor is nearly square) is cropped
+     rather than filling the page — the crop is what gives drag and two-finger
+     swipe somewhere to go before any zoom. Centring the stage keeps the crop
+     symmetric, matching the JS clamp's centre-origin maths. */
+  max-height: min(60vh, 480px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .pl-map-viewport:active { cursor: grabbing; }
 .pl-map-stage {
   position: relative;
+  width: 100%;
+  flex: none;
   transform-origin: center center;
   transition: transform 0.12s ease-out;
 }

--- a/static/js/space_map.js
+++ b/static/js/space_map.js
@@ -98,8 +98,6 @@
                 this.clampPan();
             },
 
-            // Keep the plan from being dragged off-screen: the further you zoom, the more
-            // slack there is, and at 1x there is none (so the map always snaps back square).
             // The visible floor's viewport. Every floor renders its own (x-show keeps the
             // rest in the DOM at display:none, measuring 0×0), so the lookup has to follow
             // the chosen floor — a single x-ref pointed at whichever floor came last.
@@ -107,6 +105,10 @@
                 return this.$root.querySelector('.pl-map-viewport[data-floor="' + this.floor + '"]');
             },
 
+            // Keep the plan from being dragged off-screen: the slack is however much of
+            // the stage overflows the viewport — from zooming in, or from the viewport's
+            // height cap cropping a tall floor even at 1x. A floor that fits entirely
+            // still snaps back square.
             clampPan: function () {
                 var el = this.viewportEl();
                 var stage = el ? el.querySelector('.pl-map-stage') : null;

--- a/static/js/space_map.js
+++ b/static/js/space_map.js
@@ -41,6 +41,9 @@
             pointers: {},
             pinchStart: 0,
             pinchScale: 1,
+            // Where the two-finger midpoint last was — its movement pans the map.
+            pinchX: 0,
+            pinchY: 0,
 
             // --- Accessible list state (see the .pl-map-list section) ---
             listQuery: '',
@@ -97,11 +100,19 @@
 
             // Keep the plan from being dragged off-screen: the further you zoom, the more
             // slack there is, and at 1x there is none (so the map always snaps back square).
+            // The visible floor's viewport. Every floor renders its own (x-show keeps the
+            // rest in the DOM at display:none, measuring 0×0), so the lookup has to follow
+            // the chosen floor — a single x-ref pointed at whichever floor came last.
+            viewportEl: function () {
+                return this.$root.querySelector('.pl-map-viewport[data-floor="' + this.floor + '"]');
+            },
+
             clampPan: function () {
-                var el = this.$refs.viewport;
-                if (!el) return;
-                var slackX = (el.clientWidth * (this.scale - 1)) / 2;
-                var slackY = (el.clientHeight * (this.scale - 1)) / 2;
+                var el = this.viewportEl();
+                var stage = el ? el.querySelector('.pl-map-stage') : null;
+                if (!el || !stage) return;
+                var slackX = Math.max(0, stage.offsetWidth * this.scale - el.clientWidth) / 2;
+                var slackY = Math.max(0, stage.offsetHeight * this.scale - el.clientHeight) / 2;
                 this.tx = clamp(this.tx, -slackX, slackX);
                 this.ty = clamp(this.ty, -slackY, slackY);
             },
@@ -122,6 +133,13 @@
                 return Math.sqrt(dx * dx + dy * dy);
             },
 
+            // The midpoint between the two touches — moving it pans, so a two-finger
+            // swipe on a touchscreen drags the map even while it zooms, like a maps app.
+            pinchCentroid: function () {
+                var pts = this.pointerList();
+                return { x: (pts[0].x + pts[1].x) / 2, y: (pts[0].y + pts[1].y) / 2 };
+            },
+
             onPointerDown: function (event) {
                 // A marker is a real button — let the click through instead of panning.
                 if (event.target.closest && event.target.closest('.pl-map-marker')) return;
@@ -129,6 +147,9 @@
                 if (this.pointerList().length === 2) {
                     this.pinchStart = this.pinchDistance();
                     this.pinchScale = this.scale;
+                    var start = this.pinchCentroid();
+                    this.pinchX = start.x;
+                    this.pinchY = start.y;
                     this.dragging = false;
                     return;
                 }
@@ -147,8 +168,13 @@
                     var distance = this.pinchDistance();
                     if (this.pinchStart > 0 && distance > 0) {
                         this.scale = clamp((distance / this.pinchStart) * this.pinchScale, MIN_SCALE, MAX_SCALE);
-                        this.clampPan();
                     }
+                    var mid = this.pinchCentroid();
+                    this.tx += mid.x - this.pinchX;
+                    this.ty += mid.y - this.pinchY;
+                    this.pinchX = mid.x;
+                    this.pinchY = mid.y;
+                    this.clampPan();
                     return;
                 }
                 if (!this.dragging) return;
@@ -161,7 +187,16 @@
 
             onPointerUp: function (event) {
                 delete this.pointers[event.pointerId];
-                if (this.pointerList().length < 2) this.pinchStart = 0;
+                var pts = this.pointerList();
+                if (pts.length < 2) this.pinchStart = 0;
+                // Lifting one finger out of a pinch hands over to a plain drag, so the
+                // remaining finger keeps panning without a lift-and-retouch.
+                if (pts.length === 1) {
+                    this.dragging = true;
+                    this.lastX = pts[0].x;
+                    this.lastY = pts[0].y;
+                    return;
+                }
                 this.dragging = false;
             },
 

--- a/templates/hub/_org_map.html
+++ b/templates/hub/_org_map.html
@@ -34,9 +34,9 @@ Context: floorplans, pending_space_ids, can_edit.
     </ul>
     {% endif %}
 
-    {# data-floor lets the JS measure THIS floor's viewport — a shared x-ref resolved to
-       whichever floor rendered last, so pan-clamping measured a display:none box (0×0)
-       and froze panning on every other floor. #}
+    {% comment %}data-floor lets the JS measure THIS floor's viewport — a shared x-ref
+    resolved to whichever floor rendered last, so pan-clamping measured a display:none
+    box (0×0) and froze panning on every other floor.{% endcomment %}
     <div class="pl-map-viewport"
          data-floor="{{ f.pk }}"
          @pointerdown="onPointerDown($event)"

--- a/templates/hub/_org_map.html
+++ b/templates/hub/_org_map.html
@@ -19,7 +19,7 @@ Context: floorplans, pending_space_ids, can_edit.
         <button type="button" class="pl-btn pl-btn--secondary pl-btn--sm" @click="zoomIn()" aria-label="Zoom in">+</button>
         <button type="button" class="pl-btn pl-btn--secondary pl-btn--sm" @click="zoomOut()" aria-label="Zoom out">&minus;</button>
         <button type="button" class="pl-btn pl-btn--secondary pl-btn--sm" @click="reset()">Reset</button>
-        <span class="pl-map-toolbar__hint hub-text-muted">Drag to pan &middot; scroll or pinch to zoom</span>
+        <span class="pl-map-toolbar__hint hub-text-muted">Drag or two-finger swipe to pan &middot; pinch or Ctrl+scroll to zoom</span>
     </div>
 
     {% if f.legend %}
@@ -34,8 +34,11 @@ Context: floorplans, pending_space_ids, can_edit.
     </ul>
     {% endif %}
 
+    {# data-floor lets the JS measure THIS floor's viewport — a shared x-ref resolved to
+       whichever floor rendered last, so pan-clamping measured a display:none box (0×0)
+       and froze panning on every other floor. #}
     <div class="pl-map-viewport"
-         x-ref="viewport"
+         data-floor="{{ f.pk }}"
          @pointerdown="onPointerDown($event)"
          @pointermove="onPointerMove($event)"
          @pointerup="onPointerUp($event)"


### PR DESCRIPTION
## What

Three fixes to moving around the Spaces map, following up on #164 (two-finger swipe pan), which shipped correct wheel handling but was invisible in practice:

1. **Panning was frozen on all but one floor.** Every floor's viewport shared `x-ref="viewport"`; Alpine resolves duplicate refs to the last element in the DOM, so `clampPan()` measured a `display:none` viewport (0 by 0) and clamped `tx`/`ty` to zero. Drag, swipe, everything panned nowhere. The JS now finds the visible floor's viewport via a `data-floor` attribute.

2. **The viewport is smaller, and pan works at 1x.** The frame is capped at `min(60vh, 480px)` with the stage centered, and `clampPan()` derives slack from how much the stage actually overflows the viewport rather than from the zoom factor alone. A tall floor (the 2nd floor is nearly square) starts cropped, so drag and two-finger swipe have somewhere to go immediately; a wide floor that fits fully still snaps square at 1x.

3. **Two-finger pan on touchscreens.** Two fingers previously only zoomed. The pinch handler now also pans by the centroid's movement (maps-app behavior), and lifting one finger hands off to a plain one-finger drag instead of requiring a re-touch. Toolbar hint updated to match reality: drag or two-finger swipe pans, pinch or Ctrl+scroll zooms.

## Testing

- `node --check static/js/space_map.js`
- `pytest tests/hub/space_map_views_spec.py` (87 passed) and version/changelog specs (17 passed)
- Full pre-push suite (ruff, mypy, tests) green
- No JS test runner in this repo; the pointer/wheel logic is verified by inspection. Worth a quick visual pass on /spaces/: drag on BOTH floors (this was the frozen one), trackpad swipe, and a phone pinch+swipe.

https://claude.ai/code/session_01XJKEkdaf1RZw87MPwKvgqj