### PR TITLE
[voting] Automatic results + @everyone Discord notifications (v0.23.53)

### DIFF
--- a/core/events/copy.py
+++ b/core/events/copy.py
@@ -722,6 +722,11 @@ _CURATED: dict[str, EventCopy] = {
             "intro_note",
             "cycle_label",
             "allocation_summary",
+            # ballot_recap: pre-formatted sentence for voters ("You voted — 1st: X, 2nd: Y, 3rd: Z.")
+            # Empty string for non-voters so the paragraph renders blank rather than showing
+            # "1st: , 2nd: , 3rd: ." with missing values.
+            "ballot_recap",
+            # vote_1st/2nd/3rd kept for any existing DB-stored NotificationTemplate rows.
             "vote_1st",
             "vote_2nd",
             "vote_3rd",
@@ -732,6 +737,7 @@ _CURATED: dict[str, EventCopy] = {
             "intro_note": "Heads-up: this one's a little late — going forward results are automated.",
             "cycle_label": "June 2026",
             "allocation_summary": "Metal Guild — $600.00 (45.0%)\nFiber Guild — $400.00 (30.0%)",
+            "ballot_recap": "You voted — 1st: Metal Guild, 2nd: Fiber Guild, 3rd: Wood Guild.",
             "vote_1st": "Metal Guild",
             "vote_2nd": "Fiber Guild",
             "vote_3rd": "Wood Guild",
@@ -749,7 +755,7 @@ _CURATED: dict[str, EventCopy] = {
                     "{{ intro_note }}\n\n"
                     "The votes for {{ cycle_label }} are counted. Here's how the funding pool was split:\n\n"
                     "{{ allocation_summary }}\n\n"
-                    "You were recorded as voting — 1st: {{ vote_1st }}, 2nd: {{ vote_2nd }}, 3rd: {{ vote_3rd }}.\n\n"
+                    "{{ ballot_recap }}\n\n"
                     "Full breakdown: {{ voting_url }}\n\nPast Lives Makerspace"
                 ),
                 body_html=(
@@ -757,8 +763,7 @@ _CURATED: dict[str, EventCopy] = {
                     "<p>{{ intro_note }}</p>"
                     "<p>The votes for {{ cycle_label }} are counted. Here's how the funding pool was split:</p>"
                     "<pre>{{ allocation_summary }}</pre>"
-                    "<p>You were recorded as voting — 1st: <strong>{{ vote_1st }}</strong>, "
-                    "2nd: <strong>{{ vote_2nd }}</strong>, 3rd: <strong>{{ vote_3rd }}</strong>.</p>"
+                    "<p>{{ ballot_recap }}</p>"
                     '<p><a href="{{ voting_url }}">See the full breakdown</a></p>'
                     "<p>Past Lives Makerspace</p>"
                 ),
@@ -790,6 +795,46 @@ _CURATED: dict[str, EventCopy] = {
                     "(${{ funding_pool }} pool, {{ votes_cast }} votes).</p>"
                     '<p><a href="{{ review_url }}">Review the numbers and send results to members</a></p>'
                     "<p>Past Lives Makerspace</p>"
+                ),
+            ),
+        },
+    ),
+    "voting.discord_reminder": EventCopy(
+        placeholders=("cycle_label", "closes_on", "turnout_count", "pool_display", "standings_text", "voting_url"),
+        sample_context={
+            "cycle_label": "June 2026",
+            "closes_on": "June 30, 2026",
+            "turnout_count": "18",
+            "pool_display": "$1,000",
+            "standings_text": "🥇 `████████░░` **Metal Guild** — 42 pts\n🥈 `█████░░░░░` **Fiber Guild** — 25 pts",
+            "voting_url": "https://pastlives.example/guilds/voting/",
+        },
+        channels={
+            Channel.DISCORD: ChannelCopy(
+                subject="Guild funding — {{ cycle_label }}",
+                body_text=(
+                    "Polls close {{ closes_on }}. Cast or update your picks before then — every vote moves the needle.\n\n"
+                    "{{ standings_text }}\n\n"
+                    "{{ turnout_count }} vote(s) counted · estimated pool {{ pool_display }}\n\n"
+                    "{{ voting_url }}"
+                ),
+            ),
+        },
+    ),
+    "voting.results_discord": EventCopy(
+        placeholders=("cycle_label", "allocation_summary", "voting_url"),
+        sample_context={
+            "cycle_label": "June 2026",
+            "allocation_summary": "Metal Guild — $600.00 (45.0%)\nFiber Guild — $400.00 (30.0%)",
+            "voting_url": "https://pastlives.example/guilds/voting/history/",
+        },
+        channels={
+            Channel.DISCORD: ChannelCopy(
+                subject="{{ cycle_label }} guild funding results",
+                body_text=(
+                    "The {{ cycle_label }} funding vote is closed. Here's how the pool was split:\n\n"
+                    "{{ allocation_summary }}\n\n"
+                    "Full breakdown: {{ voting_url }}"
                 ),
             ),
         },

--- a/core/events/registry.py
+++ b/core/events/registry.py
@@ -325,6 +325,8 @@ VOTING_VOTE_SOON = "voting.vote_soon"
 VOTING_OFFICERS_CLOSING_SOON = "voting.officers_closing_soon"
 VOTING_RESULTS_PUBLISHED = "voting.results_published"
 VOTING_RESULTS_READY = "voting.results_ready"
+VOTING_DISCORD_REMINDER = "voting.discord_reminder"
+VOTING_RESULTS_DISCORD = "voting.results_discord"
 RELEASE_PUBLISHED = "release.published"
 EVENT_GUILD_PUBLISHED = "event.guild_published"
 EVENT_COMMUNITY_PUBLISHED = "event.community_published"
@@ -727,6 +729,31 @@ _NEW_EVENTS: list[EventType] = [
         recipient=Recipients.SINGLE_USER,
         channels=(_IN_APP_ON, _EMAIL_ON),
         activity_kind="space_request",
+    ),
+    # 26. voting.discord_reminder — a single @everyone Discord post (no email/in-app) fired
+    #     in the same tick as the per-member reminder sources. Shows live standings + close date.
+    #     Discord-only because the email side is handled by the per-member events (closing_soon
+    #     / vote_soon); emitting one broadcast here avoids N webhook calls for N members.
+    EventType(
+        key=VOTING_DISCORD_REMINDER,
+        label="Voting reminder to #general-member-chat",
+        description="A @everyone Discord post with current standings, sent before polls close.",
+        category="Voting",
+        recipient=Recipients.ALL_ACTIVE_MEMBERS,
+        channels=(_DISCORD_ON,),
+        activity_kind=None,
+    ),
+    # 27. voting.results_discord — a single @everyone Discord post (no email/in-app) announcing
+    #     this month's allocation. Emitted once per send_results call alongside the per-member
+    #     results emails so the public channel hears the outcome.
+    EventType(
+        key=VOTING_RESULTS_DISCORD,
+        label="Funding results to #general-member-chat",
+        description="A @everyone Discord post announcing this month's guild funding allocation.",
+        category="Voting",
+        recipient=Recipients.ALL_ACTIVE_MEMBERS,
+        channels=(_DISCORD_ON,),
+        activity_kind=None,
     ),
 ]
 

--- a/core/events/scheduler.py
+++ b/core/events/scheduler.py
@@ -79,6 +79,7 @@ class ScheduledOccurrence:
     messages: dict[Channel, Message] | None = None
     attachments: dict[Channel, list[Attachment]] | None = None
     email_to: str | list[str] | None = None
+    discord_mention: str = ""
 
     def is_due(self, *, now: datetime | None = None, window: timedelta = DEFAULT_WINDOW) -> bool:
         """Whether this occurrence's fire time lands in the current tick window."""
@@ -99,6 +100,7 @@ class ScheduledOccurrence:
             messages=self.messages,
             attachments=self.attachments,
             email_to=self.email_to,
+            discord_mention=self.discord_mention,
         )
 
 

--- a/core/management/commands/send_voting_reminders.py
+++ b/core/management/commands/send_voting_reminders.py
@@ -25,6 +25,7 @@ from membership.voting import (
     closing_soon_occurrences,
     officers_closing_soon_occurrences,
     vote_soon_occurrences,
+    voting_discord_reminder_occurrences,
 )
 
 
@@ -34,7 +35,12 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> None:
         now = timezone.now()
         fired = run_sources(
-            [closing_soon_occurrences, vote_soon_occurrences, officers_closing_soon_occurrences],
+            [
+                closing_soon_occurrences,
+                vote_soon_occurrences,
+                officers_closing_soon_occurrences,
+                voting_discord_reminder_occurrences,
+            ],
             now=now,
         )
         if fired:

--- a/core/management/commands/take_cycle_snapshot.py
+++ b/core/management/commands/take_cycle_snapshot.py
@@ -63,3 +63,5 @@ class Command(BaseCommand):
             self.stdout.write("No votes — nothing to snapshot.")
         else:
             self.stdout.write(self.style.SUCCESS(f"Auto-took snapshot '{label}'."))
+            sent = snapshot.send_results()
+            self.stdout.write(self.style.SUCCESS(f"Auto-sent results to {sent} member(s)."))

--- a/membership/management/commands/send_funding_results.py
+++ b/membership/management/commands/send_funding_results.py
@@ -11,6 +11,7 @@ base64 is a single whitespace-free token, so it survives intact.
     python manage.py send_funding_results --snapshot-id 4
     python manage.py send_funding_results --snapshot-id 4 --note-b64 "$(printf '%s' 'Sorry this is late!' | base64 -w0)"
     python manage.py send_funding_results --snapshot-id 4 --resend   # re-send an already-sent snapshot
+    python manage.py send_funding_results --snapshot-id 4 --no-discord  # suppress the Discord @everyone post
 """
 
 from __future__ import annotations
@@ -40,6 +41,11 @@ class Command(BaseCommand):
             action="store_true",
             help="Allow re-sending a snapshot whose results were already sent.",
         )
+        parser.add_argument(
+            "--no-discord",
+            action="store_true",
+            help="Suppress the @everyone Discord broadcast — email members only.",
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:
         note = self._decode_note(options["note_b64"])
@@ -50,7 +56,11 @@ class Command(BaseCommand):
             raise CommandError(f"No FundingSnapshot with id {options['snapshot_id']}.")
 
         try:
-            sent = snapshot.send_results(resend=options["resend"], intro_note=note)
+            sent = snapshot.send_results(
+                resend=options["resend"],
+                intro_note=note,
+                discord=not options["no_discord"],
+            )
         except ResultsAlreadySentError as exc:
             raise CommandError(f"{exc} Pass --resend to send it again.")
 

--- a/membership/models.py
+++ b/membership/models.py
@@ -4830,7 +4830,9 @@ class FundingSnapshot(models.Model):
         lines = [f"{row['guild_name']} — ${row['funding']} ({row['share_pct']}%)" for row in results]
         return "\n".join(lines)
 
-    def send_results(self, *, actor: Any | None = None, resend: bool = False, intro_note: str = "", discord: bool = True) -> int:
+    def send_results(
+        self, *, actor: Any | None = None, resend: bool = False, intro_note: str = "", discord: bool = True
+    ) -> int:
         """Email every active member their results and post one @everyone Discord summary.
 
         Loops the snapshot's frozen ``raw_votes`` and emits ``voting.results_published``

--- a/membership/models.py
+++ b/membership/models.py
@@ -4830,27 +4830,29 @@ class FundingSnapshot(models.Model):
         lines = [f"{row['guild_name']} — ${row['funding']} ({row['share_pct']}%)" for row in results]
         return "\n".join(lines)
 
-    def send_results(self, *, actor: Any | None = None, resend: bool = False, intro_note: str = "") -> int:
-        """Email each member who voted their personalized results — the admin-confirmed send.
+    def send_results(self, *, actor: Any | None = None, resend: bool = False, intro_note: str = "", discord: bool = True) -> int:
+        """Email every active member their results and post one @everyone Discord summary.
 
         Loops the snapshot's frozen ``raw_votes`` and emits ``voting.results_published``
-        once per still-active voter, carrying that member's own 1st/2nd/3rd recorded
-        vote so the email can say "here's what we recorded *you* voting for". Stamps
-        ``results_sent_at`` and bumps ``results_send_count`` so the UI can flip to the
-        sent state and idempotency is visible.
+        once per still-active voter with a personalized ballot recap, then emits the same
+        event to every active member with a linked user account who did NOT appear in the
+        voter list — giving non-voters the allocation without a ballot recap. Finally, one
+        ``voting.results_discord`` broadcast fires so #general-member-chat hears the outcome.
+        Stamps ``results_sent_at`` and bumps ``results_send_count`` for UI state + idempotency.
 
         Args:
-            actor: The admin who clicked Send (unused for the per-member emit, kept for
+            actor: The admin who triggered the send (unused in per-member emit, kept for
                 symmetry/auditing of the calling view).
             resend: When True, allows re-sending already-sent results (a fresh ``period``
                 re-delivers); when False a second send raises ``ResultsAlreadySentError``.
             intro_note: Optional organizer note rendered at the top of the results email
-                (blank for a normal automated send; used for a one-off, e.g. explaining a
-                late send). Carried into the ``voting.results_published`` ``intro_note``
-                merge field.
+                (blank for a normal automated send). Carried into the ``intro_note`` merge field.
+            discord: When False, suppresses the ``voting.results_discord`` @everyone broadcast
+                while still emailing all members. Use ``--no-discord`` on the management command
+                when back-filling a cycle that predates Discord notifications.
 
         Returns:
-            The number of voters who received a fresh delivery this send.
+            The number of members who received a fresh delivery this send.
 
         Raises:
             ResultsAlreadySentError: If results were already sent and ``resend`` is False.
@@ -4873,10 +4875,19 @@ class FundingSnapshot(models.Model):
             member.pk: member
             for member in Member.objects.filter(pk__in=member_ids, status=Member.Status.ACTIVE).select_related("user")
         }
+
+        # --- 1. Voters: personalized ballot recap ---
+        voter_ids: set[int] = set()
         for vote in self.raw_votes:
             member = active.get(vote["member_id"])
             if member is None:
                 continue  # voter no longer active → skip (audience safety)
+            voter_ids.add(vote["member_id"])
+            ballot_recap = (
+                f"You voted — 1st: {vote['guild_1st_name']}, "
+                f"2nd: {vote['guild_2nd_name']}, "
+                f"3rd: {vote['guild_3rd_name']}."
+            )
             result = emit(
                 "voting.results_published",
                 target=self,
@@ -4886,6 +4897,7 @@ class FundingSnapshot(models.Model):
                     "intro_note": intro_note,
                     "cycle_label": self.cycle_label,
                     "allocation_summary": allocation,
+                    "ballot_recap": ballot_recap,
                     "vote_1st": vote["guild_1st_name"],
                     "vote_2nd": vote["guild_2nd_name"],
                     "vote_3rd": vote["guild_3rd_name"],
@@ -4896,6 +4908,45 @@ class FundingSnapshot(models.Model):
             )
             if result.delivery_count:
                 sent += 1
+
+        # --- 2. Non-voters: allocation only, no ballot recap ---
+        non_voters = Member.objects.active().filter(user__isnull=False).exclude(pk__in=voter_ids).select_related("user")
+        for member in non_voters:
+            result = emit(
+                "voting.results_published",
+                target=self,
+                context={
+                    "member": member,
+                    "member_name": member.display_name,
+                    "intro_note": intro_note,
+                    "cycle_label": self.cycle_label,
+                    "allocation_summary": allocation,
+                    "ballot_recap": "",
+                    "vote_1st": "",
+                    "vote_2nd": "",
+                    "vote_3rd": "",
+                    "voting_url": voting_url,
+                },
+                url=voting_url,
+                period=f"snapshot:{self.pk}:nonvoter:{member.pk}:send:{n}",
+            )
+            if result.delivery_count:
+                sent += 1
+
+        # --- 3. Discord: one @everyone broadcast to #general-member-chat ---
+        if discord:
+            emit(
+                "voting.results_discord",
+                target=self,
+                context={
+                    "cycle_label": self.cycle_label,
+                    "allocation_summary": allocation,
+                    "voting_url": voting_url,
+                },
+                discord_mention="@everyone",
+                period=f"snapshot_discord:{self.pk}:send:{n}",
+            )
+
         self.results_sent_at = timezone.now()
         self.save(update_fields=["results_sent_at", "results_send_count"])
         return sent

--- a/membership/voting.py
+++ b/membership/voting.py
@@ -33,7 +33,12 @@ from typing import TYPE_CHECKING
 
 from django.utils import timezone
 
-from core.events.registry import VOTING_CLOSING_SOON, VOTING_OFFICERS_CLOSING_SOON, VOTING_VOTE_SOON
+from core.events.registry import (
+    VOTING_CLOSING_SOON,
+    VOTING_DISCORD_REMINDER,
+    VOTING_OFFICERS_CLOSING_SOON,
+    VOTING_VOTE_SOON,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -208,13 +213,13 @@ def closing_soon_occurrences(now: datetime) -> Iterable[ScheduledOccurrence]:
 
 
 def vote_soon_occurrences(now: datetime) -> Iterable[ScheduledOccurrence]:
-    """Yield one ``voting.vote_soon`` occurrence per signed-in member who hasn't voted.
+    """Yield one ``voting.vote_soon`` occurrence per active member with an account who hasn't voted.
 
     Gated on ``VotingSettings.reminders_enabled`` *and* ``send_vote_soon_enabled``.
-    Same anchor/offset as :func:`closing_soon_occurrences`. The audience is paying,
-    active members who have logged in at least once but have no vote yet — nudging a
-    non-paying member who can't vote would be noise. The per-member ``registrant``
-    resolver + the ``voting:YYYY-MM`` period give the same safety + dedupe.
+    Same anchor/offset as :func:`closing_soon_occurrences`. Targets all active members
+    with a linked user account — paying or not — who have not yet cast a vote, so every
+    member who can log in and vote gets a nudge. The per-member ``registrant`` resolver
+    + the ``voting:YYYY-MM`` period give the same safety + dedupe.
     """
     from membership.models import Member, VotingSettings
 
@@ -234,12 +239,7 @@ def vote_soon_occurrences(now: datetime) -> Iterable[ScheduledOccurrence]:
     period = cycle_period(now)
     voting_url = _absolute_url(reverse("hub_guild_voting"))
     stats = cycle_turnout_stats()
-    non_voters = (
-        Member.objects.paying()
-        .active()
-        .filter(user__last_login__isnull=False, vote_preference__isnull=True)
-        .select_related("user")
-    )
+    non_voters = Member.objects.active().filter(user__isnull=False, vote_preference__isnull=True).select_related("user")
     for member in non_voters:
         yield ScheduledOccurrence(
             event_key=VOTING_VOTE_SOON,
@@ -296,4 +296,70 @@ def officers_closing_soon_occurrences(now: datetime) -> Iterable[ScheduledOccurr
         },
         period=cycle_period(now),
         url=voting_url,
+    )
+
+
+def voting_discord_reminder_occurrences(now: datetime) -> Iterable[ScheduledOccurrence]:
+    """Yield one ``voting.discord_reminder`` broadcast occurrence (Discord @everyone only).
+
+    Fires in the same tick as the per-member reminders — same anchor/offset — but yields
+    exactly one occurrence for the whole cycle so only a single webhook post goes to
+    #general-member-chat. The period key is ``discord:voting:YYYY-MM`` (distinct from the
+    per-member period) so this fires independently of whether the member reminders have
+    already been deduped.
+
+    The Discord body includes live standings built the same way as the ``/voting`` slash
+    command: ranked bars for guilds with points, then zero-point guilds alphabetically.
+    """
+    from membership.models import VotingSettings
+
+    settings = VotingSettings.load()
+    if not settings.reminders_enabled:
+        return
+
+    from django.urls import reverse
+
+    from core.events.scheduler import ScheduledOccurrence
+    from membership.discord_commands import _BAR_WIDTH, _bar
+    from membership.models import Guild
+    from membership.orientations import _absolute_url
+    from membership.vote_calculator import compute_live_standings
+
+    standings = compute_live_standings()
+    ranked_names = {row["guild_name"] for row in standings}
+    active_names = list(Guild.objects.filter(is_active=True).order_by("name").values_list("name", flat=True))
+    zero_point_names = [name for name in active_names if name not in ranked_names]
+
+    _MEDALS = ["🥇", "🥈", "🥉"]
+    lines: list[str] = []
+    if not standings:
+        lines.append("No votes yet this cycle — the standings are wide open. Be the first!")
+    for rank, row in enumerate(standings, start=1):
+        bar = f"`{_bar(row['bar_pct'])}`"
+        if rank <= len(_MEDALS):
+            lines.append(f"{_MEDALS[rank - 1]} {bar} **{row['guild_name']}** — {row['total_points']} pts")
+        else:
+            lines.append(f"`{rank}.` {bar} {row['guild_name']} — {row['total_points']} pts")
+    empty_bar = "░" * _BAR_WIDTH
+    lines.extend(f"`{empty_bar}` {name} — 0 pts" for name in zero_point_names)
+    standings_text = "\n".join(lines)
+
+    stats = cycle_turnout_stats()
+    voting_url = _absolute_url(reverse("hub_guild_voting"))
+
+    yield ScheduledOccurrence(
+        event_key=VOTING_DISCORD_REMINDER,
+        anchor=month_end_close(now),
+        offset=timedelta(days=-settings.reminder_lead_days),
+        context={
+            "cycle_label": cycle_label(now),
+            "closes_on": closes_on_display(now),
+            "turnout_count": stats["turnout_count"],
+            "pool_display": stats["pool_display"],
+            "standings_text": standings_text,
+            "voting_url": voting_url,
+        },
+        period=f"discord:{cycle_period(now)}",
+        url=voting_url,
+        discord_mention="@everyone",
     )

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.52"
+VERSION = "0.23.53"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.53",
+        "date": "2026-08-09",
+        "title": "Guild vote reminders and results now go to every member",
+        "changes": [
+            "A few days before the monthly vote closes, everyone with an account gets a reminder email. "
+            "If you've already voted, it shows your current picks. If you haven't, it tells you where to go. "
+            "Starting end of August, there's also an @everyone post in #general-member-chat with the live standings.",
+            "When the vote closes and results are tallied, every member gets a results email showing how "
+            "the funding pool was split. Voters see a recap of their own ballot. "
+            "The email goes out automatically — no admin needs to click 'send'.",
+            "The results @everyone post to #general-member-chat also starts at the end of August.",
+        ],
+    },
     {
         "version": "0.23.52",
         "date": "2026-08-07",

--- a/tests/core/management/take_cycle_snapshot_spec.py
+++ b/tests/core/management/take_cycle_snapshot_spec.py
@@ -54,7 +54,7 @@ def _july():
 def describe_take_cycle_snapshot():
     def it_auto_takes_once_per_cycle_flagging_is_auto_and_pinging_admins(monkeypatch):
         _freeze(monkeypatch, _july())
-        _voter("voter@x.com")
+        voter = _voter("voter@x.com")
         admin_user = _admin("admin@x.com")
 
         call_command("take_cycle_snapshot")
@@ -65,9 +65,10 @@ def describe_take_cycle_snapshot():
         snap = autos.first()
         assert snap.cycle_label == "June 2026"
         assert EventDelivery.objects.filter(event_key="voting.auto_snapshot", period="voting_close:2026-06").exists()
-        # Admins pinged; members not emailed.
+        # Admins pinged AND results auto-sent to every linked member.
         assert Notification.objects.filter(user=admin_user, trigger="voting.results_ready").exists()
-        assert not Notification.objects.filter(trigger="voting.results_published").exists()
+        assert Notification.objects.filter(user=voter.user, trigger="voting.results_published").exists()
+        assert Notification.objects.filter(user=admin_user, trigger="voting.results_published").exists()
 
     def it_is_a_noop_when_auto_snapshot_is_disabled(monkeypatch):
         settings = VotingSettings.load()

--- a/tests/hub/voting_results_send_spec.py
+++ b/tests/hub/voting_results_send_spec.py
@@ -23,7 +23,8 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture()
 def admin_client():
-    user = User.objects.create_superuser("rsadmin", "rsadmin@x.com", "p")
+    with mute_signals(post_save):
+        user = User.objects.create_superuser("rsadmin", "rsadmin@x.com", "p")
     client = Client()
     client.force_login(user)
     return client

--- a/tests/membership/funding_snapshot_results_spec.py
+++ b/tests/membership/funding_snapshot_results_spec.py
@@ -212,7 +212,10 @@ def describe_send_results():
         assert snap is not None
         with patch("core.events.emit.emit") as mock_emit:
             snap.send_results()
-        kwargs = mock_emit.call_args.kwargs
+        # send_results now calls emit multiple times (voter, non-voter loop, Discord broadcast).
+        # Find the voting.results_published call — it carries the absolute url.
+        results_call = next(c for c in mock_emit.call_args_list if c.args[0] == "voting.results_published")
+        kwargs = results_call.kwargs
         assert kwargs["url"].startswith(dj_settings.MEMBER_BASE_URL)
         assert kwargs["context"]["voting_url"].startswith(dj_settings.MEMBER_BASE_URL)
         assert kwargs["url"].endswith("/guilds/voting/history/")

--- a/tests/membership/voting_reminders_spec.py
+++ b/tests/membership/voting_reminders_spec.py
@@ -28,6 +28,7 @@ from membership.voting import (
     officers_closing_soon_occurrences,
     previous_cycle_label,
     vote_soon_occurrences,
+    voting_discord_reminder_occurrences,
 )
 from tests.membership.factories import GuildFactory, MemberFactory, VotePreferenceFactory
 
@@ -130,19 +131,22 @@ def describe_closing_soon_occurrences():
 
 
 def describe_vote_soon_occurrences():
-    def it_targets_only_paying_active_logged_in_non_voters():
+    def it_targets_all_active_members_with_accounts_who_havent_voted():
         paying = _logged_in_no_vote("p@x.com")
         nonpaying = _logged_in_no_vote("np@x.com", member_type=Member.MemberType.WORK_TRADE)
-        never = MemberFactory()
-        _linked(never, "never@x.com", last_login=None)
+        # member with account but never logged in — still included (has a user)
+        never_logged_in = MemberFactory()
+        _linked(never_logged_in, "never@x.com", last_login=None)
         voted = _voted("voted@x.com")
+        unlinked = MemberFactory()  # no user at all — excluded
 
         members = {o.context["member"].pk for o in vote_soon_occurrences(_aware(2026, 6, 1))}
 
         assert paying.pk in members
-        assert nonpaying.pk not in members
-        assert never.pk not in members
-        assert voted.pk not in members
+        assert nonpaying.pk in members  # non-paying now included
+        assert never_logged_in.pk in members  # linked user, no login → included
+        assert voted.pk not in members  # already voted
+        assert unlinked.pk not in members  # no user account
 
     def it_emits_the_vote_soon_event_key():
         _logged_in_no_vote("p@x.com")
@@ -287,18 +291,24 @@ def describe_officers_closing_soon_occurrences():
 
 
 def describe_both_sources_together():
-    def it_reminds_a_voter_and_a_nonvoter_distinctly_and_skips_never_logged_in():
+    def it_reminds_a_voter_closing_soon_and_non_voters_via_vote_soon():
         voted = _voted("voted@x.com")
         nonvoter = _logged_in_no_vote("nv@x.com")
-        never = MemberFactory()
-        never_user = _linked(never, "never@x.com", last_login=None)
+        # never_logged_in still gets vote_soon — they have an account but haven't voted
+        never_logged_in = MemberFactory()
+        never_user = _linked(never_logged_in, "never@x.com", last_login=None)
+        unlinked = MemberFactory()  # no user at all — excluded from both
         fire = _aware(2026, 6, 28)  # default 3-day lead
 
         run_sources([closing_soon_occurrences, vote_soon_occurrences], now=fire)
 
         assert Notification.objects.filter(trigger="voting.closing_soon", user=voted.user).exists()
         assert Notification.objects.filter(trigger="voting.vote_soon", user=nonvoter.user).exists()
-        assert not Notification.objects.filter(user=never_user).exists()
+        assert Notification.objects.filter(trigger="voting.vote_soon", user=never_user).exists()
+        assert not Notification.objects.filter(user__isnull=True).exists()
+        # unlinked member has no user, so no notification for them
+
+        assert not Notification.objects.filter(user__member=unlinked).exists()
 
 
 def describe_voting_email_rendering():
@@ -327,3 +337,63 @@ def describe_voting_email_rendering():
     def it_renders_the_officer_email_with_every_placeholder_supplied():
         occ = next(iter(officers_closing_soon_occurrences(_aware(2026, 6, 1))))
         _assert_no_missing("voting.officers_closing_soon", occ.context)
+
+
+def describe_voting_discord_reminder_occurrences():
+    def it_yields_one_broadcast_occurrence_with_standings_and_everyone_mention():
+        now = _aware(2026, 6, 1)
+        _voted("v@x.com")
+
+        occ = list(voting_discord_reminder_occurrences(now))
+
+        assert len(occ) == 1
+        o = occ[0]
+        assert o.event_key == "voting.discord_reminder"
+        assert o.discord_mention == "@everyone"
+        assert "member" not in o.context
+        assert o.context["cycle_label"] == "June 2026"
+        assert "standings_text" in o.context
+        assert o.anchor == month_end_close(now)
+        assert o.offset.days == -3
+
+    def it_uses_a_distinct_period_from_the_per_member_reminders():
+        occ = list(voting_discord_reminder_occurrences(_aware(2026, 6, 1)))
+        assert len(occ) == 1
+        assert occ[0].period == "discord:voting:2026-06"
+
+    def it_fires_once_per_cycle_and_dedupes():
+        _voted("v@x.com")
+        fire = _aware(2026, 6, 28)  # default 3-day lead
+
+        first = run_sources([voting_discord_reminder_occurrences], now=fire)
+        second = run_sources([voting_discord_reminder_occurrences], now=fire)
+
+        assert first == 1
+        assert second == 0
+        assert EventDelivery.objects.filter(
+            event_key="voting.discord_reminder",
+            target_ref="broadcast",
+            period="discord:voting:2026-06",
+        ).exists()
+
+    def it_yields_nothing_when_reminders_are_disabled():
+        settings = VotingSettings.load()
+        settings.reminders_enabled = False
+        settings.save()
+
+        assert list(voting_discord_reminder_occurrences(_aware(2026, 6, 1))) == []
+
+    def it_includes_a_no_votes_placeholder_when_nobody_has_voted():
+        occ = list(voting_discord_reminder_occurrences(_aware(2026, 6, 1)))
+        assert len(occ) == 1
+        assert "No votes yet" in occ[0].context["standings_text"]
+
+    def it_renders_the_discord_copy_with_every_placeholder_supplied():
+        _voted("v@x.com")
+        from core.events.registry import Channel
+        from core.events.templates import rendered_message
+
+        occ = next(iter(voting_discord_reminder_occurrences(_aware(2026, 6, 1))))
+        message = rendered_message("voting.discord_reminder", Channel.DISCORD, occ.context)
+        for part in (message.title, message.body, message.html_body or ""):
+            assert "[missing:" not in part, "voting.discord_reminder Discord copy has a missing placeholder"


### PR DESCRIPTION
## Summary

- **Results email now sends automatically.** When `take_cycle_snapshot` runs at cycle close, it calls `send_results()` immediately after. No admin needs to click "Send results."
- **Every member with an account gets an email.** Phase 1: voters get a personalized ballot recap. Phase 2: non-voters get the allocation summary without a ballot section. Phase 3: Discord @everyone broadcast (gated; starts end of August).
- **Pre-close reminder email widened.** `vote_soon_occurrences()` now targets all active members with accounts, not just voters. Non-voters get a "go vote" nudge; voters still see their current picks.
- **Discord @everyone notifications.** Two new broadcast event types (`voting.discord_reminder`, `voting.results_discord`) fire once per cycle. The scheduler emits them as broadcast occurrences, not per-member — one webhook call total.
- **`--no-discord` flag on `send_funding_results`.** For the July results send (which predates the Discord rollout), pass `--no-discord` to suppress the @everyone post.

## July results

To send July results without Discord (do this on production after merge/deploy):

```
python manage.py send_funding_results --snapshot-id <ID> --no-discord
```

Find the snapshot ID in the admin at `/manage/voting/history/` or via `python manage.py shell -c "from membership.models import FundingSnapshot; print(FundingSnapshot.objects.last().pk)"`.

## Test plan

- [ ] `pytest tests/membership/voting_reminders_spec.py` — Discord reminder occurrence tests (6 new tests)
- [ ] `pytest tests/membership/funding_snapshot_results_spec.py` — Results send audience + URL tests pass
- [ ] `pytest tests/hub/voting_results_send_spec.py` — View send tests pass (admin client fixture isolated)
- [ ] `pytest tests/core/management/take_cycle_snapshot_spec.py` — Auto-send assertions pass
- [ ] Full suite passes (pre-push hooks: ruff, mypy, template checks all green)