### PR TITLE
[analytics] Cover the member hub, and count hx-boost navigations (v0.23.50)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.49"
+VERSION = "0.23.50"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.50",
+        "date": "2026-08-06",
+        "title": "Usage measurement now covers the Member Hub",
+        "changes": [
+            "We already measured which pages get used on the main site and on class pages. That now "
+            "covers the Member Hub too, so we can see which tools members actually use and put our "
+            "time where it helps most.",
+            "This is anonymous, aggregate usage data through Google Analytics. It does not include "
+            "your name or your email address. The Privacy Policy has the details.",
+            "The staff admin area is still excluded, the same as before.",
+        ],
+    },
     {
         "version": "0.23.49",
         "date": "2026-07-29",

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="{% static 'css/hub.css' %}">
     <link rel="stylesheet" href="{% static 'css/components.css' %}">
     <meta name="default-theme" content="{% block default_theme %}dark{% endblock %}">
+    {% include "includes/google_analytics.html" %}
     <script>
         (function() {
             var h = document.documentElement;

--- a/templates/includes/google_analytics.html
+++ b/templates/includes/google_analytics.html
@@ -5,5 +5,29 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   gtag('config', '{{ google_analytics_measurement_id }}');
+
+  // The member hub navigates with hx-boost: htmx swaps the body and pushes a new URL
+  // without a document load, so gtag's automatic page_view only ever fires for the
+  // first page of a session. The head-support extension keys head elements by their
+  // outerHTML and preserves identical ones, so this block is never re-evaluated on a
+  // boosted navigation either. Send page_view ourselves instead.
+  //
+  // afterSettle covers forward navigation; historyRestore covers back/forward, which
+  // merges the head without firing a swap. Both bubble to document. The path guard
+  // keeps partial swaps that leave the URL alone from counting as navigations.
+  (function () {
+    var lastPath = window.location.pathname + window.location.search;
+    function trackPageView() {
+      var currentPath = window.location.pathname + window.location.search;
+      if (currentPath === lastPath) { return; }
+      lastPath = currentPath;
+      gtag('event', 'page_view', {
+        page_location: window.location.href,
+        page_title: document.title
+      });
+    }
+    document.addEventListener('htmx:afterSettle', trackPageView);
+    document.addEventListener('htmx:historyRestore', trackPageView);
+  })();
 </script>
 {% endif %}

--- a/tests/hub/google_analytics_spec.py
+++ b/tests/hub/google_analytics_spec.py
@@ -1,0 +1,55 @@
+"""BDD specs for Google Analytics coverage of the member hub.
+
+The hub renders from ``templates/hub/base.html``, which was the one member-facing
+layout the GA include never reached. It also navigates with ``hx-boost``, so a plain
+gtag snippet reports a single page_view per session; see the include for the fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+from core.models import SiteConfiguration
+
+
+@pytest.mark.django_db
+def describe_google_analytics_on_the_hub():
+    def _sign_in(client: Client) -> None:
+        User.objects.create_user(username="hubmember", password="pass")
+        client.login(username="hubmember", password="pass")
+
+    def it_omits_the_tag_when_no_measurement_id_is_set(client: Client):
+        _sign_in(client)
+
+        response = client.get("/feedback/")
+
+        assert response.status_code == 200
+        assert b"googletagmanager.com" not in response.content
+
+    def it_injects_the_tag_when_configured(client: Client):
+        config = SiteConfiguration.load()
+        config.google_analytics_measurement_id = "G-HUB12345"
+        config.save()
+        _sign_in(client)
+
+        response = client.get("/feedback/")
+
+        assert response.status_code == 200
+        assert b"googletagmanager.com" in response.content
+        assert b"G-HUB12345" in response.content
+
+    def it_sends_a_page_view_on_boosted_navigation(client: Client):
+        config = SiteConfiguration.load()
+        config.google_analytics_measurement_id = "G-HUB12345"
+        config.save()
+        _sign_in(client)
+
+        response = client.get("/feedback/")
+        body = response.content.decode()
+
+        # Without these, hx-boost navigation is invisible to GA.
+        assert "htmx:afterSettle" in body
+        assert "htmx:historyRestore" in body
+        assert "'page_view'" in body


### PR DESCRIPTION
## Why

Site Settings describes Google Analytics as *"injected on every member-facing and public page (the Django admin is excluded)"*, but `templates/hub/base.html` never included the partial. GA reached `base.html`, `classes/base_public.html`, and `guilds/base_public.html` only. The hub, where members actually spend their time, went unmeasured.

## Including the partial is not sufficient

The hub is `hx-boost="true" hx-ext="head-support"`. Two consequences, both verified by reading `static/js/htmx-ext-head-support.js` rather than assuming:

1. Boosted navigation swaps the body and pushes a URL without a document load, so gtag's automatic `page_view` fires only for the first page of a session.
2. head-support keys head elements by `outerHTML` and *preserves* identical ones (it deletes them from the merge map instead of re-appending), so the snippet is never re-evaluated on navigation either. No double counting, but no counting at all.

So the partial now sends `page_view` itself:

- `htmx:afterSettle` for forward navigation. The head merge runs on `htmx:afterSwap`, so `document.title` is already correct by then.
- `htmx:historyRestore` for back/forward, which merges the head without firing a swap.
- A path guard, so partial swaps that leave the URL alone are not counted as navigations.

## Scope

- The Django admin stays excluded. That is handled in the context processor and is untouched.
- The privacy policy already discloses Google Analytics and "pages viewed", so no policy change is needed.
- Members get a changelog entry anyway, since this widens what is measured.

## Testing

New `tests/hub/google_analytics_spec.py` covers tag absent when unconfigured, tag present when configured, and the boosted-navigation hooks being emitted. Full suite: 6951 passed. `ruff format`, `ruff check` clean.

## Note for the reviewer

`announce_release` raises `CommandError` when no CHANGELOG entry matches `VERSION`, and a test enforces it, so the version bump requires an entry. The entry here is deliberately about the measurement change itself rather than a feature, because that is what actually changed for members.

https://claude.ai/code/session_01BjUajPuNWTaHF4ncHP9Qr4