### PR TITLE
[mobile] Patch brace-expansion and tar security advisories

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -353,15 +353,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-crc32": {
@@ -932,9 +932,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
Clears the three open Dependabot alerts, all against `mobile/package-lock.json`.

| Package | From | To | Severity |
|---|---|---|---|
| `brace-expansion` | 5.0.7 | 5.0.9 | 2x high (GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895) |
| `tar` | 7.5.19 | 7.5.22 | moderate (GHSA-r292-9mhp-454m) |

## Why this is low risk

Both packages are **transitive under `@capacitor/cli`**, and both fixes are **in-range patch bumps**, so `mobile/package.json` is unchanged. The diff is 7 lines of `version`/`resolved`/`integrity` in the lockfile. No packages added or removed.

Dependency chains:

```
@capacitor/cli -> tar                                                  (one hop)
@capacitor/cli -> rimraf -> glob -> minimatch -> brace-expansion       (four hops)
```

`npm audit` goes from 3 advisories to `found 0 vulnerabilities`.

## Exposure was low to begin with

These are Node-side dependencies of the `cap` CLI, used during `cap sync` / `cap run` on a developer machine. The Capacitor shell runs in server-URL mode against the live Django site and ships no npm-produced artifact, so nothing here was reachable from the published app. No native rebuild or store resubmission is implied.

## Notes

- `brace-expansion@5.0.9` narrows its `engines` to `node: "20 || >=22"` (was `18 || 20 || >=22`). No impact: local Node is 22 and no CI job runs Node.
- No CI workflow touches `mobile/`, so CI cannot exercise this path either way.

## Follow-ups worth considering (not in this PR)

- `@capacitor/cli` sits in `dependencies` rather than `devDependencies`; moving it would let future alerts self-classify as dev-only.
- Dependabot **security updates are disabled** on this repo (`dependabot_security_updates: disabled`, no `.github/dependabot.yml`), which is why these three never arrived as PRs. Enabling it would automate the next one.

https://claude.ai/code/session_01DSckuV5twbjoMe8aweHsvm