### PR TITLE
[ci] Unbreak lint: parameterize the contact formset annotation for django-stubs 6.0.8

### DIFF
--- a/hub/views.py
+++ b/hub/views.py
@@ -38,6 +38,7 @@ from hub.forms import (
     GuildEditForm,
     GuildRoleFormSet,
     MemberAdminEditForm,
+    MemberContactForm,
     MemberContactFormSet,
     MemberSkillForm,
     OrgInfoPageForm,
@@ -1448,7 +1449,10 @@ def user_settings(request: HttpRequest) -> HttpResponse:
     member = _get_member(request)
 
     profile_form: ProfileSettingsForm | None
-    contact_formset: BaseInlineFormSet | None
+    # Parameterized on purpose: django-stubs 6.0.8 types inlineformset_factory's product as
+    # BaseInlineFormSet[MemberContact, Member, MemberContactForm], and a bare BaseInlineFormSet
+    # means BaseInlineFormSet[Any, Any, ModelForm[Any]], which no longer accepts that assignment.
+    contact_formset: BaseInlineFormSet[MemberContact, Member, MemberContactForm] | None
     if request.method == "POST" and request.POST.get("form_id") == "profile":
         if member is None:
             messages.error(request, "Your account is not linked to a membership.")


### PR DESCRIPTION
## This is blocking every open PR

`lint` is currently failing on branches that touch **no Python at all** (#180 changes one YAML file). The cause is not in any branch:

`requirements-dev.txt` asks for `django-stubs>=5.1` with no upper bound. **6.0.8** landed after main's last green run on 2026-08-05, so every CI run since picks it up while main's recorded green run used an older one.

## Root cause

6.0.8 types the product of `inlineformset_factory` as `BaseInlineFormSet[MemberContact, Member, MemberContactForm]`. A bare `BaseInlineFormSet` means `BaseInlineFormSet[Any, Any, ModelForm[Any]]`, so the assignment at `hub/views.py:1457` is no longer valid.

The other three errors are cascade, not separate bugs: once the assignment is rejected, the declared type keeps its `None` arm, so `is_valid()` and `save()` look like attribute access on `None`.

## How I confirmed it is not the PRs

Checked out **unmodified main**, installed `django-stubs==6.0.8`, and ran CI's exact invocation (`mypy plfog/ core/ membership/ hub/` with CI's env). Same five errors, on a tree with no PR changes on it. With 6.0.7 the same tree passes.

## The fix

Parameterize the annotation to the concrete types. Verified against **both 6.0.7 and 6.0.8**, so it does not depend on which version resolution picks, and no pin is needed.

Type-only change; runtime behavior untouched. 199 hub tests pass, `ruff format`/`ruff check` clean.

## Worth considering separately

`mypy>=1.13` and `django-stubs>=5.1` being unbounded means any upstream release can turn CI red with no change on our side. A compatible-release bound (`~=`) on the type-checking tools would make CI reproducible. I did not do that here since it is a policy call, not a blocker.

## Merge order

#179 and #180 cannot go green until this lands.

https://claude.ai/code/session_01BjUajPuNWTaHF4ncHP9Qr4