### PR TITLE
[analytics] Hub coverage + hx-boost pageviews, auto release announce, and a CI unbreak (v0.23.50)

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,12 +1,24 @@
 name: Discord Notifications
 
-# Manual-only on purpose. This used to fire on every push to main, which re-posted the
-# WHOLE current release-line changelog on every routine hotfix merge — a duplicate
-# announcement to members each time. A release announcement is a deliberate act, so it is
-# now triggered by hand when a release actually ships:
-#   gh workflow run discord-notify.yml        (or the "Run workflow" button in the Actions UI)
+# Fires automatically when a push to main ships a new VERSION, and can still be run by
+# hand (`gh workflow run discord-notify.yml`, or the Actions "Run workflow" button).
+#
+# This was manual-only for a while because it used to re-post the WHOLE current
+# release-line changelog on every routine hotfix merge, spamming members with things
+# already announced. The script now posts ONLY the entry/entries stamped at the current
+# VERSION, so one merge means one deploy means one announcement. Two guards keep it that
+# way on automatic runs:
+#   1. `paths:` — the job is only considered when plfog/version.py itself changed.
+#   2. the "Check whether VERSION changed" step below — it compares VERSION against the
+#      parent commit and skips the post when it is unchanged, so edits to changelog
+#      wording (or any other version.py churn) never re-announce a shipped release.
+# A manual run always posts, which is the escape hatch for re-sending an announcement.
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "plfog/version.py"
 
 jobs:
   notify:
@@ -14,13 +26,38 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Need the parent commit so the step below can diff VERSION across the push.
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
+      - name: Check whether VERSION changed
+        id: version_changed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual run, announcing regardless of VERSION."
+            echo "should_post=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          current=$(python -c "import sys; sys.path.insert(0, '.'); from plfog.version import VERSION; print(VERSION)")
+          previous=$(git show HEAD^:plfog/version.py 2>/dev/null | grep -E '^VERSION = ' | head -1 | cut -d'"' -f2 || true)
+          echo "previous=${previous:-<none>} current=${current}"
+          if [ "$current" = "$previous" ]; then
+            echo "VERSION is unchanged, skipping the announcement."
+            echo "should_post=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_post=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Post release announcement to Discord
+        if: steps.version_changed.outputs.should_post == 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         # Posts only the current VERSION's changelog entry (what just shipped),

--- a/hub/views.py
+++ b/hub/views.py
@@ -38,6 +38,7 @@ from hub.forms import (
     GuildEditForm,
     GuildRoleFormSet,
     MemberAdminEditForm,
+    MemberContactForm,
     MemberContactFormSet,
     MemberSkillForm,
     OrgInfoPageForm,
@@ -1448,7 +1449,10 @@ def user_settings(request: HttpRequest) -> HttpResponse:
     member = _get_member(request)
 
     profile_form: ProfileSettingsForm | None
-    contact_formset: BaseInlineFormSet | None
+    # Parameterized on purpose: django-stubs 6.0.8 types inlineformset_factory's product as
+    # BaseInlineFormSet[MemberContact, Member, MemberContactForm], and a bare BaseInlineFormSet
+    # means BaseInlineFormSet[Any, Any, ModelForm[Any]], which no longer accepts that assignment.
+    contact_formset: BaseInlineFormSet[MemberContact, Member, MemberContactForm] | None
     if request.method == "POST" and request.POST.get("form_id") == "profile":
         if member is None:
             messages.error(request, "Your account is not linked to a membership.")

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.49"
+VERSION = "0.23.50"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.50",
+        "date": "2026-08-06",
+        "title": "Usage measurement now covers the Member Hub",
+        "changes": [
+            "We already measured which pages get used on the main site and on class pages. That now "
+            "covers the Member Hub too, so we can see which tools members actually use and put our "
+            "time where it helps most.",
+            "This is anonymous, aggregate usage data through Google Analytics. It does not include "
+            "your name or your email address. The Privacy Policy has the details.",
+            "The staff admin area is still excluded, the same as before.",
+        ],
+    },
     {
         "version": "0.23.49",
         "date": "2026-07-29",

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="{% static 'css/hub.css' %}">
     <link rel="stylesheet" href="{% static 'css/components.css' %}">
     <meta name="default-theme" content="{% block default_theme %}dark{% endblock %}">
+    {% include "includes/google_analytics.html" %}
     <script>
         (function() {
             var h = document.documentElement;

--- a/templates/includes/google_analytics.html
+++ b/templates/includes/google_analytics.html
@@ -5,5 +5,29 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   gtag('config', '{{ google_analytics_measurement_id }}');
+
+  // The member hub navigates with hx-boost: htmx swaps the body and pushes a new URL
+  // without a document load, so gtag's automatic page_view only ever fires for the
+  // first page of a session. The head-support extension keys head elements by their
+  // outerHTML and preserves identical ones, so this block is never re-evaluated on a
+  // boosted navigation either. Send page_view ourselves instead.
+  //
+  // afterSettle covers forward navigation; historyRestore covers back/forward, which
+  // merges the head without firing a swap. Both bubble to document. The path guard
+  // keeps partial swaps that leave the URL alone from counting as navigations.
+  (function () {
+    var lastPath = window.location.pathname + window.location.search;
+    function trackPageView() {
+      var currentPath = window.location.pathname + window.location.search;
+      if (currentPath === lastPath) { return; }
+      lastPath = currentPath;
+      gtag('event', 'page_view', {
+        page_location: window.location.href,
+        page_title: document.title
+      });
+    }
+    document.addEventListener('htmx:afterSettle', trackPageView);
+    document.addEventListener('htmx:historyRestore', trackPageView);
+  })();
 </script>
 {% endif %}

--- a/tests/hub/google_analytics_spec.py
+++ b/tests/hub/google_analytics_spec.py
@@ -1,0 +1,55 @@
+"""BDD specs for Google Analytics coverage of the member hub.
+
+The hub renders from ``templates/hub/base.html``, which was the one member-facing
+layout the GA include never reached. It also navigates with ``hx-boost``, so a plain
+gtag snippet reports a single page_view per session; see the include for the fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+from core.models import SiteConfiguration
+
+
+@pytest.mark.django_db
+def describe_google_analytics_on_the_hub():
+    def _sign_in(client: Client) -> None:
+        User.objects.create_user(username="hubmember", password="pass")
+        client.login(username="hubmember", password="pass")
+
+    def it_omits_the_tag_when_no_measurement_id_is_set(client: Client):
+        _sign_in(client)
+
+        response = client.get("/feedback/")
+
+        assert response.status_code == 200
+        assert b"googletagmanager.com" not in response.content
+
+    def it_injects_the_tag_when_configured(client: Client):
+        config = SiteConfiguration.load()
+        config.google_analytics_measurement_id = "G-HUB12345"
+        config.save()
+        _sign_in(client)
+
+        response = client.get("/feedback/")
+
+        assert response.status_code == 200
+        assert b"googletagmanager.com" in response.content
+        assert b"G-HUB12345" in response.content
+
+    def it_sends_a_page_view_on_boosted_navigation(client: Client):
+        config = SiteConfiguration.load()
+        config.google_analytics_measurement_id = "G-HUB12345"
+        config.save()
+        _sign_in(client)
+
+        response = client.get("/feedback/")
+        body = response.content.decode()
+
+        # Without these, hx-boost navigation is invisible to GA.
+        assert "htmx:afterSettle" in body
+        assert "htmx:historyRestore" in body
+        assert "'page_view'" in body


### PR DESCRIPTION
Combines three related-but-separable changes, ordered so the CI fix comes first. Supersedes #179, #180, #181.

---

## 1. Unbreak lint (`hub/views.py`)

`lint` was failing on branches that touch **no Python at all**, which was the tell that this is not a PR problem.

`requirements-dev.txt` asks for `django-stubs>=5.1` with no upper bound. **6.0.8** landed after main's last green run on 2026-08-05. It types `inlineformset_factory`'s product as `BaseInlineFormSet[MemberContact, Member, MemberContactForm]`, while a bare `BaseInlineFormSet` means `BaseInlineFormSet[Any, Any, ModelForm[Any]]` — so the assignment at `hub/views.py:1457` stopped type-checking. The other three errors are cascade: once the assignment is rejected the declared type keeps its `None` arm, so `is_valid()`/`save()` look like attribute access on `None`.

**Confirmed rather than assumed:** checked out unmodified main, installed `django-stubs==6.0.8`, ran CI's exact invocation, reproduced the same five errors on a tree with zero PR changes. Same tree passes with 6.0.7.

Fix parameterizes the annotation. Verified against **both 6.0.7 and 6.0.8**, so no pin is needed and it will not flip-flop on resolution. Type-only; runtime untouched.

## 2. Google Analytics reaches the member hub

Site Settings describes GA as *"injected on every member-facing and public page (the Django admin is excluded)"*, but `templates/hub/base.html` never included the partial. GA reached `base.html`, `classes/base_public.html`, and `guilds/base_public.html` only — not the hub, where members actually spend their time.

**Including the partial is not sufficient.** The hub is `hx-boost="true" hx-ext="head-support"`. I read `static/js/htmx-ext-head-support.js` rather than trusting recollection:

1. Boosted navigation swaps the body and pushes a URL without a document load, so gtag's automatic `page_view` fires only for the session's first page.
2. head-support keys head elements by `outerHTML` and *preserves* identical ones (deletes them from the merge map instead of re-appending), so the snippet is never re-evaluated on navigation either. No double counting, but no counting at all.

So the partial now sends `page_view` itself: `htmx:afterSettle` for forward navigation (the head merge runs on `afterSwap`, so `document.title` is already correct), and `htmx:historyRestore` for back/forward, which merges the head without firing a swap. A path guard keeps partial swaps that leave the URL alone from counting.

The Django admin stays excluded — that is in the context processor, untouched. The privacy policy already discloses Google Analytics and "pages viewed", so no policy change is needed; members still get a changelog entry since this widens what is measured.

## 3. Auto-announce a release on a VERSION bump

The workflow was manual-only because it used to re-post the **whole** release-line changelog on every hotfix merge. That reason is gone — the script now posts only entries stamped at the current `VERSION`.

Restores `push: branches: [main]`, keeps `workflow_dispatch`, and adds two guards: a `paths:` filter on `plfog/version.py`, and a gate step comparing `VERSION` against the parent commit.

The second guard is not redundant — `198b463` (PR #175) is a merge to main that did **not** bump `VERSION`; a naive push trigger would have re-announced 0.23.49 to members. Gate logic tested against that commit and against the 0.23.49→0.23.50 bump: skips the first, posts the second.

---

## Testing

New `tests/hub/google_analytics_spec.py` covers tag-absent-when-unconfigured, tag-present-when-configured, and the boosted-navigation hooks. Full local suite 6951 passed; `mypy plfog/ core/ membership/ hub/` clean under django-stubs 6.0.8; `ruff format`/`ruff check` clean.

## Two things for the reviewer

1. **Confirm `DISCORD_WEBHOOK_URL` points at #fog-app-announcements** before merging. That secret alone determines the destination, and this makes posting automatic.
2. `mypy>=1.13` and `django-stubs>=5.1` are unbounded, so any upstream release can turn CI red with no change on our side. A compatible-release bound on the type-checking tools would make CI reproducible. Not done here — that is a policy call.

https://claude.ai/code/session_01BjUajPuNWTaHF4ncHP9Qr4