### PR TITLE
diag: temporary secret-gated endpoint for the reviewer login

### DIFF
--- a/core/diagnostics.py
+++ b/core/diagnostics.py
@@ -1,0 +1,85 @@
+"""Temporary secret-gated diagnostics for the app-store reviewer login.
+
+TEMPORARY — delete this module, its URL and its spec once the reviewer login is
+confirmed working in production.
+
+Why this exists: Render one-off jobs report ``succeeded`` regardless of the
+process exit code, and neither job stdout nor request-time logs reach the log
+stream. That leaves no way to observe what the running web process actually
+sees. This endpoint is the observation channel: it answers, over HTTPS where the
+response can simply be read, whether the deployed build and its environment
+match what we think they are.
+
+It reports presence and fingerprints only. No secret value is ever returned.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+from typing import Any
+
+import allauth
+from allauth.account import app_settings as account_app_settings
+from allauth.account.forms import ConfirmLoginCodeForm
+from allauth.utils import get_form_class
+from django.http import Http404, HttpRequest, JsonResponse
+
+from plfog.version import VERSION
+
+TOKEN_ENV_VAR = "DIAG_TOKEN"
+
+
+def _fingerprint(value: str) -> str:
+    """Return a short SHA-256 prefix, so a secret can be matched but never read."""
+    return hashlib.sha256(value.encode()).hexdigest()[:8]
+
+
+def _dotted_path(obj: type) -> str:
+    """Return the importable dotted path of a class, for comparing what is wired up."""
+    return f"{obj.__module__}.{obj.__qualname__}"
+
+
+def reviewer_login_diagnostics(request: HttpRequest) -> JsonResponse:
+    """Report what the running web process sees about the reviewer login carve-out.
+
+    Gated on the ``DIAG_TOKEN`` environment variable. When that variable is unset,
+    or the supplied ``?t=`` value does not match it, the endpoint raises 404 so it
+    is indistinguishable from a route that does not exist. Removing the env var
+    disables the endpoint without a code change.
+
+    Returns:
+        A JSON body describing the deployed build, the wired-up confirm form, and
+        whether ``PLAY_REVIEW_CODE`` is visible to this process (length and
+        fingerprint only, never the value).
+
+    Raises:
+        Http404: If ``DIAG_TOKEN`` is unset or the supplied token does not match.
+    """
+    expected = os.environ.get(TOKEN_ENV_VAR, "").strip()
+    supplied = request.GET.get("t", "")
+    if not expected or not secrets.compare_digest(supplied, expected):
+        raise Http404("Not found.")
+
+    from plfog import adapters
+
+    review_code = os.environ.get("PLAY_REVIEW_CODE", "").strip()
+    confirm_form = get_form_class(account_app_settings.FORMS, "confirm_login_code", ConfirmLoginCodeForm)
+
+    payload: dict[str, Any] = {
+        # Which build is actually serving this request.
+        "app_version": VERSION,
+        "render_git_commit": os.environ.get("RENDER_GIT_COMMIT", ""),
+        "allauth_version": ".".join(str(part) for part in allauth.VERSION[:3]),
+        # Is the merged code really here?
+        "golden_form_present": hasattr(adapters, "GoldenTicketConfirmLoginCodeForm"),
+        "adapter_overrides_generate_login_code": "generate_login_code" in adapters.AdminRedirectAccountAdapter.__dict__,
+        # Is our form the one allauth will actually use for the confirm step?
+        "confirm_login_code_form": _dotted_path(confirm_form),
+        # Can this process see the secret at all?
+        "play_review_code_present": bool(review_code),
+        "play_review_code_length": len(review_code),
+        "play_review_code_fingerprint": _fingerprint(review_code) if review_code else "",
+    }
+    return JsonResponse(payload)

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,9 +2,12 @@
 
 from django.urls import path
 
-from . import copy_review_views, views
+from . import copy_review_views, diagnostics, views
 
 urlpatterns = [
+    # TEMPORARY reviewer-login diagnostics. 404s unless DIAG_TOKEN is set and matches.
+    # Delete this route with core/diagnostics.py once reviewer login is confirmed.
+    path("_diag/reviewer-login/", diagnostics.reviewer_login_diagnostics, name="reviewer_login_diagnostics"),
     # Cross-surface session relay (SSO between members and book surfaces)
     path("auth/relay/", views.relay_issue, name="relay_issue"),
     path("auth/relay/accept/", views.relay_accept, name="relay_accept"),

--- a/tests/core/reviewer_diagnostics_spec.py
+++ b/tests/core/reviewer_diagnostics_spec.py
@@ -1,0 +1,91 @@
+"""Specs for the temporary secret-gated reviewer-login diagnostics endpoint.
+
+NOTE: specs are deliberately flat. ``context_`` is neither in ``python_functions``
+nor in pytest-describe's ``describe_prefixes``, so a ``context_`` block collects as
+a single no-op leaf test and every ``it_`` nested inside it silently never runs.
+"""
+
+import hashlib
+import json
+
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+TOKEN = "diag-token-for-tests"
+
+
+def _get(client, monkeypatch, token=TOKEN, diag_token=TOKEN):
+    """Call the endpoint with the given supplied/configured tokens."""
+    if diag_token is None:
+        monkeypatch.delenv("DIAG_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("DIAG_TOKEN", diag_token)
+    url = reverse("reviewer_login_diagnostics")
+    return client.get(url, {"t": token} if token is not None else {})
+
+
+def describe_reviewer_login_diagnostics():
+    def it_404s_when_the_env_var_is_unset(client, monkeypatch):
+        assert _get(client, monkeypatch, diag_token=None).status_code == 404
+
+    def it_404s_when_the_env_var_is_blank(client, monkeypatch):
+        assert _get(client, monkeypatch, diag_token="   ").status_code == 404
+
+    def it_404s_when_no_token_is_supplied(client, monkeypatch):
+        assert _get(client, monkeypatch, token=None).status_code == 404
+
+    def it_404s_when_the_token_does_not_match(client, monkeypatch):
+        assert _get(client, monkeypatch, token="wrong-token").status_code == 404
+
+    def it_returns_json_when_the_token_matches(client, monkeypatch):
+        response = _get(client, monkeypatch)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/json"
+
+    def it_reports_the_wired_up_confirm_form(client, monkeypatch):
+        payload = json.loads(_get(client, monkeypatch).content)
+
+        assert payload["confirm_login_code_form"] == "plfog.adapters.GoldenTicketConfirmLoginCodeForm"
+
+    def it_reports_that_the_golden_form_is_present(client, monkeypatch):
+        payload = json.loads(_get(client, monkeypatch).content)
+
+        assert payload["golden_form_present"] is True
+
+    def it_reports_that_the_old_override_is_gone(client, monkeypatch):
+        payload = json.loads(_get(client, monkeypatch).content)
+
+        assert payload["adapter_overrides_generate_login_code"] is False
+
+    def it_reports_the_build_identifiers(client, monkeypatch):
+        monkeypatch.setenv("RENDER_GIT_COMMIT", "abc1234")
+        payload = json.loads(_get(client, monkeypatch).content)
+
+        assert payload["render_git_commit"] == "abc1234"
+        assert payload["app_version"]
+        assert payload["allauth_version"].startswith("65.")
+
+    def it_reports_the_review_code_as_present_with_a_fingerprint(client, monkeypatch):
+        monkeypatch.setenv("PLAY_REVIEW_CODE", "  supersecretvalue  ")
+        payload = json.loads(_get(client, monkeypatch).content)
+
+        assert payload["play_review_code_present"] is True
+        assert payload["play_review_code_length"] == len("supersecretvalue")
+        assert payload["play_review_code_fingerprint"] == hashlib.sha256(b"supersecretvalue").hexdigest()[:8]
+
+    def it_never_returns_the_review_code_itself(client, monkeypatch):
+        monkeypatch.setenv("PLAY_REVIEW_CODE", "supersecretvalue")
+        body = _get(client, monkeypatch).content.decode()
+
+        assert "supersecretvalue" not in body
+
+    def it_reports_the_review_code_as_absent_when_unset(client, monkeypatch):
+        monkeypatch.delenv("PLAY_REVIEW_CODE", raising=False)
+        payload = json.loads(_get(client, monkeypatch).content)
+
+        assert payload["play_review_code_present"] is False
+        assert payload["play_review_code_length"] == 0
+        assert payload["play_review_code_fingerprint"] == ""


### PR DESCRIPTION
**TEMPORARY.** Delete `core/diagnostics.py`, its route and its spec once reviewer login is confirmed working in production.

## Why

Reviewer sign in still fails in production with "Incorrect code" after #175, while the identical curl flow succeeds against a local replica running the same commit under gunicorn with `DEBUG=False`. Closing that gap needs a look inside the running web process, and there is currently no way to get one.

**Render one-off jobs report `succeeded` regardless of the process exit code.** Verified with controls, all of which reported succeeded when they should have failed:

| Command | Expected | Actual |
|---|---|---|
| `manage.py shell -c` … `sys.exit(1)` | failed | **succeeded** |
| `manage.py shell -c` … `assert False` | failed | **succeeded** |
| plain `python -c` … `sys.exit(1)` | failed | **succeeded** |

Job stdout does not reach the log stream, and no request-time logs arrive either, so logging is not an option. That leaves no channel at all, which is how a full day of debugging ended up built on results that always read as "pass".

## What this adds

A single read-only endpoint that answers, over HTTPS where the response can simply be read, whether the deployed build and its environment are what we think they are:

- `app_version`, `render_git_commit`, `allauth_version` — which build is actually serving
- `golden_form_present`, `adapter_overrides_generate_login_code` — is the merged code really there
- `confirm_login_code_form` — which form allauth actually resolves for the confirm step
- `play_review_code_present`, `play_review_code_length`, `play_review_code_fingerprint` — can this process see the secret

## Safety

- 404s unless `DIAG_TOKEN` is set **and** the supplied `?t=` matches, compared with `secrets.compare_digest`. Indistinguishable from a route that does not exist.
- Unsetting the env var disables it with no code change.
- Reports presence, length and an 8 character SHA-256 prefix only. The secret value is never returned, and a spec asserts it does not appear in the body.
- Read-only. No writes, no session or auth side effects.

## Testing

Full suite green: **6960 passed, coverage 98.41%** (gate 98%). `core/diagnostics.py` is at **100%**. Ruff clean.

Verified over real HTTP against a local gunicorn replica, not just the test client:

```
no token      -> 404
wrong token   -> 404
correct token -> 200 {"app_version": "0.23.49", "allauth_version": "65.18.0",
                      "golden_form_present": true,
                      "adapter_overrides_generate_login_code": false,
                      "confirm_login_code_form": "plfog.adapters.GoldenTicketConfirmLoginCodeForm",
                      "play_review_code_present": true, ...}
```

Those are the reference values production should match.

## To use it

Set `DIAG_TOKEN` on Render to any random string, let it redeploy, then fetch `/_diag/reviewer-login/?t=<token>`. Remove the env var when finished, and delete this code once the login is fixed.

https://claude.ai/code/session_01E3AT42tU6DZoADp8yjhqkk
