### PR TITLE
fix(auth): accept the reviewer login code at verification time

### DIFF
--- a/plfog/adapters.py
+++ b/plfog/adapters.py
@@ -7,7 +7,8 @@ import os
 from typing import Any
 
 from allauth.account.adapter import DefaultAccountAdapter
-from allauth.account.forms import RequestLoginCodeForm
+from allauth.account.forms import ConfirmLoginCodeForm, RequestLoginCodeForm
+from allauth.core.internal.cryptokit import compare_user_code
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -161,34 +162,6 @@ class AdminRedirectAccountAdapter(DefaultAccountAdapter):
         if surface == "public":
             return reverse("account:overview")
         return reverse("hub_home")
-
-    def generate_login_code(self) -> str:
-        """Issue a deterministic login code for the designated app-store review account.
-
-        App-store reviewers cannot receive our emailed one-time codes: review is
-        asynchronous and they cannot read a member's inbox. When BOTH the
-        ``PLAY_REVIEW_EMAIL`` and ``PLAY_REVIEW_CODE`` env vars are set, the single
-        matching email receives that fixed code instead of a random one, so a
-        reviewer signs in without an inbox (allauth verifies the code locally, so
-        the email never has to arrive).
-
-        This is intentionally opt-in: with either env var unset the branch does not
-        run and every account, including this one, gets allauth's random code. The
-        carve-out is scoped to exactly one address; all other members are untouched.
-        The fixed code is a secret set only in the deploy environment, so treat it
-        like a password (long and random).
-        """
-        review_email = os.environ.get("PLAY_REVIEW_EMAIL", "").strip().lower()
-        review_code = os.environ.get("PLAY_REVIEW_CODE", "").strip()
-        if review_email and review_code:
-            from allauth.core import context as allauth_context
-
-            request = getattr(allauth_context, "request", None)
-            submitted = (request.POST.get("email", "") if request is not None else "").strip().lower()
-            if submitted and submitted == review_email:
-                logger.info("Issuing fixed review login code for %s", review_email)
-                return review_code
-        return super().generate_login_code()
 
     def send_mail(self, template_prefix: str, email: str, context: dict) -> None:
         """Gate login-code emails through the global circuit breaker, then send.
@@ -377,3 +350,64 @@ class AutoCreateUserLoginCodeForm(RequestLoginCodeForm):
                     pass
 
         return super().clean_email()
+
+
+class GoldenTicketConfirmLoginCodeForm(ConfirmLoginCodeForm):
+    """Accept a single fixed login code for any account that requested one.
+
+    App-store reviewers cannot receive our emailed one-time codes: review is
+    asynchronous and they cannot read a member's inbox. When ``PLAY_REVIEW_CODE``
+    is set, that value is accepted *in addition to* the real emailed code, for
+    whichever account is mid-login. Nothing about code generation changes —
+    every member still gets a random emailed code, and the fixed value is never
+    sent to anyone.
+
+    Checking at verification time rather than generation time is what makes this
+    robust: it holds no matter how the code was issued, so "Resend code" can no
+    longer strand a reviewer with a code that silently stopped working.
+
+    SECURITY: this is a master key. Anyone holding ``PLAY_REVIEW_CODE`` can sign
+    in as any account that has an email address, including addresses on
+    ``ADMIN_DOMAINS``, which :meth:`AdminRedirectAccountAdapter._sync_permissions`
+    auto-grants ``is_staff`` and ``is_superuser``. Treat the value like a root
+    password: long, random, set only in the deploy environment, and rotated the
+    moment app-store review is finished. Leaving the env var unset disables the
+    behaviour entirely.
+    """
+
+    @staticmethod
+    def _pending_login_user() -> Any | None:
+        """The user allauth is mid-login for, or None if there isn't one.
+
+        Deliberately *not* keyed off ``expected_code``: whether a code was
+        successfully generated and stashed is exactly the thing that can go wrong,
+        and the golden ticket has to keep working when it does.
+        """
+        from allauth.core import context as allauth_context
+
+        request = getattr(allauth_context, "request", None)
+        stage = getattr(request, "_login_stage", None)
+        login = getattr(stage, "login", None)
+        return getattr(login, "user", None)
+
+    def clean_code(self) -> str:
+        """Accept the golden ticket, otherwise fall back to allauth's own check."""
+        code: str = self.cleaned_data["code"]
+        golden = os.environ.get("PLAY_REVIEW_CODE", "").strip()
+
+        if golden and compare_user_code(actual=code, expected=golden):
+            # Requiring a pending user keeps the enumeration-prevention path (unknown
+            # email -> fake process with no user) from reaching a login with nobody to
+            # log in as, which would otherwise assert deep inside allauth.
+            user = self._pending_login_user()
+            if user is not None:
+                # A master key that leaves no trace is not auditable. Name the account
+                # every time it is used, at WARNING so it survives prod log levels.
+                logger.warning(
+                    "Golden-ticket login code accepted for %s (pk=%s)",
+                    getattr(user, "email", "") or "<no email>",
+                    getattr(user, "pk", "?"),
+                )
+                return code
+
+        return super().clean_code()

--- a/plfog/settings.py
+++ b/plfog/settings.py
@@ -438,7 +438,10 @@ LOGOUT_REDIRECT_URL = "/"
 ACCOUNT_ADAPTER = "plfog.adapters.AdminRedirectAccountAdapter"
 
 ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
-ACCOUNT_FORMS = {"request_login_code": "plfog.adapters.AutoCreateUserLoginCodeForm"}
+ACCOUNT_FORMS = {
+    "request_login_code": "plfog.adapters.AutoCreateUserLoginCodeForm",
+    "confirm_login_code": "plfog.adapters.GoldenTicketConfirmLoginCodeForm",
+}
 
 # Login-by-code (passwordless email login)
 ACCOUNT_LOGIN_BY_CODE_ENABLED = True

--- a/tests/plfog/adapters_spec.py
+++ b/tests/plfog/adapters_spec.py
@@ -1,6 +1,7 @@
 """BDD-style tests for plfog.adapters module — auto-admin, admin redirect, and signup gating."""
 
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -670,106 +671,117 @@ def describe_AdminRedirectAccountAdapter():
             ):
                 adapter.pre_login(request, user, signup=True)  # Should not raise
 
-    def describe_generate_login_code():
-        """App-store review carve-out: one designated email gets a fixed code.
+    def describe_GoldenTicketConfirmLoginCodeForm():
+        """App-store review carve-out: one fixed code is accepted for any pending login.
 
-        Everyone else — and every environment without both env vars set — falls
-        through to allauth's random code. The carve-out is proven by patching the
-        base ``generate_login_code`` to a sentinel and asserting delegation.
+        Code *generation* is untouched — every account still gets a random emailed
+        code. The carve-out lives at verification time, so it survives resends and
+        every other entry path. With ``PLAY_REVIEW_CODE`` unset it does nothing.
         """
 
-        REVIEW_EMAIL = "play-review@pastlives.space"
-        REVIEW_CODE = "PLR-9f3k2m7q"
+        GOLDEN = "59157bd9bbf9873fd724ec09eb13bbd2"
+        REAL_CODE = "PLR-9f3k2m7q"
 
-        def _request(rf, email):
-            """Build the request allauth would have in context during a code request.
+        def _form(submitted, expected=REAL_CODE, pending_user=object()):
+            """Validate the confirm form the way allauth's view drives it.
 
-            ``email`` of None means a GET with no email field (nothing submitted).
-            """
-            if email is None:
-                return rf.get("/accounts/login/code/")
-            return rf.post("/accounts/login/code/", data={"email": email})
-
-        def _generate(rf, email):
-            """Run generate_login_code with the given request in allauth's context.
-
-            allauth 65 sources the request from ``allauth.core.context``, not the
-            adapter constructor, so the request is injected there (as the real
-            middleware does), mirroring the send_mail specs above.
+            ``expected`` is the code allauth generated and stashed for this login.
+            ``pending_user`` is the account being logged in; None models the
+            enumeration-prevention path, where an unknown email yields a pending
+            login with nobody behind it.
             """
             from allauth.core import context as allauth_context
 
-            from plfog.adapters import AdminRedirectAccountAdapter
+            from plfog.adapters import GoldenTicketConfirmLoginCodeForm
 
-            adapter = AdminRedirectAccountAdapter()
-            request = _request(rf, email) if email is not ... else None
+            request = SimpleNamespace(_login_stage=SimpleNamespace(login=SimpleNamespace(user=pending_user)))
+            form = GoldenTicketConfirmLoginCodeForm(data={"code": submitted}, code=expected)
             with patch.object(allauth_context, "request", request):
-                return adapter.generate_login_code()
+                return form.is_valid(), form
 
-        def _generate_delegating(rf, email):
-            """Same as _generate but with the base random generator stubbed to a sentinel."""
-            from plfog.adapters import AdminRedirectAccountAdapter
+        def it_accepts_the_golden_code_for_any_pending_login(monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            with patch.object(AdminRedirectAccountAdapter.__bases__[0], "generate_login_code", return_value="RANDOM"):
-                return _generate(rf, email)
+            valid, _ = _form(GOLDEN)
+            assert valid
 
-        def it_returns_the_fixed_code_for_the_review_email(rf, monkeypatch):
-            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
-            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+        def it_still_accepts_the_real_emailed_code(monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            assert _generate(rf, REVIEW_EMAIL) == REVIEW_CODE
+            valid, _ = _form(REAL_CODE)
+            assert valid
 
-        def it_normalizes_whitespace_and_case_on_both_sides(rf, monkeypatch):
-            monkeypatch.setenv("PLAY_REVIEW_EMAIL", "  Play-Review@PastLives.Space  ")
-            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+        def it_rejects_a_code_that_is_neither(monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            assert _generate(rf, "  play-review@pastlives.space  ") == REVIEW_CODE
+            valid, form = _form("not-the-code")
+            assert not valid
+            assert "code" in form.errors
 
-        def it_delegates_to_random_for_any_other_email(rf, monkeypatch):
-            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
-            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+        def it_ignores_punctuation_and_case_like_allauth_does(monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            assert _generate_delegating(rf, "member@example.com") == "RANDOM"
+            valid, _ = _form(f"  {GOLDEN.upper()}  ")
+            assert valid
 
-        def it_delegates_to_random_when_env_is_not_set(rf, monkeypatch):
-            monkeypatch.delenv("PLAY_REVIEW_EMAIL", raising=False)
+        # NOTE: keep these flat. ``context_`` is neither in ``python_functions`` nor in
+        # pytest-describe's ``describe_prefixes``, so a ``context_`` block collects as a
+        # single no-op leaf test and every ``it_`` nested inside it silently never runs.
+        def it_falls_back_to_allauth_verification_when_the_env_var_is_unset(monkeypatch):
             monkeypatch.delenv("PLAY_REVIEW_CODE", raising=False)
 
-            assert _generate_delegating(rf, REVIEW_EMAIL) == "RANDOM"
+            assert _form(REAL_CODE)[0]
+            assert not _form(GOLDEN)[0]
 
-        def it_delegates_when_only_the_email_env_is_set(rf, monkeypatch):
-            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
-            monkeypatch.delenv("PLAY_REVIEW_CODE", raising=False)
+        def it_does_not_accept_an_empty_code_when_the_env_var_is_blank(monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", "   ")
 
-            assert _generate_delegating(rf, REVIEW_EMAIL) == "RANDOM"
+            assert not _form("")[0]
 
-        def it_delegates_when_only_the_code_env_is_set(rf, monkeypatch):
-            monkeypatch.delenv("PLAY_REVIEW_EMAIL", raising=False)
-            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+        def it_still_accepts_the_golden_code_when_no_code_was_stashed(monkeypatch):
+            """The live bug: the generated code goes missing by verification time."""
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            assert _generate_delegating(rf, REVIEW_EMAIL) == "RANDOM"
+            assert _form(GOLDEN, expected="")[0]
 
-        def it_delegates_when_there_is_no_request(rf, monkeypatch):
-            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
-            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+        def it_still_rejects_other_codes_when_no_code_was_stashed(monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            # email sentinel ``...`` forces the context request to None
-            assert _generate_delegating(rf, ...) == "RANDOM"
+            assert not _form(REAL_CODE, expected="")[0]
 
-        def it_delegates_when_no_email_is_submitted(rf, monkeypatch):
-            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
-            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+        def it_rejects_the_golden_code_when_there_is_no_account_to_log_in_as(monkeypatch):
+            """Unknown email -> fake pending login with no user. Must not be accepted."""
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            assert _generate_delegating(rf, None) == "RANDOM"  # GET, no email field
+            assert not _form(GOLDEN, pending_user=None)[0]
 
-        def it_logs_when_issuing_the_review_code(rf, monkeypatch, caplog):
-            monkeypatch.setenv("PLAY_REVIEW_EMAIL", REVIEW_EMAIL)
-            monkeypatch.setenv("PLAY_REVIEW_CODE", REVIEW_CODE)
+        def it_logs_a_warning_when_the_golden_code_is_used(monkeypatch, caplog):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            with caplog.at_level(logging.INFO, logger="plfog.adapters"):
-                _generate(rf, REVIEW_EMAIL)
+            with caplog.at_level(logging.WARNING, logger="plfog.adapters"):
+                _form(GOLDEN)
 
-            assert "Issuing fixed review login code" in caplog.text
+            assert "Golden-ticket login code accepted" in caplog.text
+
+        def it_names_the_account_in_the_audit_log(monkeypatch, caplog):
+            """A master key that leaves no trace is not auditable."""
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            user = SimpleNamespace(email="reviewer@example.com", pk=4242)
+
+            with caplog.at_level(logging.WARNING, logger="plfog.adapters"):
+                _form(GOLDEN, pending_user=user)
+
+            assert "reviewer@example.com" in caplog.text
+            assert "4242" in caplog.text
+
+        def it_logs_a_placeholder_when_the_account_has_no_email(monkeypatch, caplog):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            user = SimpleNamespace(email="", pk=7)
+
+            with caplog.at_level(logging.WARNING, logger="plfog.adapters"):
+                _form(GOLDEN, pending_user=user)
+
+            assert "<no email>" in caplog.text
 
     def describe_send_mail():
         def it_adds_dev_message_in_debug_mode(rf, settings):


### PR DESCRIPTION
## Why

App store reviewer sign in fails in production with "Incorrect code", and so does signing in as `appreview@pastlives.app` by hand.

Verified against prod before writing any code:

| Check | Result |
|---|---|
| `PLAY_REVIEW_EMAIL` / `PLAY_REVIEW_CODE` set on Render | yes |
| Active User + linked Member exist | yes |
| A real HTTPS code request stashes the **fixed** code in the DB session | yes, confirmed before and after the confirm page GET |
| Replaying that exact session in process | logs in fine |
| Submitting that same code over HTTPS | **rejected, real `id_code_error`** |

So the credential and the deployed adapter are both correct. Something between stashing the code and comparing it loses the value over HTTP. **That root cause is still open.** This PR stops the reviewer flow from depending on it.

## What changed

Move the carve out from generation time to verification time. `GoldenTicketConfirmLoginCodeForm` accepts `PLAY_REVIEW_CODE` in addition to the real emailed code, for whichever account is mid login.

* Code generation is untouched. Every member still gets a random emailed code, and the fixed value is never sent to anyone.
* It compares against the env var directly, so it works **even when the stashed code goes missing**, which is the live failure. Covered by `context_when_no_code_was_stashed`.
* Fixes the resend footgun. The old override keyed off `request.POST["email"]`; "Resend code" posts `action=resend` with no email, so it fell through to a random code and silently stranded the reviewer for good. Verification time checking survives every entry path.
* Accepting requires a pending login with a real user, so the enumeration prevention path (unknown email, no user) cannot reach a login with nobody to log in as.
* Every acceptance logs the account and pk at WARNING, so use of the key is auditable in prod logs.
* Drops the now unused `generate_login_code` override and `PLAY_REVIEW_EMAIL`. The env var can stay set on Render; nothing reads it.

> [!WARNING]
> **This is deliberately a master key.** Anyone holding `PLAY_REVIEW_CODE` can sign in as any account, including `ADMIN_DOMAINS` addresses, which `_sync_permissions` auto grants `is_staff` and `is_superuser`. This tradeoff was raised and chosen knowingly to unblock app store review. Treat the value like a root password, and rotate it once review is done. Unset the env var to disable the behaviour entirely.

## Testing

Full suite green: **6948 passed, coverage 98.41%** (gate 98%). Ruff clean.

New specs cover: golden code accepted for any pending login, real emailed code still accepted, anything else rejected, allauth punctuation and case normalisation, env var unset and blank, stashed code missing, no account to log in as, and the audit log naming the account.

The new specs are deliberately flat. `context_` is neither in `python_functions` nor in pytest-describe's `describe_prefixes`, so a `context_` block collects as a single no-op leaf test and every `it_` nested inside it silently never runs. Three specs here were written that way at first and were not executing; flattening them raised the file from 76 to 77 tests and closed a branch gap in `clean_code`. No other spec in the repo uses that pattern.

Wiring was verified through allauth's own `get_form_class(app_settings.FORMS, "confirm_login_code", ...)` rather than by reading the settings dict, so the form is confirmed live and not merely declared.

CI `lint` is green. Locally `mypy` crashes with `Error constructing plugin instance of NewSemanalDjangoPlugin` on this branch **and** on pristine `main`, so that is a local environment issue rather than anything this PR introduces.

## Considered and dropped

An earlier revision also switched the `pastlives.app` canonical redirect from 301 to 308 for unsafe methods, on the theory that a 301'd POST silently loses its body at the app shell origin. `mobile/capacitor.config.ts` sets `server.url` to `https://members.pastlives.space`, so the webview never posts to `pastlives.app` and that redirect only ever serves GETs. Dropped as speculative.

## Still open

Why a correct code is rejected over HTTP but accepted in process. Live debugging is currently blocked by the `3/h` per address rate limit on `request_login_code`, which is also worth revisiting since three attempts per hour is hostile to a store reviewer.

https://claude.ai/code/session_01E3AT42tU6DZoADp8yjhqkk
