### PR TITLE
[discord] Harden nightly events push and role sync against Discord throttling (v0.23.57)

### DIFF
--- a/core/events/discord_dm.py
+++ b/core/events/discord_dm.py
@@ -129,23 +129,31 @@ def post_dm(discord_user_id: str, message: Message) -> bool:
     return False
 
 
-_CLOSED_DM_ERROR_CODE = 50007  # Discord's "Cannot send messages to this user".
+def _dm_undeliverable(response: httpx.Response) -> bool:
+    """``True`` when Discord refused a DM open/send with 403 — undeliverable to this recipient.
 
-
-def _dms_closed(response: httpx.Response) -> bool:
-    """``True`` when Discord refused with 403 + JSON error code 50007.
-
-    That combination means the recipient's privacy settings block DMs from the bot —
-    permanently undeliverable, never worth a retry. Anything else (other statuses,
-    non-JSON bodies, other error codes) is NOT "closed DMs" and stays loud.
+    A 403 means closed DMs, a blocked bot, no mutual server, or any other per-user block, and
+    is never worth retrying. Broadened from the original 403 + code-50007 check after a 403
+    with a different sub-code on the message-post call crashed the reconcile cron every 15
+    minutes on the same reactor forever (2026-08-09): the guard row is only written on a clean
+    or closed send, so an uncaught raise never wrote it and the same reactor was retried and
+    crashed every tick. A non-403 failure (401 bad token, 429, 5xx, network) is systemic, not
+    per-user, and must stay loud.
     """
-    if response.status_code != 403:
-        return False
+    return response.status_code == 403
+
+
+def _discord_error_code(response: httpx.Response) -> int | None:
+    """The Discord JSON error ``code`` for the undeliverable-DM log line.
+
+    Returns ``None`` when the body isn't JSON, isn't an object, or has no int ``code``.
+    """
     try:
         payload = response.json()
     except ValueError:
-        return False
-    return isinstance(payload, dict) and payload.get("code") == _CLOSED_DM_ERROR_CODE
+        return None
+    code = payload.get("code") if isinstance(payload, dict) else None
+    return code if isinstance(code, int) else None
 
 
 def send_dm_text(discord_user_id: str, content: str) -> bool:
@@ -153,9 +161,9 @@ def send_dm_text(discord_user_id: str, content: str) -> bool:
 
     For callers that must know whether a send genuinely went out (e.g. the one-time
     guild-link nudge, which persists "already nudged" state on the result). Returns
-    ``True`` on a 2xx send, and ``False`` ONLY when the recipient's DMs are closed
-    (403 + Discord error code 50007 on either call — logged, permanently
-    undeliverable, never retried). Any other non-2xx raises
+    ``True`` on a 2xx send, and ``False`` on ANY 403 from either call (undeliverable to
+    this recipient — closed DMs, a blocked bot, no mutual server, or any other per-user
+    block — logged, never retried). Any other non-2xx (401, 429, 5xx) raises
     :class:`httpx.HTTPStatusError`, and network errors propagate as
     :class:`httpx.HTTPError` — the caller decides what an undelivered send means.
     The caller ensures the bot is configured (a blank token would just 401 loudly).
@@ -166,8 +174,8 @@ def send_dm_text(discord_user_id: str, content: str) -> bool:
         headers=_auth_headers(),
         timeout=_DEFAULT_TIMEOUT_SECONDS,
     )
-    if _dms_closed(response):
-        logger.info("Discord DM to %s undeliverable (DMs closed).", discord_user_id)
+    if _dm_undeliverable(response):
+        logger.info("Discord DM to %s undeliverable (403, code %s).", discord_user_id, _discord_error_code(response))
         return False
     response.raise_for_status()
     channel_id = str(response.json()["id"])
@@ -177,8 +185,8 @@ def send_dm_text(discord_user_id: str, content: str) -> bool:
         headers=_auth_headers(),
         timeout=_DEFAULT_TIMEOUT_SECONDS,
     )
-    if _dms_closed(response):
-        logger.info("Discord DM to %s undeliverable (DMs closed).", discord_user_id)
+    if _dm_undeliverable(response):
+        logger.info("Discord DM to %s undeliverable (403, code %s).", discord_user_id, _discord_error_code(response))
         return False
     response.raise_for_status()
     return True

--- a/core/integrations/discord_events.py
+++ b/core/integrations/discord_events.py
@@ -53,6 +53,7 @@ DEFAULT_LOCATION = "Past Lives Makerspace"
 
 _TIMEOUT_SECONDS = 5.0
 _RATE_LIMIT_MAX_WAIT_SECONDS = 15.0
+_RATE_LIMIT_MAX_ATTEMPTS = 3  # the initial send + up to 2 retries
 _SYNC_ERROR_MAX = 500
 _NAME_MAX = 100
 _LOCATION_MAX = 100
@@ -142,19 +143,23 @@ class DiscordScheduledEventsClient:
 
         Both a transport failure (``httpx.HTTPError``) and a non-2xx status become a
         ``DiscordEventsError``; a 2xx with an empty body (a ``DELETE`` 204) returns ``{}``.
-        With ``retry_on_rate_limit`` a 429 is retried once after Discord's ``Retry-After``
-        — the scheduled-events bucket is tiny, so the daily mirror's burst of ~a-dozen
-        calls reliably trips it mid-run; waiting the advertised second or two clears it.
+        With ``retry_on_rate_limit`` a 429 is retried up to ``_RATE_LIMIT_MAX_ATTEMPTS - 1``
+        more times, each after Discord's ``Retry-After`` — the scheduled-events bucket is
+        tiny, so the daily mirror's burst of ~a-dozen calls reliably trips it mid-run, at
+        times on consecutive calls; waiting the advertised second or two each time clears it.
         Only batch paths opt in: an interactive FOG save should fail fast into the retry
         cron, not hang the request sleeping. A 429 without the flag, or with no usable or
-        too-long ``Retry-After``, raises immediately.
+        too-long ``Retry-After`` on any attempt, raises immediately.
         """
         response = DiscordScheduledEventsClient._send(method, path, json=json)
-        if response.status_code == 429 and retry_on_rate_limit:
+        attempts = 1
+        while response.status_code == 429 and retry_on_rate_limit and attempts < _RATE_LIMIT_MAX_ATTEMPTS:
             retry_after = _retry_after_seconds(response)
-            if retry_after is not None and retry_after <= _RATE_LIMIT_MAX_WAIT_SECONDS:
-                time.sleep(retry_after)
-                response = DiscordScheduledEventsClient._send(method, path, json=json)
+            if retry_after is None or retry_after > _RATE_LIMIT_MAX_WAIT_SECONDS:
+                break
+            time.sleep(retry_after)
+            response = DiscordScheduledEventsClient._send(method, path, json=json)
+            attempts += 1
         if not response.is_success:
             raise DiscordEventsError(f"Discord API {response.status_code}: {response.text[:300]}")
         return response.json() if response.content else {}

--- a/hub/calendar_service.py
+++ b/hub/calendar_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import urllib.request
 from collections.abc import Callable
 from datetime import date as date_type
@@ -219,6 +220,10 @@ def sync_general_calendar() -> int:
 # list — only this near window is pushed, capped well under Discord's 100-per-guild limit.
 _DISCORD_PUSH_HORIZON = timedelta(days=30)
 _DISCORD_PUSH_CAP = 50
+_DISCORD_PUSH_PACE_SECONDS = 0.5  # light pacing between Discord calls so a capped-50
+# nightly run doesn't burst the tiny scheduled-events bucket in one breath. Worst case
+# (the full cap, no 429s) adds ~25s -- fine for an unattended nightly cron; the
+# interactive single-event save (push_community_event) never goes through this loop.
 
 
 def _discord_event_body(event: CalendarEvent) -> dict[str, Any]:
@@ -264,6 +269,12 @@ def sync_discord_feed_events() -> int:
 
     Every event is attempted even when one fails; failures are then raised as one
     :class:`DiscordEventsError` so ``sync_all_sources`` records the source as failed.
+
+    Discord calls are lightly paced: the very first call of the run is un-paced, then every
+    later call — push OR delete — sleeps ``_DISCORD_PUSH_PACE_SECONDS`` first. Pacing is at
+    one-call-per-feed-event granularity; the rare update-then-recreate double-call inside a
+    single ``_push_feed_event`` is not internally paced (an isolated one-off, and
+    ``_execute``'s own retry covers a transient 429 there).
     """
     from core.integrations.discord_events import DiscordEventsError, DiscordScheduledEventsClient
 
@@ -287,8 +298,17 @@ def sync_discord_feed_events() -> int:
         .order_by("start_dt")[:_DISCORD_PUSH_CAP]
     )
     failures: list[str] = []
+    made_a_call = False
+
+    def _pace() -> None:
+        """Sleep before every Discord call except the first, sharing one run-wide counter."""
+        nonlocal made_a_call
+        if made_a_call:
+            time.sleep(_DISCORD_PUSH_PACE_SECONDS)
+        made_a_call = True
 
     for event in push_set:
+        _pace()
         try:
             _push_feed_event(client, event)
         except DiscordEventsError as exc:
@@ -300,6 +320,7 @@ def sync_discord_feed_events() -> int:
         .exclude(pk__in=[event.pk for event in push_set])
     )
     for event in dropped:
+        _pace()
         try:
             _delete_feed_event_copy(client, event)
         except DiscordEventsError as exc:

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.55"
+VERSION = "0.23.57"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.57",
+        "date": "2026-08-09",
+        "title": "Behind-the-scenes fixes for Discord sync",
+        "changes": [
+            "The nightly sync to Discord's Events tab could miss a few events if Discord "
+            "asked us to slow down partway through. It now waits a moment and tries again, "
+            "so every event makes it over.",
+            "If you reacted in #choose-your-guild but the bot could not send you a DM, that "
+            "used to block the 'link your Discord' reminder for everyone who reacted after "
+            "you too. That is fixed: your reminder is now marked as sent and everyone else "
+            "still gets theirs.",
+        ],
+    },
     {
         "version": "0.23.55",
         "date": "2026-08-09",

--- a/tests/core/events/discord_dm_spec.py
+++ b/tests/core/events/discord_dm_spec.py
@@ -180,23 +180,40 @@ def describe_send_dm_text():
             discord_dm.send_dm_text("555", "hi")
 
     @respx.mock
-    def it_raises_on_a_403_with_a_different_error_code(settings):
+    def it_returns_false_on_a_403_with_a_different_error_code(settings):
+        # Any 403 is per-recipient undeliverable now, not just code 50007 — never raises.
         settings.DISCORD_BOT_TOKEN = "tok"
         respx.post(_CHANNELS_URL).mock(return_value=httpx.Response(403, json={"code": 50001}))
-        with pytest.raises(httpx.HTTPStatusError):
-            discord_dm.send_dm_text("555", "hi")
+        assert discord_dm.send_dm_text("555", "hi") is False
 
     @respx.mock
-    def it_raises_on_a_non_json_403(settings):
+    def it_returns_false_on_a_non_json_403(settings):
         settings.DISCORD_BOT_TOKEN = "tok"
         respx.post(_CHANNELS_URL).mock(return_value=httpx.Response(403, text="forbidden"))
-        with pytest.raises(httpx.HTTPStatusError):
-            discord_dm.send_dm_text("555", "hi")
+        assert discord_dm.send_dm_text("555", "hi") is False
 
     @respx.mock
-    def it_raises_on_a_403_with_a_non_object_json_body(settings):
+    def it_returns_false_on_a_403_with_a_non_object_json_body(settings):
         settings.DISCORD_BOT_TOKEN = "tok"
         respx.post(_CHANNELS_URL).mock(return_value=httpx.Response(403, json=["nope"]))
+        assert discord_dm.send_dm_text("555", "hi") is False
+
+    @respx.mock
+    def it_returns_false_on_a_403_with_no_code_key_on_the_message_post(settings):
+        # The channel opens, but the message post 403s with a body that carries no `code` —
+        # the exact shape that used to crash the reconcile cron. It's now a quiet False.
+        settings.DISCORD_BOT_TOKEN = "tok"
+        respx.post(_CHANNELS_URL).mock(return_value=httpx.Response(200, json={"id": "dm99"}))
+        respx.post(_MESSAGES_URL).mock(return_value=httpx.Response(403, json={"message": "Missing Access"}))
+        assert discord_dm.send_dm_text("555", "hi") is False
+
+    @respx.mock
+    def it_raises_on_a_401_bad_token(settings):
+        # A bot-wide auth failure is systemic, not per-recipient — it must still surface.
+        settings.DISCORD_BOT_TOKEN = "tok"
+        respx.post(_CHANNELS_URL).mock(
+            return_value=httpx.Response(401, json={"code": 0, "message": "401: Unauthorized"})
+        )
         with pytest.raises(httpx.HTTPStatusError):
             discord_dm.send_dm_text("555", "hi")
 

--- a/tests/core/integrations/discord_events_spec.py
+++ b/tests/core/integrations/discord_events_spec.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import httpx
 import pytest
@@ -486,6 +486,22 @@ def describe_DiscordScheduledEventsClient():
             assert route.call_count == 2
 
         @respx.mock
+        def it_retries_up_to_the_max_attempts_before_succeeding(settings):
+            # Two consecutive 429s then a 200 — the bounded retry keeps going past the first
+            # retry (up to _RATE_LIMIT_MAX_ATTEMPTS - 1 waits) and still lands the send.
+            settings.DISCORD_BOT_TOKEN = "tok"
+            rate_limited = httpx.Response(429, json={"retry_after": 1.0}, headers={"Retry-After": "1.0"})
+            route = respx.post(_EVENTS_URL).mock(
+                side_effect=[rate_limited, rate_limited, httpx.Response(200, json={"id": "e1"})]
+            )
+            client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
+            with patch("core.integrations.discord_events.time.sleep") as fake_sleep:
+                assert client.insert_event(SERVER_ID, {"name": "x"}, retry_on_rate_limit=True) == {"id": "e1"}
+            assert route.call_count == 3
+            assert fake_sleep.call_count == 2
+            fake_sleep.assert_has_calls([call(1.0), call(1.0)])
+
+        @respx.mock
         def it_fails_fast_on_a_429_without_the_retry_flag(settings):
             # Interactive FOG saves must not hang the request sleeping — only the
             # batch mirror opts into the wait-and-retry.
@@ -503,17 +519,20 @@ def describe_DiscordScheduledEventsClient():
             assert route.call_count == 1
 
         @respx.mock
-        def it_raises_when_the_retry_is_also_rate_limited(settings):
+        def it_raises_after_exhausting_all_rate_limit_retries(settings):
+            # Every attempt 429s — the bounded loop makes _RATE_LIMIT_MAX_ATTEMPTS calls
+            # (the initial send + two retries) then gives up and raises.
             settings.DISCORD_BOT_TOKEN = "tok"
             rate_limited = httpx.Response(429, json={"retry_after": 1.0}, headers={"Retry-After": "1.0"})
-            route = respx.post(_EVENTS_URL).mock(side_effect=[rate_limited, rate_limited])
+            route = respx.post(_EVENTS_URL).mock(side_effect=[rate_limited, rate_limited, rate_limited])
             client = de.DiscordScheduledEventsClient(enabled=True, server_id=SERVER_ID)
             with (
-                patch("core.integrations.discord_events.time.sleep"),
+                patch("core.integrations.discord_events.time.sleep") as fake_sleep,
                 pytest.raises(de.DiscordEventsError, match="429"),
             ):
                 client.insert_event(SERVER_ID, {}, retry_on_rate_limit=True)
-            assert route.call_count == 2
+            assert route.call_count == 3
+            assert fake_sleep.call_count == 2
 
         @respx.mock
         def it_raises_without_retrying_when_a_429_has_no_usable_retry_after(settings):

--- a/tests/hub/calendar_service_spec.py
+++ b/tests/hub/calendar_service_spec.py
@@ -397,7 +397,11 @@ def describe_sync_discord_feed_events():
         for _ in range(3):
             _feed_event()
         client = _events_client()
-        with _with_client(client), patch("hub.calendar_service._DISCORD_PUSH_CAP", 2):
+        with (
+            _with_client(client),
+            patch("hub.calendar_service._DISCORD_PUSH_CAP", 2),
+            patch("hub.calendar_service.time.sleep"),
+        ):
             assert sync_discord_feed_events() == 2
         assert client.insert_event.call_count == 2
 
@@ -425,6 +429,39 @@ def describe_sync_discord_feed_events():
         past.refresh_from_db()
         assert past.discord_event_id == "disc-past"
 
+    def it_does_not_pace_a_single_push():
+        # The very first Discord call of a run is un-paced — a lone event never sleeps.
+        from hub.calendar_service import sync_discord_feed_events
+
+        _feed_event()
+        client = _events_client()
+        with _with_client(client), patch("hub.calendar_service.time.sleep") as sleep:
+            sync_discord_feed_events()
+        sleep.assert_not_called()
+
+    def it_paces_between_two_pushes():
+        from hub.calendar_service import _DISCORD_PUSH_PACE_SECONDS, sync_discord_feed_events
+
+        _feed_event(days=1)
+        _feed_event(days=2)
+        client = _events_client()
+        with _with_client(client), patch("hub.calendar_service.time.sleep") as sleep:
+            sync_discord_feed_events()
+        sleep.assert_called_once_with(_DISCORD_PUSH_PACE_SECONDS)
+
+    def it_paces_between_a_push_and_a_later_delete_in_the_same_run():
+        # One shared counter across both loops: the push is call #1 (un-paced), the
+        # later delete is call #2 and sleeps first. A per-loop counter would reset and
+        # never sleep the delete — this pins that down.
+        from hub.calendar_service import _DISCORD_PUSH_PACE_SECONDS, sync_discord_feed_events
+
+        _feed_event(days=1)  # inside the 30-day window → pushed
+        _feed_event(days=40, discord_event_id="disc-drop")  # future but out of window → dropped
+        client = _events_client()
+        with _with_client(client), patch("hub.calendar_service.time.sleep") as sleep:
+            sync_discord_feed_events()
+        sleep.assert_called_once_with(_DISCORD_PUSH_PACE_SECONDS)
+
     def it_attempts_every_event_then_raises_on_failures():
         from core.integrations.discord_events import DiscordEventsError
         from hub.calendar_service import sync_discord_feed_events
@@ -433,7 +470,11 @@ def describe_sync_discord_feed_events():
         second = _feed_event(days=2)
         client = _events_client()
         client.insert_event.side_effect = [DiscordEventsError("boom"), {"id": "disc-2"}]
-        with _with_client(client), pytest.raises(DiscordEventsError, match="1 Discord event push"):
+        with (
+            _with_client(client),
+            patch("hub.calendar_service.time.sleep"),
+            pytest.raises(DiscordEventsError, match="1 Discord event push"),
+        ):
             sync_discord_feed_events()
 
         second.refresh_from_db()

--- a/tests/membership/discord_sync_spec.py
+++ b/tests/membership/discord_sync_spec.py
@@ -263,6 +263,18 @@ def describe_reconcile_nudges_unlinked_reactors():
         assert DiscordLinkNudge.objects.filter(discord_user_id="stranger").exists()  # never retried
 
     @respx.mock
+    def it_marks_the_reactor_nudged_on_a_403_with_a_different_error_code(sync_config):
+        # A 403 that isn't the 50007 "DMs closed" code (e.g. a blocked bot / no mutual server)
+        # used to raise and crash the cron on the same reactor every tick. Any 403 is now a
+        # quiet, permanent "undeliverable" — the guard row is written so it's never retried.
+        DiscordGuildEmojiFactory(emoji="🔥", guild=GuildFactory())
+        _mock_reactions({"🔥": ["stranger"]})
+        _mock_dm(message_response=httpx.Response(403, json={"message": "Missing Access"}))
+        stats = discord_sync.reconcile_reactions()  # must not raise
+        assert stats.nudged == 1
+        assert DiscordLinkNudge.objects.filter(discord_user_id="stranger").exists()
+
+    @respx.mock
     def it_raises_and_leaves_the_reactor_unmarked_on_any_other_dm_error(sync_config):
         DiscordGuildEmojiFactory(emoji="🔥", guild=GuildFactory())
         _mock_reactions({"🔥": ["stranger"]})


### PR DESCRIPTION
## What and why

Two separate Discord sync failures were firing in production. Both are fixed here, in one PR, because they share the same root shape (a Discord HTTP status the code did not handle robustly) and the same test surface.

### Bug A: nightly `sync_all_sources` failed with HTTP 429

The failing "source" in the nightly job was the Discord Scheduled Events mirror, not the Drupal class feed (that endpoint was independently confirmed healthy). Prod log:

```
discord events: 5 Discord event push(es) failed; first: 'Art Framing open studio hours':
  Discord API 429: {"message": "You are being rate limited.", "retry_after": 1.149, ...}
```

`sync_discord_feed_events` pushes up to 50 scheduled events back to back, and `DiscordScheduledEventsClient._execute` retried a 429 exactly once. Under a burst, several calls still 429 after their single retry and were recorded as failures.

**Fix:** `_execute` now retries a 429 up to `_RATE_LIMIT_MAX_ATTEMPTS` (3) times, each wait still bounded by `_RATE_LIMIT_MAX_WAIT_SECONDS`; and `sync_discord_feed_events` lightly paces its calls (`_DISCORD_PUSH_PACE_SECONDS = 0.5`, shared across the push and delete passes so the first call is un-paced and every later one waits). The interactive single-event save path does not go through this loop and still fails fast into the retry cron.

### Bug B: `sync_discord_guild_roles` failed 403 every 15 minutes

The uncaught error was the unlinked-reactor link nudge. `send_dm_text` treated a 403 as "DMs closed → return False" only when the body carried Discord error code `50007`. Any other 403 on the DM message POST hit `raise_for_status()` and crashed `reconcile_reactions`. Because the `DiscordLinkNudge` guard row is written only after a clean or closed send, the same reactor was retried and crashed every single tick, forever.

**Fix:** any per-recipient 403 on the DM open/send now counts as undeliverable (`_dm_undeliverable`), so the caller marks the reactor nudged and never retries. A bot-wide auth problem is a 401, not a per-user 403, so `401 / 429 / 5xx / network` still raise loudly and surface a genuine outage. The actual Discord sub-code is logged.

## Tests

New and updated BDD specs across `discord_events_spec`, `calendar_service_spec`, `discord_dm_spec`, and `discord_sync_spec` cover: multi-attempt 429 retry (exact call and sleep counts), pacing between two pushes and between a push and a later delete in the same run, any-403-returns-False on both DM calls (including a non-50007 message-post 403), and a 401 still raising. Sleeps are patched so tests stay fast.

Local run of the full CI gate: `ruff format --check` + `ruff check` clean, `mypy plfog/ core/ membership/ hub/` clean, `manage.py check` clean, full `pytest` = 7070 passed, total coverage 98.36% (>= 98% threshold).

## Out of scope (follow-up, not in this PR)

The architect review flagged that `retry_discord_event_pushes` and `backfill_discord_events` call `push_community_event` without `retry_on_rate_limit=True` at all, so that path gets zero 429 retries even after this change. It is unrelated to the two reported bugs and left for a separate ticket.

## Version

`VERSION` bumps to `0.23.57` (main is 0.23.55; PR #190 owns 0.23.56) with one plain-language CHANGELOG entry covering both fixes.

https://claude.ai/code/session_01A7CVXYJGyRWs9cN6Ujz7up
