### PR TITLE
fix(auth): golden ticket must provision the account it logs in

### DIFF
--- a/plfog/adapters.py
+++ b/plfog/adapters.py
@@ -32,6 +32,26 @@ _AUTH_TRIGGER_KINDS: dict[str, str] = {
 }
 
 
+def _get_or_create_passwordless_user(email: str) -> Any:
+    """Fetch the User for an email, creating a passwordless one if there isn't one.
+
+    Tolerates a concurrent create: two login-code requests for the same new email
+    (e.g. a double-clicked submit) can both miss the existence check; the username
+    unique constraint then makes the loser raise IntegrityError. The user exists
+    either way, so re-read instead of surfacing a 500.
+    """
+    from django.db import IntegrityError
+
+    user = User.objects.filter(email__iexact=email).first()
+    if user is not None:
+        return user
+    try:
+        return User.objects.create_user(username=email, email=email)
+    except IntegrityError:
+        logger.info("Login-code user already created concurrently for %s", email)
+        return User.objects.filter(email__iexact=email).first()
+
+
 def _auth_trigger_kind(template_prefix: str) -> str:
     """Derive a ``TransactionalEmailLog`` trigger label from an allauth template prefix.
 
@@ -310,19 +330,8 @@ class AutoCreateUserLoginCodeForm(RequestLoginCodeForm):
 
     @staticmethod
     def _create_user_idempotent(email: str) -> None:
-        """Create a passwordless User, tolerating a concurrent create.
-
-        Two login-code requests for the same new email (e.g. a double-clicked
-        submit) can both pass the existence check in ``clean_email``; the
-        username unique constraint then makes the loser raise IntegrityError.
-        Swallow it — the user exists either way — instead of surfacing a 500.
-        """
-        from django.db import IntegrityError
-
-        try:
-            User.objects.create_user(username=email, email=email)
-        except IntegrityError:
-            logger.info("Login-code user already created concurrently for %s", email)
+        """Create a passwordless User, tolerating a concurrent create."""
+        _get_or_create_passwordless_user(email)
 
     def clean_email(self) -> str:
         """Auto-create User for known Members, then run normal allauth lookup."""
@@ -364,31 +373,69 @@ class GoldenTicketConfirmLoginCodeForm(ConfirmLoginCodeForm):
 
     Checking at verification time rather than generation time is what makes this
     robust: it holds no matter how the code was issued, so "Resend code" can no
-    longer strand a reviewer with a code that silently stopped working.
+    longer strand a reviewer with a code that silently stopped working. When the
+    typed email has no account behind it, one is provisioned — see
+    :meth:`_login_user` for why that is required rather than merely convenient.
 
     SECURITY: this is a master key. Anyone holding ``PLAY_REVIEW_CODE`` can sign
-    in as any account that has an email address, including addresses on
-    ``ADMIN_DOMAINS``, which :meth:`AdminRedirectAccountAdapter._sync_permissions`
-    auto-grants ``is_staff`` and ``is_superuser``. Treat the value like a root
-    password: long, random, set only in the deploy environment, and rotated the
-    moment app-store review is finished. Leaving the env var unset disables the
-    behaviour entirely.
+    in as any email address, including one that does not exist yet and including
+    addresses on ``ADMIN_DOMAINS``, which
+    :meth:`AdminRedirectAccountAdapter._sync_permissions` auto-grants ``is_staff``
+    and ``is_superuser``. Treat the value like a root password: long, random, set
+    only in the deploy environment, and rotated the moment app-store review is
+    finished. Leaving the env var unset disables the behaviour entirely.
     """
 
     @staticmethod
-    def _pending_login_user() -> Any | None:
-        """The user allauth is mid-login for, or None if there isn't one.
-
-        Deliberately *not* keyed off ``expected_code``: whether a code was
-        successfully generated and stashed is exactly the thing that can go wrong,
-        and the golden ticket has to keep working when it does.
-        """
+    def _login_stage() -> Any | None:
+        """The allauth login stage for the request being verified, if there is one."""
         from allauth.core import context as allauth_context
 
         request = getattr(allauth_context, "request", None)
-        stage = getattr(request, "_login_stage", None)
-        login = getattr(stage, "login", None)
-        return getattr(login, "user", None)
+        return getattr(request, "_login_stage", None)
+
+    @staticmethod
+    def _attach_user(stage: Any, user: Any) -> None:
+        """Put ``user`` behind a pending login that has nobody behind it yet.
+
+        ``LoginCodeVerificationProcess`` is built before the form runs, so its
+        ``_user`` is already latched to ``None`` and setting ``login.user`` alone is
+        not enough. Its ``user`` property falls through to ``state["user_id"]``, and
+        that state dict is the same object as ``stage.state`` — so writing the id
+        there is what actually gives ``finish()`` somebody to log in.
+        """
+        from allauth.account.internal.userkit import user_id_to_str
+
+        stage.login.user = user
+        stage.state["user_id"] = user_id_to_str(user)
+
+    @classmethod
+    def _login_user(cls) -> Any | None:
+        """The account to log in, provisioning one from the typed email if needed.
+
+        An email with no ``User`` row does not fail the login-code request: allauth's
+        enumeration prevention runs the whole flow with an empty shell of a login so
+        the response is indistinguishable from a real one. Nothing is stashed to
+        compare against and there is no user to log in, so the golden ticket has to
+        supply the account itself or it is dead on exactly the accounts a reviewer is
+        most likely to be handed.
+        """
+        stage = cls._login_stage()
+        if stage is None:
+            return None
+
+        user = getattr(stage.login, "user", None)
+        if user is not None:
+            return user
+
+        email: str = (stage.state.get("email") or getattr(stage.login, "email", "") or "").strip()
+        if not email:
+            # A phone-only or otherwise contactless login: nothing to provision from.
+            return None
+
+        user = _get_or_create_passwordless_user(email)
+        cls._attach_user(stage, user)
+        return user
 
     def clean_code(self) -> str:
         """Accept the golden ticket, otherwise fall back to allauth's own check."""
@@ -396,10 +443,7 @@ class GoldenTicketConfirmLoginCodeForm(ConfirmLoginCodeForm):
         golden = os.environ.get("PLAY_REVIEW_CODE", "").strip()
 
         if golden and compare_user_code(actual=code, expected=golden):
-            # Requiring a pending user keeps the enumeration-prevention path (unknown
-            # email -> fake process with no user) from reaching a login with nobody to
-            # log in as, which would otherwise assert deep inside allauth.
-            user = self._pending_login_user()
+            user = self._login_user()
             if user is not None:
                 # A master key that leaves no trace is not auditable. Name the account
                 # every time it is used, at WARNING so it survives prod log levels.

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.49"
+VERSION = "0.23.50"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {

--- a/tests/plfog/adapters_spec.py
+++ b/tests/plfog/adapters_spec.py
@@ -682,19 +682,26 @@ def describe_AdminRedirectAccountAdapter():
         GOLDEN = "59157bd9bbf9873fd724ec09eb13bbd2"
         REAL_CODE = "PLR-9f3k2m7q"
 
-        def _form(submitted, expected=REAL_CODE, pending_user=object()):
+        def _stage(pending_user=object(), email=""):
+            """A stand-in for allauth's login stage, with the same shape the form reads."""
+            state = {"email": email} if email else {}
+            return SimpleNamespace(login=SimpleNamespace(user=pending_user, email=email), state=state)
+
+        def _form(submitted, expected=REAL_CODE, pending_user=object(), email="", stage=None):
             """Validate the confirm form the way allauth's view drives it.
 
             ``expected`` is the code allauth generated and stashed for this login.
             ``pending_user`` is the account being logged in; None models the
             enumeration-prevention path, where an unknown email yields a pending
-            login with nobody behind it.
+            login with nobody behind it and only the typed ``email`` to go on.
             """
             from allauth.core import context as allauth_context
 
             from plfog.adapters import GoldenTicketConfirmLoginCodeForm
 
-            request = SimpleNamespace(_login_stage=SimpleNamespace(login=SimpleNamespace(user=pending_user)))
+            if stage is None:
+                stage = _stage(pending_user=pending_user, email=email)
+            request = SimpleNamespace(_login_stage=stage)
             form = GoldenTicketConfirmLoginCodeForm(data={"code": submitted}, code=expected)
             with patch.object(allauth_context, "request", request):
                 return form.is_valid(), form
@@ -749,11 +756,60 @@ def describe_AdminRedirectAccountAdapter():
 
             assert not _form(REAL_CODE, expected="")[0]
 
-        def it_rejects_the_golden_code_when_there_is_no_account_to_log_in_as(monkeypatch):
-            """Unknown email -> fake pending login with no user. Must not be accepted."""
+        def it_provisions_an_account_when_the_email_has_none(monkeypatch):
+            """The live prod failure: an email with no User row.
+
+            allauth's enumeration prevention runs the whole flow with an empty shell
+            of a login, so requiring a pre-existing user silently disabled the golden
+            ticket on exactly the accounts a reviewer gets handed.
+            """
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            assert not User.objects.filter(email="nobody@example.com").exists()
+
+            valid, _ = _form(GOLDEN, expected="", pending_user=None, email="nobody@example.com")
+
+            assert valid
+            assert User.objects.filter(email="nobody@example.com").count() == 1
+
+        def it_attaches_the_provisioned_account_to_the_pending_login(monkeypatch):
+            """Attaching to ``login.user`` alone is not enough — the process reads state."""
+            from allauth.account.internal.userkit import user_id_to_str
+
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            stage = _stage(pending_user=None, email="nobody@example.com")
+
+            _form(GOLDEN, expected="", stage=stage)
+
+            user = User.objects.get(email="nobody@example.com")
+            assert stage.login.user == user
+            assert stage.state["user_id"] == user_id_to_str(user)
+
+        def it_reuses_an_existing_account_rather_than_duplicating_it(monkeypatch):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            existing = User.objects.create_user(username="known@example.com", email="known@example.com")
+
+            valid, _ = _form(GOLDEN, expected="", pending_user=None, email="known@example.com")
+
+            assert valid
+            assert User.objects.filter(email="known@example.com").count() == 1
+            assert User.objects.get(email="known@example.com").pk == existing.pk
+
+        def it_rejects_the_golden_code_when_there_is_no_email_to_provision_from(monkeypatch):
+            """No user and no email — nothing to log in as, so fall through."""
             monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
 
-            assert not _form(GOLDEN, pending_user=None)[0]
+            assert not _form(GOLDEN, pending_user=None, email="")[0]
+
+        def it_rejects_the_golden_code_when_there_is_no_login_stage(monkeypatch):
+            """Not mid-login at all: nothing to attach a user to."""
+            from allauth.core import context as allauth_context
+
+            from plfog.adapters import GoldenTicketConfirmLoginCodeForm
+
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            form = GoldenTicketConfirmLoginCodeForm(data={"code": GOLDEN}, code="")
+            with patch.object(allauth_context, "request", SimpleNamespace()):
+                assert not form.is_valid()
 
         def it_logs_a_warning_when_the_golden_code_is_used(monkeypatch, caplog):
             monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
@@ -782,6 +838,61 @@ def describe_AdminRedirectAccountAdapter():
                 _form(GOLDEN, pending_user=user)
 
             assert "<no email>" in caplog.text
+
+        # End-to-end, through allauth's real views and session state. The form-level
+        # specs above drive a hand-built stage, which is precisely how the prod-only
+        # failure slipped through: the fake always had a user, so the branch that
+        # matters never ran. These post to the actual URLs instead.
+        def _sign_in(client, email, code=GOLDEN):
+            """Drive the real two-step login-code flow and report whether it signed in."""
+            client.post(reverse("account_request_login_code"), {"email": email})
+            response = client.post(reverse("account_confirm_login_code"), {"code": code})
+            return response, client.session.get("_auth_user_id")
+
+        def it_signs_in_end_to_end_when_the_email_has_no_account(client, monkeypatch, settings):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            settings.ACCOUNT_RATE_LIMITS = False
+
+            response, auth_user_id = _sign_in(client, "reviewer@example.com")
+
+            assert response.status_code == 302
+            assert auth_user_id is not None
+            assert User.objects.get(pk=auth_user_id).email == "reviewer@example.com"
+
+        def it_signs_in_end_to_end_when_the_account_already_exists(client, monkeypatch, settings):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            settings.ACCOUNT_RATE_LIMITS = False
+            existing = User.objects.create_user(username="member@example.com", email="member@example.com")
+
+            response, auth_user_id = _sign_in(client, "member@example.com")
+
+            assert response.status_code == 302
+            assert auth_user_id == str(existing.pk)
+
+        def it_does_not_sign_in_end_to_end_with_a_wrong_code(client, monkeypatch, settings):
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            settings.ACCOUNT_RATE_LIMITS = False
+
+            _, auth_user_id = _sign_in(client, "reviewer@example.com", code="not-the-code")
+
+            assert auth_user_id is None
+
+        def it_does_not_provision_an_account_for_a_wrong_code(client, monkeypatch, settings):
+            """A rejected attempt must not leave a User behind for the typed email."""
+            monkeypatch.setenv("PLAY_REVIEW_CODE", GOLDEN)
+            settings.ACCOUNT_RATE_LIMITS = False
+
+            _sign_in(client, "stranger@example.com", code="not-the-code")
+
+            assert not User.objects.filter(email="stranger@example.com").exists()
+
+        def it_does_not_sign_in_end_to_end_when_the_env_var_is_unset(client, monkeypatch, settings):
+            monkeypatch.delenv("PLAY_REVIEW_CODE", raising=False)
+            settings.ACCOUNT_RATE_LIMITS = False
+
+            _, auth_user_id = _sign_in(client, "reviewer@example.com")
+
+            assert auth_user_id is None
 
     def describe_send_mail():
         def it_adds_dev_message_in_debug_mode(rf, settings):


### PR DESCRIPTION
Fixes the reviewer login still failing with "Incorrect code" in production after #175.

## Root cause

The golden ticket was disabled on exactly the accounts a reviewer gets handed.

When the typed email has no `User` row, allauth does **not** report an unknown account. `ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False` makes it run the entire flow against an empty shell of a login, so the response is indistinguishable from a real one and the form cannot be used to enumerate registered emails. That shell has `login.user = None`, and no code is ever generated or stashed.

`GoldenTicketConfirmLoginCodeForm.clean_code` required a pending user before honouring the fixed code. There isn't one on that path, so it fell through to allauth's own check, which compared the submitted code against a code that was never generated. Result: a correct `PLAY_REVIEW_CODE` is rejected forever, and resending never helps.

The guard existed for a real reason: `LoginCodeVerificationProcess.finish` does a bare `assert user`, so accepting the code with nobody behind the login would have raised deep inside allauth. The guard traded a 500 for a permanent "Incorrect code".

This was invisible locally because the test account existed. Same code, different data.

## Fix

When the code matches and there is nobody behind the pending login, provision the account from the typed email and attach it. That is the "any email" behaviour this feature was asked for.

Attaching is the non-obvious part. `LoginCodeVerificationProcess` is constructed in the view's `dispatch`, before the form runs, so its `_user` is already latched to `None` and setting `login.user` alone changes nothing. Its `user` property falls through to `state["user_id"]`, and `stage.state` is the same dict object the process holds, so writing the id there is what actually gives `finish()` somebody to log in.

Also folds the existing `_create_user_idempotent` body into a shared `_get_or_create_passwordless_user` helper, so both entry points create the passwordless user the same way and both tolerate a concurrent create.

## Testing

The previous specs drove a hand-built stage that always had a user, which is precisely how this got through: the branch that breaks never ran. This adds end-to-end specs that post to the real allauth URLs and assert on the session.

Reproduced against merged `main` before fixing:

| scenario | with this fix | against merged main |
|---|---|---|
| email with no account | 302, signed in | **200 — the production symptom** |
| email with an existing account | 302, signed in | 302, signed in |

That second row is why local testing missed it.

21 golden-ticket specs, 5 of them end-to-end, covering: account provisioned when the email has none, the provisioned user attached to both `login.user` and `state["user_id"]`, an existing account reused rather than duplicated, no account provisioned for a wrong code, and the whole carve-out inert when `PLAY_REVIEW_CODE` is unset.

## Security

Unchanged in kind, wider in reach, and worth stating plainly: `PLAY_REVIEW_CODE` is a master key. It now signs in as **any email, including one that does not exist yet**, and an address on `ADMIN_DOMAINS` is auto-granted `is_staff` and `is_superuser` by `_sync_permissions`. Every use is logged at WARNING with the account name and pk. Rotate the value the moment app-store review is finished; unsetting the env var disables the behaviour entirely.

## Changelog

`VERSION` bumped, no `CHANGELOG` entry. This is an app-store-reviewer-only carve-out that no member can see, so there is nothing member-facing to announce. `announce_release` at `0.23.50` will post nothing, which is the intended outcome.
