### PR TITLE
fix(css): mobile class-card photo fills its box instead of a tiny thumbnail (v0.23.60)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.59"
+VERSION = "0.23.60"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "0.23.59",
-        "date": "2026-08-09",
+        "version": "0.23.60",
+        "date": "2026-08-10",
         "title": "Photos now fit your screen, especially on phones",
         "changes": [
             "Some photos — guild icons and logos especially — could show up way too big on a phone and "
             "spill off the edge of the screen. Every photo across the site now automatically resizes to "
             "fit, so pages look right no matter what device you're using.",
+            "On the class booking pages, each class photo now fills its space on phones instead of "
+            "showing as a tiny thumbnail floating in an empty box.",
         ],
     },
     {

--- a/static/css/cms-public.css
+++ b/static/css/cms-public.css
@@ -558,8 +558,11 @@ html.dark .cp-page {
 .cp-page .empty{padding:24px;text-align:center;color:var(--text3);font-size:11px}
 
 @media(max-width:768px){
-  .cp-page .cls-card{grid-template-columns:64px 1fr auto;gap:10px;padding:10px 12px}
-  .cp-page .cls-img,.cp-page .cls-img-ph{width:64px;height:48px}
+  /* Phone: the class card stays a vertical stack (flex column), so the photo fills
+     the full-width media box like the desktop card. The old compact 64x48 thumbnail
+     was for a horizontal 64px|text|price row that was never wired up (the card never
+     became display:grid), which left a tiny photo stranded in the 150px image box. */
+  .cp-page .cls-card{gap:10px;padding:10px 12px}
   .cp-page .dc-igrid{grid-template-columns:1fr}
   .cp-page #hero{padding:32px 20px}
   .cp-page #hero h1{font-size:24px}


### PR DESCRIPTION
## Problem
On the public class booking pages (`book.pastlives.space/classes/`), below 768px each class card showed its photo as a tiny 64×48 thumbnail stranded in the full-width 150px image box — a small photo floating in a big empty rectangle.

## Root cause (pre-existing, NOT the v0.23.59 image reset)
The `@media(max-width:768px)` block forced `.cls-img{width:64px;height:48px}` for a compact horizontal `64px | text | price` row. That row was never wired up: `.cls-card` stays `display:flex; flex-direction:column` at every width, so its `grid-template-columns` never took effect and the thumbnail was left stranded.

I verified in-browser on the live page by toggling the v0.23.59 global `img` reset on and off: the card renders identically either way. The global reset is a **no-op** on these cards because `.cls-img` (specificity 0,2,0) wins over the bare `img` rule (0,0,1). So this is a pre-existing layout bug my testing surfaced, not a regression.

## Fix
Remove the vestigial `64×48` override (and the dead `grid-template-columns`) so the phone card renders like the desktop card — the photo fills its full-width 150px media box. Confirmed visually before/after across widths.

## Release
- `VERSION` → `0.23.60`.
- Folded into the existing "Photos now fit your screen" changelog entry (same photos-on-mobile theme, per the repo's one-entry-per-feature rule) with an added bullet about class photos; re-stamped to 0.23.60.

https://claude.ai/code/session_01A7CVXYJGyRWs9cN6Ujz7up