### PR TITLE
[voting] Visual bar chart in the guild-funding results email (v0.23.56)

### DIFF
--- a/core/events/copy.py
+++ b/core/events/copy.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from django.utils.safestring import mark_safe
+
 from core.events.registry import Channel, EventType, Recipients, all_events, get_event
 
 # Channels that carry authored copy. Discord reuses the in-app/email copy (it is a
@@ -721,7 +723,12 @@ _CURATED: dict[str, EventCopy] = {
             # automated send; used for a one-off, e.g. a late "sorry this is overdue").
             "intro_note",
             "cycle_label",
+            # allocation_summary: plain-text lines for the text body.
             "allocation_summary",
+            # allocation_chart: app-built, email-safe HTML bar chart for the HTML body
+            # (FundingSnapshot.allocation_chart_html) — a SafeString the renderer injects
+            # unescaped. The text body still uses allocation_summary.
+            "allocation_chart",
             # ballot_recap: pre-formatted sentence for voters ("You voted — 1st: X, 2nd: Y, 3rd: Z.")
             # Empty string for non-voters so the paragraph renders blank rather than showing
             # "1st: , 2nd: , 3rd: ." with missing values.
@@ -737,6 +744,29 @@ _CURATED: dict[str, EventCopy] = {
             "intro_note": "Heads-up: this one's a little late — going forward results are automated.",
             "cycle_label": "June 2026",
             "allocation_summary": "Metal Guild — $600.00 (45.0%)\nFiber Guild — $400.00 (30.0%)",
+            # A two-bar sample so the live copy preview shows the real chart, not escaped
+            # tags. The send path builds this from FundingSnapshot.allocation_chart_html.
+            "allocation_chart": mark_safe(
+                '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" '
+                "style=\"border-collapse:collapse;margin:8px 0 20px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;\">"
+                '<tr><td style="padding:0 0 6px;">'
+                '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr>'
+                '<td align="left" style="color:#F4EFDD;font-size:14px;font-weight:600;padding:0 8px 5px 0;">🥇 Metal Guild</td>'
+                '<td align="right" style="color:#EEB44B;font-size:14px;font-weight:700;padding:0 0 5px;white-space:nowrap;">$600.00 &middot; 45.0%</td>'
+                "</tr></table>"
+                '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0a1929;border-radius:5px;">'
+                '<tr><td width="100%" style="height:18px;font-size:0;background-color:#EEB44B;background-image:linear-gradient(90deg,#EEB44B,#d4a043);border-radius:5px;">&nbsp;</td></tr></table>'
+                "</td></tr>"
+                '<tr><td style="padding:0 0 6px;">'
+                '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr>'
+                '<td align="left" style="color:#F4EFDD;font-size:14px;font-weight:600;padding:0 8px 5px 0;">🥈 Fiber Guild</td>'
+                '<td align="right" style="color:#EEB44B;font-size:14px;font-weight:700;padding:0 0 5px;white-space:nowrap;">$400.00 &middot; 30.0%</td>'
+                "</tr></table>"
+                '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0a1929;border-radius:5px;">'
+                '<tr><td width="67%" style="height:18px;font-size:0;background-color:#EEB44B;background-image:linear-gradient(90deg,#EEB44B,#d4a043);border-radius:5px;">&nbsp;</td>'
+                '<td style="height:18px;font-size:0;">&nbsp;</td></tr></table>'
+                "</td></tr></table>"
+            ),
             "ballot_recap": "You voted — 1st: Metal Guild, 2nd: Fiber Guild, 3rd: Wood Guild.",
             "vote_1st": "Metal Guild",
             "vote_2nd": "Fiber Guild",
@@ -762,7 +792,7 @@ _CURATED: dict[str, EventCopy] = {
                     "<p>Hi {{ member_name }},</p>"
                     "<p>{{ intro_note }}</p>"
                     "<p>The votes for {{ cycle_label }} are counted. Here's how the funding pool was split:</p>"
-                    "<pre>{{ allocation_summary }}</pre>"
+                    "{{ allocation_chart }}"
                     "<p>{{ ballot_recap }}</p>"
                     '<p><a href="{{ voting_url }}">See the full breakdown</a></p>'
                     "<p>Past Lives Makerspace</p>"

--- a/core/events/rendering.py
+++ b/core/events/rendering.py
@@ -72,12 +72,23 @@ def render_html(template: str, context: Mapping[str, object]) -> SafeString:
     markup. Unknown placeholders become an escaped ``[missing: name]`` marker. Returns
     a :class:`~django.utils.safestring.SafeString` (the surrounding template is the
     intended HTML; only the interpolated values were escaped). Never raises.
+
+    A value that is already a :class:`~django.utils.safestring.SafeString` is inserted
+    **unescaped** — the opt-in Django convention for trusted, app-built markup (e.g. the
+    voting results bar chart :meth:`FundingSnapshot.allocation_chart_html`). This never
+    weakens the injection guard for DB copy: only *application code* can mark a context
+    value safe; a value drawn from the DB or user input is a plain ``str`` and is still
+    escaped. Any dynamic text inside a SafeString value must be escaped by whoever built
+    it (the chart renders through Django's autoescaping template engine, which does).
     """
 
     def _sub(match: re.Match[str]) -> str:
         name = match.group(1)
         if name in context:
-            return escape(str(context[name]))
+            value = context[name]
+            if isinstance(value, SafeString):
+                return str(value)  # trusted app-built markup — pass through unescaped
+            return escape(str(value))
         return escape(f"[missing: {name}]")
 
     return mark_safe(_PLACEHOLDER_RE.sub(_sub, template))  # noqa: S308 - values escaped above; literal is admin-authored

--- a/membership/models.py
+++ b/membership/models.py
@@ -4830,6 +4830,54 @@ class FundingSnapshot(models.Model):
         lines = [f"{row['guild_name']} — ${row['funding']} ({row['share_pct']}%)" for row in results]
         return "\n".join(lines)
 
+    def allocation_chart_html(self) -> SafeString:
+        """A branded, email-safe bar chart of the per-guild allocation.
+
+        The HTML twin of :meth:`allocation_summary`: one bar per guild (funding
+        descending), each sized to that guild's funding relative to the leader — the top
+        guild fills the bar — with the dollar amount, share of the pool, and a medal on
+        the top three. Mirrors the live standings bars on the voting page so the results
+        email reads the same as what members watched all month.
+
+        Rendered through Django's autoescaping template engine (``_allocation_chart.html``),
+        so guild names are HTML-escaped; the returned :class:`SafeString` is injected
+        *unescaped* into the results email by the constrained copy renderer (see
+        :func:`core.events.rendering.render_html`). Empty ``SafeString`` when the snapshot
+        has no per-guild results (a legacy or vote-less snapshot), so the email simply
+        omits the chart.
+        """
+        from decimal import ROUND_HALF_UP
+
+        from django.template.loader import render_to_string
+        from django.utils.safestring import mark_safe
+
+        results = (self.results or {}).get("results", [])
+        if not results:
+            return mark_safe("")
+
+        # funding is a Decimal fresh from calculate_results, or a string once the results
+        # JSON has round-tripped the DB — coerce either way. The leader sets the scale.
+        fundings = [Decimal(str(row["funding"])) for row in results]
+        top = max(fundings)
+        medals = {0: "🥇 ", 1: "🥈 ", 2: "🥉 "}
+        rows = []
+        for index, (row, funding) in enumerate(zip(results, fundings, strict=True)):
+            if top > 0:
+                width = int((funding / top * 100).to_integral_value(rounding=ROUND_HALF_UP))
+                width = max(width, 2) if funding > 0 else 0
+            else:
+                width = 0  # every guild at $0 (degenerate) — flat empty bars
+            rows.append(
+                {
+                    "name": row["guild_name"],
+                    "funding_display": f"{funding:.2f}",
+                    "share_display": row["share_pct"],
+                    "width_pct": width,
+                    "medal": medals.get(index, ""),
+                }
+            )
+        return mark_safe(render_to_string("membership/emails/_allocation_chart.html", {"rows": rows}))
+
     def send_results(
         self, *, actor: Any | None = None, resend: bool = False, intro_note: str = "", discord: bool = True
     ) -> int:
@@ -4869,6 +4917,7 @@ class FundingSnapshot(models.Model):
         n = self.results_send_count
         sent = 0
         allocation = self.allocation_summary()
+        allocation_chart = self.allocation_chart_html()
         # The spine never absolutizes URLs — the results email's "See the full
         # breakdown" link must carry the full host or it's a dead link in an inbox.
         voting_url = _absolute_url("/guilds/voting/history/")
@@ -4899,6 +4948,7 @@ class FundingSnapshot(models.Model):
                     "intro_note": intro_note,
                     "cycle_label": self.cycle_label,
                     "allocation_summary": allocation,
+                    "allocation_chart": allocation_chart,
                     "ballot_recap": ballot_recap,
                     "vote_1st": vote["guild_1st_name"],
                     "vote_2nd": vote["guild_2nd_name"],
@@ -4923,6 +4973,7 @@ class FundingSnapshot(models.Model):
                     "intro_note": intro_note,
                     "cycle_label": self.cycle_label,
                     "allocation_summary": allocation,
+                    "allocation_chart": allocation_chart,
                     "ballot_recap": "",
                     "vote_1st": "",
                     "vote_2nd": "",

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,24 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.55"
+VERSION = "0.23.56"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.56",
+        "date": "2026-08-09",
+        "title": "Guild vote reminders and results now go to every member",
+        "changes": [
+            "A few days before the monthly vote closes, everyone with an account gets a reminder email. "
+            "If you've already voted, it shows your current picks. If you haven't, it tells you where to go. "
+            "Starting end of August, there's also an @everyone post in #general-member-chat with the live standings.",
+            "When the vote closes and results are tallied, every member gets a results email that shows, guild by "
+            "guild, how the funding pool was split — a visual bar chart with the dollar amount and share for each "
+            "guild, just like the standings on the voting page. Voters also see a recap of their own ballot. "
+            "The email goes out automatically — no admin needs to click 'send'.",
+            "The results @everyone post to #general-member-chat also starts at the end of August.",
+        ],
+    },
     {
         "version": "0.23.55",
         "date": "2026-08-09",
@@ -30,20 +45,6 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
             "to members who missed it.",
             "A new 'fog' terminal tool gives admins a fast command-line shortcut to list, read, "
             "create, sync, and announce events, and to list members and guilds, all from a shell prompt.",
-        ],
-    },
-    {
-        "version": "0.23.53",
-        "date": "2026-08-09",
-        "title": "Guild vote reminders and results now go to every member",
-        "changes": [
-            "A few days before the monthly vote closes, everyone with an account gets a reminder email. "
-            "If you've already voted, it shows your current picks. If you haven't, it tells you where to go. "
-            "Starting end of August, there's also an @everyone post in #general-member-chat with the live standings.",
-            "When the vote closes and results are tallied, every member gets a results email showing how "
-            "the funding pool was split. Voters see a recap of their own ballot. "
-            "The email goes out automatically — no admin needs to click 'send'.",
-            "The results @everyone post to #general-member-chat also starts at the end of August.",
         ],
     },
     {

--- a/templates/membership/emails/_allocation_chart.html
+++ b/templates/membership/emails/_allocation_chart.html
@@ -1,0 +1,33 @@
+{% comment %}
+Email-safe guild-funding bar chart for the results email (voting.results_published).
+
+Rendered by FundingSnapshot.allocation_chart_html() into a SafeString and injected
+into the branded dark shell (#092E4C card, cream #F4EFDD text, gold #EEB44B). One row
+per guild, funding-descending: name (+ medal for the top three), the dollar amount and
+share of the pool, and a bar whose width is that guild's funding relative to the leader
+(the top guild fills the bar) -- mirroring the live standings on the voting page.
+
+Table-based with inline styles only, so it survives Gmail/Apple Mail/Outlook. `rows` is
+a list of {name, funding_display, share_display, width_pct, medal}; `name` is escaped by
+autoescape, the rest are app-built numbers.
+{% endcomment %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;margin:8px 0 20px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;">
+{% for row in rows %}
+    <tr>
+        <td style="padding:0 0 6px;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+                <tr>
+                    <td align="left" style="color:#F4EFDD;font-size:14px;font-weight:600;line-height:1.3;padding:0 8px 5px 0;">{{ row.medal }}{{ row.name }}</td>
+                    <td align="right" style="color:#EEB44B;font-size:14px;font-weight:700;line-height:1.3;padding:0 0 5px;white-space:nowrap;">${{ row.funding_display }} &middot; {{ row.share_display }}%</td>
+                </tr>
+            </table>
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:separate;background-color:#0a1929;border-radius:5px;">
+                <tr>
+                    <td width="{{ row.width_pct }}%" style="height:18px;line-height:18px;font-size:0;background-color:#EEB44B;background-image:linear-gradient(90deg,#EEB44B,#d4a043);border-radius:5px;">&nbsp;</td>
+                    <td style="height:18px;line-height:18px;font-size:0;">&nbsp;</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+{% endfor %}
+</table>

--- a/tests/core/events/rendering_spec.py
+++ b/tests/core/events/rendering_spec.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from django.utils.safestring import mark_safe
+
 from core.events.rendering import (
     placeholders_in,
     render_copy,
@@ -50,6 +52,26 @@ def describe_render_html():
     def it_escapes_the_missing_marker_too():
         out = str(render_html("<p>{{ gone }}</p>", {}))
         assert "[missing: gone]" in out
+
+    def describe_with_a_safestring_value():
+        def it_passes_app_built_markup_through_unescaped():
+            # A SafeString value is trusted app-built markup (e.g. the allocation chart)
+            # and is inserted verbatim — the whole point of the opt-in.
+            chart = mark_safe('<table><tr><td width="100%">bar</td></tr></table>')
+            out = str(render_html("<div>{{ chart }}</div>", {"chart": chart}))
+            assert '<table><tr><td width="100%">bar</td></tr></table>' in out
+
+        def it_still_escapes_plain_string_values_alongside_a_safestring():
+            # Marking one value safe must not weaken escaping for the others.
+            out = str(
+                render_html(
+                    "{{ chart }}{{ evil }}",
+                    {"chart": mark_safe("<b>ok</b>"), "evil": "<script>x</script>"},
+                )
+            )
+            assert "<b>ok</b>" in out
+            assert "<script>" not in out
+            assert "&lt;script&gt;" in out
 
 
 def describe_render_copy():

--- a/tests/membership/funding_snapshot_results_spec.py
+++ b/tests/membership/funding_snapshot_results_spec.py
@@ -279,3 +279,40 @@ def describe_send_results_audience_safety():
         )
         assert inapp_users == {active.user_id, opted_out.user_id}
         assert n == 2  # active + opted-out each had at least one fresh delivery
+
+
+def describe_allocation_chart_html():
+    def it_renders_one_escaped_bar_per_guild_with_dollars_and_share(db):
+        # Metal leads (both a 1st and a 2nd place point), so it should top the chart.
+        _voter("a@x.com", picks=(GuildFactory(name="Metal"), GuildFactory(name="Fiber"), GuildFactory(name="Wood")))
+        _voter("b@x.com", picks=(GuildFactory(name="Metal"), GuildFactory(name="Clay"), GuildFactory(name="Glass")))
+        snap = FundingSnapshot.take()
+        assert snap is not None
+
+        html = str(snap.allocation_chart_html())
+        # A guild name per row, the medal on the leader, and a money/percent figure.
+        assert "Metal" in html
+        assert "🥇" in html
+        assert "$" in html and "%" in html
+        # The leader fills the bar (width 100%); it is a real table bar, not a <pre> block.
+        assert 'width="100%"' in html
+        assert "<pre>" not in html
+
+    def it_html_escapes_guild_names(db):
+        _voter(
+            "a@x.com",
+            picks=(GuildFactory(name="Ben & Jerry's <Guild>"), GuildFactory(name="Fiber"), GuildFactory(name="Wood")),
+        )
+        snap = FundingSnapshot.take()
+        assert snap is not None
+        html = str(snap.allocation_chart_html())
+        assert "<Guild>" not in html
+        assert "&lt;Guild&gt;" in html
+        assert "&amp;" in html
+
+    def describe_with_a_voteless_or_legacy_snapshot():
+        def it_returns_empty_markup(db):
+            snap = FundingSnapshot.objects.create(
+                cycle_label="Legacy", contributor_count=0, funding_pool=Decimal("0"), results={}
+            )
+            assert str(snap.allocation_chart_html()) == ""


### PR DESCRIPTION
## What

The monthly guild-funding **results email** listed the allocation as a plain monospace block (`<pre>`). It now shows the same **bar chart** members watch on the voting page: one gold bar per guild (funding-descending), sized to that guild's funding relative to the leader, with the dollar amount, share of the pool, and a medal on the top three — rendered into the branded dark email shell.

This is the visual half of the "results go to every member" feature (the send/automation landed in #186); folded into the same changelog entry, re-stamped to v0.23.56.

## How

- **`FundingSnapshot.allocation_chart_html()`** — builds an email-safe, table-based bar chart (`SafeString`) from the snapshot results, via a new app-owned partial `templates/membership/emails/_allocation_chart.html`. Guild names are autoescaped by the template engine. `allocation_summary()` (plain text) is unchanged and still drives the text body.
- **`send_results()`** passes `allocation_chart` into both the voter and non-voter emit contexts.
- **`core.events.rendering.render_html`** now passes a `SafeString` context value through **unescaped** (the opt-in Django convention for trusted, app-built markup). Plain strings from DB copy are still escaped, so the copy injection guard is unchanged — only application code can mark a value safe.
- **`voting.results_published` copy** — HTML body uses `{{ allocation_chart }}` in place of `<pre>{{ allocation_summary }}</pre>`; added the `allocation_chart` placeholder and a two-bar sample so the live copy-editor preview renders the real chart.

## Tests

- `render_html`: SafeString value passes through unescaped; a plain string alongside it is still escaped (injection guard intact).
- `allocation_chart_html`: one escaped bar per guild, medal + 100%-width leader, dollar/percent figures, and empty markup for a voteless/legacy snapshot.
- Full events + funding/voting sweep green locally (847 passed).

## Notes

Table-based bars with inline styles only, so it survives Gmail / Apple Mail / Outlook. No migration. Rebased on latest `main` (past the Stripe billing-mode v0.23.55).

https://claude.ai/code/session_01NjbhB5hvRChHow2qcjDP8E