### PR TITLE
fix(tests): register Discord-only voting events in registry_spec

### DIFF
--- a/tests/core/events/registry_spec.py
+++ b/tests/core/events/registry_spec.py
@@ -20,6 +20,8 @@ _BRAND_NEW_KEYS = {
     "voting.officers_closing_soon",
     "voting.results_published",
     "voting.results_ready",
+    "voting.discord_reminder",
+    "voting.results_discord",
     "release.published",
     "event.guild_published",
     "event.community_published",
@@ -72,7 +74,14 @@ def describe_event_registry():
             # login-invite reaches someone who hasn't signed in; the Discord-guilds import
             # is a transactional email_to confirmation with no bell row), so the in-app
             # invariant holds for every OTHER event.
-            email_only = {"member.invited", "member.login_invite", "discord_guilds_imported"}
+            # Discord-broadcast events have no in-app bell (they're @everyone channel posts)
+            email_only = {
+                "member.invited",
+                "member.login_invite",
+                "discord_guilds_imported",
+                "voting.discord_reminder",
+                "voting.results_discord",
+            }
             for event in registry.EVENTS:
                 if event.key in email_only:
                     assert event.channel(Channel.IN_APP) is None


### PR DESCRIPTION
Two CI failures from the new `voting.discord_reminder` / `voting.results_discord` events added in #186.

- `_BRAND_NEW_KEYS` hardcoded 27 keys — added the two new ones so the count assertion passes.
- In-app invariant test assumed every per-recipient event has an `IN_APP` channel. Discord-broadcast events are channel-only (no bell), so they're excluded alongside the existing email-only set.