### PR TITLE
[billing] tab_payments_enabled now gates billing job and entry notifications

### DIFF
--- a/billing/management/commands/bill_tabs.py
+++ b/billing/management/commands/bill_tabs.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 
 from billing.models import BillingSettings, Tab, TabCharge, TabEntry
 from billing.notifications import notify_admin_charge_failed, send_receipt
+from core.models import SiteConfiguration
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,10 @@ class Command(BaseCommand):
     def _run_billing(self, *, force: bool) -> None:
         """Core billing logic."""
         settings = BillingSettings.load()
+
+        if not SiteConfiguration.load().tab_payments_enabled:
+            self.stdout.write("Tab payments are disabled. Exiting.")
+            return
 
         if settings.charge_frequency == BillingSettings.ChargeFrequency.OFF:
             self.stdout.write("Billing is turned off. Exiting.")

--- a/billing/models.py
+++ b/billing/models.py
@@ -444,6 +444,10 @@ class Tab(models.Model):
         of the same add is idempotent.
         """
         from core.events.emit import emit
+        from core.models import SiteConfiguration
+
+        if not SiteConfiguration.load().tab_payments_enabled:
+            return
 
         # Both events resolve the TAB_MEMBER (the tab's own member) and are transactional
         # (money the member owes), so their EMAIL channel is FORCED — the bell row and the

--- a/tests/billing/dispatch_spec.py
+++ b/tests/billing/dispatch_spec.py
@@ -11,7 +11,7 @@ from django.db.models.signals import post_save
 from factory.django import mute_signals
 
 from billing.notifications import notify_admin_charge_failed, send_receipt
-from core.models import Notification
+from core.models import Notification, SiteConfiguration
 from tests.billing.factories import BillingSettingsFactory, TabChargeFactory, TabFactory, ProductFactory
 from tests.membership.factories import MemberFactory
 
@@ -135,3 +135,36 @@ def describe_tab_approaching_limit_dispatch():
         tab.add_entry(description="Below limit", amount=Decimal("79.00"), product=product)
 
         assert not Notification.objects.filter(user=user, trigger="tab_approaching_limit").exists()
+
+    def it_does_not_create_notification_when_tab_payments_disabled():
+        BillingSettingsFactory(default_tab_limit=Decimal("100.00"))
+        member = MemberFactory(_pre_signup_email="disabled@example.com")
+        user = _user_for_member(member)
+        tab = TabFactory(member=member, tab_limit=Decimal("100.00"))
+        product = ProductFactory()
+        config = SiteConfiguration.load()
+        config.tab_payments_enabled = False
+        config.save(update_fields=["tab_payments_enabled"])
+
+        tab.add_entry(description="Should not notify", amount=Decimal("80.00"), product=product)
+
+        assert not Notification.objects.filter(user=user, trigger="tab_approaching_limit").exists()
+
+
+def describe_tab_entry_added_when_payments_disabled():
+    def it_does_not_create_notification_when_tab_payments_disabled():
+        BillingSettingsFactory()
+        member = MemberFactory(_pre_signup_email="disabledentry@example.com")
+        user = _user_for_member(member)
+        tab = TabFactory(member=member)
+        admin = User.objects.create_user(username="admin_disabled", email="admin_disabled@example.com")
+        product = ProductFactory()
+        config = SiteConfiguration.load()
+        config.tab_payments_enabled = False
+        config.save(update_fields=["tab_payments_enabled"])
+
+        tab.add_entry(
+            description="Should not notify", amount=Decimal("20.00"), added_by=admin, is_self_service=False, product=product
+        )
+
+        assert not Notification.objects.filter(user=user, trigger="tab_entry_added").exists()

--- a/tests/billing/dispatch_spec.py
+++ b/tests/billing/dispatch_spec.py
@@ -164,7 +164,11 @@ def describe_tab_entry_added_when_payments_disabled():
         config.save(update_fields=["tab_payments_enabled"])
 
         tab.add_entry(
-            description="Should not notify", amount=Decimal("20.00"), added_by=admin, is_self_service=False, product=product
+            description="Should not notify",
+            amount=Decimal("20.00"),
+            added_by=admin,
+            is_self_service=False,
+            product=product,
         )
 
         assert not Notification.objects.filter(user=user, trigger="tab_entry_added").exists()

--- a/tests/billing/management/bill_tabs_spec.py
+++ b/tests/billing/management/bill_tabs_spec.py
@@ -12,6 +12,7 @@ from django.core.management import call_command
 from django.utils import timezone
 
 from billing.models import BillingSettings, TabCharge
+from core.models import SiteConfiguration
 from tests.billing.factories import (
     BillingSettingsFactory,
     ProductFactory,
@@ -38,6 +39,14 @@ def describe_bill_tabs():
             assert "Another billing run" in output
 
     def describe_schedule():
+        def it_exits_when_tab_payments_disabled():
+            BillingSettingsFactory()
+            config = SiteConfiguration.load()
+            config.tab_payments_enabled = False
+            config.save(update_fields=["tab_payments_enabled"])
+            output = _call_bill_tabs(force=True)
+            assert "disabled" in output
+
         def it_exits_when_billing_is_off():
             BillingSettingsFactory(charge_frequency=BillingSettings.ChargeFrequency.OFF)
             output = _call_bill_tabs()


### PR DESCRIPTION
## Summary

- `tab_payments_enabled` was a UI-only flag: it hid the nav and redirected members visiting /tab/, but the billing pipeline ran on regardless
- `bill_tabs` management command fired every 15 min and actually charged tabs, even when the feature was toggled off
- `Tab._dispatch_entry_notifications()` emitted `tab_approaching_limit` and `tab_entry_added` with no knowledge of the flag

## Changes

- `bill_tabs._run_billing()`: exits early if `SiteConfiguration.tab_payments_enabled` is false
- `Tab._dispatch_entry_notifications()`: returns without emitting any notifications when the feature is off
- Three new tests cover all three guard paths

## Test plan

- [ ] `tests/billing/management/bill_tabs_spec.py::describe_bill_tabs::describe_schedule::it_exits_when_tab_payments_disabled`
- [ ] `tests/billing/dispatch_spec.py::describe_tab_approaching_limit_dispatch::it_does_not_create_notification_when_tab_payments_disabled`
- [ ] `tests/billing/dispatch_spec.py::describe_tab_entry_added_when_payments_disabled::it_does_not_create_notification_when_tab_payments_disabled`