### PR TITLE
[discord] Auto announce a release when a push to main ships a new VERSION

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,12 +1,24 @@
 name: Discord Notifications
 
-# Manual-only on purpose. This used to fire on every push to main, which re-posted the
-# WHOLE current release-line changelog on every routine hotfix merge — a duplicate
-# announcement to members each time. A release announcement is a deliberate act, so it is
-# now triggered by hand when a release actually ships:
-#   gh workflow run discord-notify.yml        (or the "Run workflow" button in the Actions UI)
+# Fires automatically when a push to main ships a new VERSION, and can still be run by
+# hand (`gh workflow run discord-notify.yml`, or the Actions "Run workflow" button).
+#
+# This was manual-only for a while because it used to re-post the WHOLE current
+# release-line changelog on every routine hotfix merge, spamming members with things
+# already announced. The script now posts ONLY the entry/entries stamped at the current
+# VERSION, so one merge means one deploy means one announcement. Two guards keep it that
+# way on automatic runs:
+#   1. `paths:` — the job is only considered when plfog/version.py itself changed.
+#   2. the "Check whether VERSION changed" step below — it compares VERSION against the
+#      parent commit and skips the post when it is unchanged, so edits to changelog
+#      wording (or any other version.py churn) never re-announce a shipped release.
+# A manual run always posts, which is the escape hatch for re-sending an announcement.
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "plfog/version.py"
 
 jobs:
   notify:
@@ -14,13 +26,38 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Need the parent commit so the step below can diff VERSION across the push.
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
+      - name: Check whether VERSION changed
+        id: version_changed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual run, announcing regardless of VERSION."
+            echo "should_post=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          current=$(python -c "import sys; sys.path.insert(0, '.'); from plfog.version import VERSION; print(VERSION)")
+          previous=$(git show HEAD^:plfog/version.py 2>/dev/null | grep -E '^VERSION = ' | head -1 | cut -d'"' -f2 || true)
+          echo "previous=${previous:-<none>} current=${current}"
+          if [ "$current" = "$previous" ]; then
+            echo "VERSION is unchanged, skipping the announcement."
+            echo "should_post=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_post=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Post release announcement to Discord
+        if: steps.version_changed.outputs.should_post == 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         # Posts only the current VERSION's changelog entry (what just shipped),


### PR DESCRIPTION
## Why

Release announcements are currently manual (`workflow_dispatch` only). The comment explains the reason: the workflow used to fire on every push to main and re-post the **whole** current release-line changelog, so every routine hotfix merge spammed members with things already announced.

That reason no longer holds. `discord_release_notify.py` now posts only the entry/entries stamped at the current `VERSION`, so one merge means one deploy means one announcement.

## What changed

Restores `push: branches: [main]`, keeps `workflow_dispatch`, and adds two guards so an automatic run cannot re-announce a release that already went out:

1. **`paths: [plfog/version.py]`** so the job is only considered when the version file changed at all.
2. **A gate step** that reads `VERSION` at `HEAD` and at `HEAD^` and skips the post when they match. This catches changelog wording edits and any other `version.py` churn that is not a release.

`workflow_dispatch` bypasses the gate and always posts, which is the escape hatch for re-sending an announcement by hand.

## Why the second guard is not redundant

`198b463` (PR #175) is a merge to main that did **not** bump `VERSION`. Under a naive push trigger it would have re-announced 0.23.49 to members. I ran the gate logic against that commit and against the 0.23.49 to 0.23.50 bump; it skips the first and posts on the second.

## Please confirm before merging

The destination channel is entirely determined by the `DISCORD_WEBHOOK_URL` repository secret, which I cannot read. Worth confirming it points at **#fog-app-announcements** and not wherever it was aimed when announcements were manual, since this makes posting automatic.

Also note `_release_entries()` falls back to `[CHANGELOG[0]]` when nothing matches `VERSION`, so a bump with no matching entry would quietly re-post the previous release under a new version footer. In practice CI blocks that (`announce_release` raises `CommandError`, and a test covers it), so I left the script alone rather than widen this PR.

https://claude.ai/code/session_01BjUajPuNWTaHF4ncHP9Qr4