### PR TITLE
[api] Event sync/announce actions, fog CLI wrapper, bot user command (v0.23.54)

### DIFF
--- a/membership/api_views.py
+++ b/membership/api_views.py
@@ -78,6 +78,20 @@ class CommunityEventViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer: serializers.BaseSerializer) -> None:
         serializer.save()
 
+    @action(detail=True, methods=["post"], permission_classes=[IsFogAdmin])
+    def sync(self, request: Request, pk: str | None = None) -> Response:
+        """Re-push this event to Google Calendar and Discord. Idempotent."""
+        event = self.get_object()
+        event.schedule_or_go_live(actor=request.user)
+        return Response(CommunityEventSerializer(event).data)
+
+    @action(detail=True, methods=["post"], permission_classes=[IsFogAdmin])
+    def announce(self, request: Request, pk: str | None = None) -> Response:
+        """Fire the in-app, email, and Discord announcement without re-pushing to Google Calendar."""
+        event = self.get_object()
+        event.announce(actor=request.user)
+        return Response(CommunityEventSerializer(event).data)
+
 
 class GuildAnnouncementViewSet(viewsets.ModelViewSet):
     permission_classes: ClassVar = [IsFogAdminOrReadOnly]

--- a/membership/management/commands/create_api_bot_user.py
+++ b/membership/management/commands/create_api_bot_user.py
@@ -1,0 +1,32 @@
+"""Management command to create (or re-use) the fog-bot API service user."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from rest_framework.authtoken.models import Token
+
+User = get_user_model()
+
+_BOT_USERNAME = "fog-bot"
+_BOT_EMAIL = "fog-bot@pastlives.space"
+
+
+class Command(BaseCommand):
+    """Create or re-use the fog-bot service account and print its REST API token."""
+
+    help = "Create the fog-bot API service user (idempotent) and print its auth token."
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        user, created = User.objects.get_or_create(
+            username=_BOT_USERNAME,
+            defaults={"email": _BOT_EMAIL, "is_superuser": True, "is_staff": True},
+        )
+        if not created and (not user.is_superuser or not user.is_staff):
+            user.is_superuser = True
+            user.is_staff = True
+            user.save(update_fields=["is_superuser", "is_staff"])
+        token, _ = Token.objects.get_or_create(user=user)
+        self.stdout.write(f"Token: {token.key}")

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,24 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.53"
+VERSION = "0.23.54"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.54",
+        "date": "2026-08-09",
+        "title": "Admin tools: manual event sync, re-announce, and a terminal shortcut",
+        "changes": [
+            "Admins can now force-sync any Community Calendar event to Google Calendar and the "
+            "Discord events list with one API call -- handy when an event falls out of sync after "
+            "a brief outage.",
+            "A separate call lets admins re-send an event's in-app notification, email, and Discord "
+            "announcement without touching Google Calendar -- useful for a quiet correction or a nudge "
+            "to members who missed it.",
+            "A new 'fog' terminal tool gives admins a fast command-line shortcut to list, read, "
+            "create, sync, and announce events, and to list members and guilds, all from a shell prompt.",
+        ],
+    },
     {
         "version": "0.23.53",
         "date": "2026-08-09",

--- a/scripts/fog
+++ b/scripts/fog
@@ -1,0 +1,77 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    source "$ENV_FILE"
+    set +a
+fi
+
+BASE_URL="${BASE_URL:-https://members.pastlives.space/api/v1}"
+TOKEN="${FOG_API_TOKEN:?FOG_API_TOKEN is not set in .env or the environment}"
+
+_req() {
+    local method="$1"
+    local path="$2"
+    shift 2
+    curl -s -X "$method" \
+        -H "Authorization: Token $TOKEN" \
+        -H "Content-Type: application/json" \
+        "$@" \
+        "${BASE_URL}${path}" | python3 -m json.tool
+}
+
+_usage() {
+    cat <<'EOF'
+fog -- Past Lives Makerspace API CLI
+
+Usage:
+  fog events list
+  fog events get <id>
+  fog events create '<json body>'
+  fog events sync <id>
+  fog events announce <id>
+  fog members list
+  fog members get <id>
+  fog guilds list
+EOF
+    exit 1
+}
+
+[[ $# -lt 2 ]] && _usage
+
+resource="$1"
+cmd="$2"
+shift 2 || true
+
+case "$resource" in
+    events)
+        case "$cmd" in
+            list)     _req GET /events/ ;;
+            get)      [[ -n "${1:-}" ]] || _usage; _req GET "/events/$1/" ;;
+            create)   [[ -n "${1:-}" ]] || _usage; _req POST /events/ --data "$1" ;;
+            sync)     [[ -n "${1:-}" ]] || _usage; _req POST "/events/$1/sync/" ;;
+            announce) [[ -n "${1:-}" ]] || _usage; _req POST "/events/$1/announce/" ;;
+            *)        _usage ;;
+        esac
+        ;;
+    members)
+        case "$cmd" in
+            list) _req GET /members/ ;;
+            get)  [[ -n "${1:-}" ]] || _usage; _req GET "/members/$1/" ;;
+            *)    _usage ;;
+        esac
+        ;;
+    guilds)
+        case "$cmd" in
+            list) _req GET /guilds/ ;;
+            *)    _usage ;;
+        esac
+        ;;
+    *)
+        _usage
+        ;;
+esac

--- a/tests/api/membership_api_spec.py
+++ b/tests/api/membership_api_spec.py
@@ -165,6 +165,48 @@ def describe_CommunityEventViewSet():
             assert response.status_code == status.HTTP_200_OK
             mock_sog.assert_not_called()
 
+    def describe_sync_action():
+        def it_requires_fog_admin(member_client):
+            event = CommunityEventFactory()
+            response = member_client.post(f"/api/v1/events/{event.id}/sync/")
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        def it_calls_schedule_or_go_live(admin_client, admin_member):
+            event = CommunityEventFactory()
+            with patch.object(CommunityEvent, "schedule_or_go_live") as mock_sog:
+                response = admin_client.post(f"/api/v1/events/{event.id}/sync/")
+            assert response.status_code == status.HTTP_200_OK
+            mock_sog.assert_called_once()
+
+        def it_returns_event_data(admin_client, admin_member):
+            event = CommunityEventFactory()
+            with patch.object(CommunityEvent, "schedule_or_go_live"):
+                response = admin_client.post(f"/api/v1/events/{event.id}/sync/")
+            assert response.status_code == status.HTTP_200_OK
+            assert response.data["id"] == event.id
+            assert "sync_state" in response.data
+
+    def describe_announce_action():
+        def it_requires_fog_admin(member_client):
+            event = CommunityEventFactory()
+            response = member_client.post(f"/api/v1/events/{event.id}/announce/")
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        def it_calls_announce(admin_client, admin_member):
+            event = CommunityEventFactory()
+            with patch.object(CommunityEvent, "announce") as mock_announce:
+                response = admin_client.post(f"/api/v1/events/{event.id}/announce/")
+            assert response.status_code == status.HTTP_200_OK
+            mock_announce.assert_called_once()
+
+        def it_returns_event_data(admin_client, admin_member):
+            event = CommunityEventFactory()
+            with patch.object(CommunityEvent, "announce"):
+                response = admin_client.post(f"/api/v1/events/{event.id}/announce/")
+            assert response.status_code == status.HTTP_200_OK
+            assert response.data["id"] == event.id
+            assert "discord_sync_state" in response.data
+
 
 def describe_GuildAnnouncementViewSet():
     def describe_list():

--- a/tests/membership/management/create_api_bot_user_spec.py
+++ b/tests/membership/management/create_api_bot_user_spec.py
@@ -1,0 +1,37 @@
+"""BDD specs for the create_api_bot_user management command."""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from rest_framework.authtoken.models import Token
+
+User = get_user_model()
+
+
+def describe_create_api_bot_user():
+    def it_creates_superuser(db, capsys):
+        call_command("create_api_bot_user")
+
+        user = User.objects.get(username="fog-bot")
+        assert user.email == "fog-bot@pastlives.space"
+        assert user.is_superuser is True
+        assert user.is_staff is True
+
+    def it_is_idempotent(db, capsys):
+        call_command("create_api_bot_user")
+        first_token = Token.objects.get(user__username="fog-bot").key
+        capsys.readouterr()
+
+        call_command("create_api_bot_user")
+        second_token = Token.objects.get(user__username="fog-bot").key
+
+        assert first_token == second_token
+        assert User.objects.filter(username="fog-bot").count() == 1
+
+    def it_prints_token(db, capsys):
+        call_command("create_api_bot_user")
+
+        captured = capsys.readouterr()
+        token = Token.objects.get(user__username="fog-bot")
+        assert f"Token: {token.key}" in captured.out


### PR DESCRIPTION
## Summary
- POST /api/v1/events/{id}/sync/ -- re-runs schedule_or_go_live() to re-push Google Calendar + Discord; IsFogAdmin permission
- POST /api/v1/events/{id}/announce/ -- fires announce() (in-app + email + Discord) without calendar re-push; IsFogAdmin permission
- scripts/fog -- zsh CLI wrapper that loads .env and wraps all event/member/guild API endpoints
- create_api_bot_user management command -- idempotent fog-bot superuser + Token creation, prints the token

## Test plan
- [ ] pytest tests/api/membership_api_spec.py passes (sync + announce action tests added)
- [ ] pytest tests/membership/management/create_api_bot_user_spec.py passes (bot user command tests added)
- [ ] ruff + mypy clean
- [ ] fog events list returns event list in terminal