### PR TITLE
Email copy review: apply requested copy and design changes

### DIFF
--- a/classes/models.py
+++ b/classes/models.py
@@ -800,6 +800,7 @@ class ClassOffering(HeroCropMixin, models.Model):
                 "member_name": "there",
                 "class_title": self.title,
                 "class_starts_at": self.cancellation_date_label,
+                "classes_url": f"{settings.BOOK_BASE_URL}/classes/",
             },
             url="/classes/",
             email_to=self.registrant_notice_emails,

--- a/core/events/copy.py
+++ b/core/events/copy.py
@@ -187,11 +187,12 @@ _CURATED: dict[str, EventCopy] = {
         },
     ),
     "class_cancelled": EventCopy(
-        placeholders=("member_name", "class_title", "class_starts_at"),
+        placeholders=("member_name", "class_title", "class_starts_at", "classes_url"),
         sample_context={
             "member_name": "Robin Vale",
             "class_title": "Intro to Lost-Wax Casting",
             "class_starts_at": "Saturday, July 12",
+            "classes_url": "https://pastlives.example/classes/",
         },
         channels={
             Channel.IN_APP: ChannelCopy(
@@ -202,13 +203,22 @@ _CURATED: dict[str, EventCopy] = {
                 subject="Cancelled: {{ class_title }}",
                 body_text=(
                     "Hi {{ member_name }},\n\n"
-                    "Unfortunately {{ class_title }} on {{ class_starts_at }} has been cancelled. "
-                    "Any payment will be refunded.\n\nPast Lives Makerspace"
+                    "Life happens... and due to rare and unfortunate circumstances, {{ class_title }} "
+                    "on {{ class_starts_at }} has been cancelled. Any payment will be refunded in full, "
+                    "and we're really sorry for any inconvenience.\n\n"
+                    "We'd still love to see you in our space. Find another class: {{ classes_url }}\n\n"
+                    "Past Lives Makerspace"
                 ),
                 body_html=(
                     "<p>Hi {{ member_name }},</p>"
-                    "<p>Unfortunately <strong>{{ class_title }}</strong> on {{ class_starts_at }} "
-                    "has been cancelled. Any payment will be refunded.</p>"
+                    "<p>Life happens... and due to rare and unfortunate circumstances, "
+                    "<strong>{{ class_title }}</strong> on {{ class_starts_at }} has been cancelled. "
+                    "Any payment will be refunded in full, and we're really sorry for any inconvenience.</p>"
+                    "<p>We'd still love to see you in our space. Click below to find another class.</p>"
+                    '<p style="text-align:center;margin:24px 0 8px;"><a href="{{ classes_url }}" '
+                    'style="display:inline-block;padding:12px 28px;background-color:#EEB44B;color:#092E4C;'
+                    'font-size:14px;font-weight:700;text-decoration:none;border-radius:6px;">'
+                    "Find a Class</a></p>"
                     "<p>Past Lives Makerspace</p>"
                 ),
             ),
@@ -346,15 +356,14 @@ _CURATED: dict[str, EventCopy] = {
                 body_text=(
                     "Hi {{ member_name }},\n\n"
                     "Your tab balance is {{ balance }} of your {{ limit }} limit. Once you reach the "
-                    "limit your tab locks until it's paid down, so it's worth settling up before then.\n\n"
+                    "limit, your tab locks until it's paid down.\n\n"
                     "Pay down your tab: {{ tab_url }}\n\n"
                     "Past Lives Makerspace"
                 ),
                 body_html=(
                     "<p>Hi {{ member_name }},</p>"
                     "<p>Your tab balance is <strong>{{ balance }}</strong> of your {{ limit }} limit. "
-                    "Once you reach the limit your tab locks until it's paid down, so it's worth "
-                    "settling up before then.</p>"
+                    "Once you reach the limit, your tab locks until it's paid down.</p>"
                     '<p><a href="{{ tab_url }}">Pay down your tab</a></p>'
                     "<p>Past Lives Makerspace</p>"
                 ),
@@ -378,15 +387,15 @@ _CURATED: dict[str, EventCopy] = {
                 subject="Refund issued for {{ class_title }}",
                 body_text=(
                     "Hi {{ member_name }},\n\n"
-                    "We've refunded {{ amount }} for {{ class_title }}. Refunds usually land back on "
-                    "your original payment method within 5–10 business days.\n\n"
+                    "We've refunded {{ amount }} for {{ class_title }}. Refunds typically process "
+                    "within 5–10 business days.\n\n"
                     "View your booking: {{ registration_url }}\n\n"
                     "Past Lives Makerspace"
                 ),
                 body_html=(
                     "<p>Hi {{ member_name }},</p>"
-                    "<p>We've refunded <strong>{{ amount }}</strong> for {{ class_title }}. Refunds usually "
-                    "land back on your original payment method within 5–10 business days.</p>"
+                    "<p>We've refunded <strong>{{ amount }}</strong> for {{ class_title }}. Refunds "
+                    "typically process within 5–10 business days.</p>"
                     '<p><a href="{{ registration_url }}">View your booking</a></p>'
                     "<p>Past Lives Makerspace</p>"
                 ),
@@ -410,16 +419,14 @@ _CURATED: dict[str, EventCopy] = {
                 body_text=(
                     "Hi {{ member_name }},\n\n"
                     "Your lease for {{ space_name }} ends on {{ end_date }} — about a month from now.\n\n"
-                    "If you'd like to renew, reply to this email or talk to a staff member at the space "
-                    "and we'll get it sorted before the end date.\n\n"
+                    "If you'd like to renew, reply to this email.\n\n"
                     "Past Lives Makerspace"
                 ),
                 body_html=(
                     "<p>Hi {{ member_name }},</p>"
                     "<p>Your lease for <strong>{{ space_name }}</strong> ends on {{ end_date }} — "
                     "about a month from now.</p>"
-                    "<p>If you'd like to renew, reply to this email or talk to a staff member at the "
-                    "space and we'll get it sorted before the end date.</p>"
+                    "<p>If you'd like to renew, reply to this email.</p>"
                     "<p>Past Lives Makerspace</p>"
                 ),
             ),
@@ -468,9 +475,13 @@ _CURATED: dict[str, EventCopy] = {
             ),
             Channel.EMAIL: ChannelCopy(
                 subject="{{ guild_name }}: {{ announcement_title }}",
-                body_text="{{ announcement_body }}\n\nVisit the guild: {{ guild_url }}\n\nPast Lives Makerspace",
+                body_text=(
+                    "{{ guild_name }} Announcement!\n\n{{ announcement_title }}\n\n{{ announcement_body }}\n\n"
+                    "Visit the guild: {{ guild_url }}\n\nPast Lives Makerspace"
+                ),
                 body_html=(
-                    "<h2>{{ announcement_title }}</h2>"
+                    "<h2>{{ guild_name }} Announcement!</h2>"
+                    "<h3>{{ announcement_title }}</h3>"
                     "<p>{{ announcement_body }}</p>"
                     '<p><a href="{{ guild_url }}">Visit {{ guild_name }}</a></p>'
                     "<p>Past Lives Makerspace</p>"
@@ -512,20 +523,17 @@ _CURATED: dict[str, EventCopy] = {
             Channel.EMAIL: ChannelCopy(
                 subject="You're invited to Past Lives Makerspace",
                 body_text=(
-                    "You've been invited to join Past Lives Makerspace!\n\n"
+                    "You've been invited to join the Past Lives Makerspace Member Portal.\n\n"
                     "Click the link below to create your account:\n\n"
-                    "{{ signup_url }}\n\n"
-                    "If you didn't expect this invite, you can ignore this email."
+                    "{{ signup_url }}"
                 ),
                 body_html=(
-                    "<p>You've been invited to join <strong>Past Lives Makerspace</strong>!</p>"
+                    "<p>You've been invited to join the <strong>Past Lives Makerspace</strong> Member Portal.</p>"
                     '<div style="text-align:center; margin:24px 0 0;">'
                     '<a href="{{ signup_url }}" style="display:inline-block; padding:12px 32px; '
                     "background-color:#EEB44B; color:#092E4C; font-size:14px; font-weight:700; "
                     'text-decoration:none; border-radius:6px;">Create your account</a>'
                     "</div>"
-                    '<p style="margin:16px 0 0; font-size:13px; color:#96ACBB;">'
-                    "If you didn't expect this invite, you can ignore this email.</p>"
                 ),
             ),
         },
@@ -541,22 +549,20 @@ _CURATED: dict[str, EventCopy] = {
                 subject="Sign in to Past Lives Makerspace",
                 body_text=(
                     "Hi {{ member_name }},\n\n"
-                    "Your Past Lives Makerspace account is ready — you just haven't signed in yet.\n\n"
-                    "Use the link below to sign in for the first time. We'll email you a one-time "
-                    "code to finish:\n\n"
+                    "Your Past Lives Makerspace account is ready — now it's time to sign in.\n\n"
+                    "Click the link below, and we'll email you a one-time login code:\n\n"
                     "{{ login_url }}\n\n"
                     "See you at the space!\nPast Lives Makerspace"
                 ),
                 body_html=(
                     "<p>Hi {{ member_name }},</p>"
-                    "<p>Your <strong>Past Lives Makerspace</strong> account is ready — you just "
-                    "haven't signed in yet.</p>"
-                    "<p>Use the button below to sign in for the first time. We'll email you a "
-                    "one-time code to finish.</p>"
+                    "<p>Your <strong>Past Lives Makerspace</strong> account is ready — now it's "
+                    "time to sign in.</p>"
+                    "<p>Click below, and we'll email you a one-time login code.</p>"
                     '<div style="text-align:center; margin:24px 0 0;">'
                     '<a href="{{ login_url }}" style="display:inline-block; padding:12px 32px; '
                     "background-color:#EEB44B; color:#092E4C; font-size:14px; font-weight:700; "
-                    'text-decoration:none; border-radius:6px;">Sign in for the first time</a>'
+                    'text-decoration:none; border-radius:6px;">Activate your account</a>'
                     "</div>"
                     '<p style="margin:16px 0 0; font-size:13px; color:#96ACBB;">'
                     "See you at the space! — Past Lives Makerspace</p>"
@@ -601,7 +607,7 @@ _CURATED: dict[str, EventCopy] = {
                     "2nd: {{ vote_2nd }}\n"
                     "3rd: {{ vote_3rd }}\n\n"
                     "{{ turnout_count }} members have voted so far, and {{ pool_display }} goes to the guilds "
-                    "when the month rolls over. Results land in your inbox in the first week.\n\n"
+                    "when the month rolls over. Results will be shared in the first week of the month.\n\n"
                     "Change your vote any time before close: {{ voting_url }}\n\nPast Lives Makerspace"
                 ),
                 body_html=(
@@ -622,7 +628,7 @@ _CURATED: dict[str, EventCopy] = {
                     "</table>"
                     "<p><strong>{{ turnout_count }}</strong> members have voted so far, and "
                     "<strong>{{ pool_display }}</strong> goes to the guilds when the month rolls over. "
-                    "Results land in your inbox in the first week.</p>"
+                    "Results will be shared in the first week of the month.</p>"
                     '<p style="text-align:center;margin:24px 0 8px;"><a href="{{ voting_url }}" '
                     'style="display:inline-block;padding:12px 28px;background-color:#EEB44B;color:#092E4C;'
                     'font-size:14px;font-weight:700;text-decoration:none;border-radius:6px;">'
@@ -644,20 +650,20 @@ _CURATED: dict[str, EventCopy] = {
         channels={
             Channel.IN_APP: ChannelCopy(
                 subject="Vote soon — {{ cycle_label }}",
-                body_text="You haven't cast a {{ cycle_label }} guild funding vote yet — it closes {{ closes_on }}.",
+                body_text="You haven't cast a {{ cycle_label }} guild funding vote yet — voting closes {{ closes_on }}.",
             ),
             Channel.EMAIL: ChannelCopy(
                 subject="Your {{ cycle_label }} guild vote closes {{ closes_on }}",
                 body_text=(
                     "Hi {{ member_name }},\n\n"
-                    "You haven't cast a guild funding vote yet for {{ cycle_label }} — it closes {{ closes_on }}. "
+                    "You haven't cast a guild funding vote yet for {{ cycle_label }} — voting closes {{ closes_on }}. "
                     "It takes a minute, and it decides how {{ pool_display }} is split between the guilds. "
                     "{{ turnout_count }} members have voted so far.\n\n"
                     "Cast your vote: {{ voting_url }}\n\nPast Lives Makerspace"
                 ),
                 body_html=(
                     "<p>Hi {{ member_name }},</p>"
-                    "<p>You haven't cast a guild funding vote yet for {{ cycle_label }} — it closes "
+                    "<p>You haven't cast a guild funding vote yet for {{ cycle_label }} — voting closes "
                     "<strong>{{ closes_on }}</strong>. It takes a minute, and it decides how "
                     "<strong>{{ pool_display }}</strong> is split between the guilds. "
                     "<strong>{{ turnout_count }}</strong> members have voted so far.</p>"
@@ -741,7 +747,7 @@ _CURATED: dict[str, EventCopy] = {
         ),
         sample_context={
             "member_name": "Robin Vale",
-            "intro_note": "Heads-up: this one's a little late — going forward results are automated.",
+            "intro_note": "",
             "cycle_label": "June 2026",
             "allocation_summary": "Metal Guild — $600.00 (45.0%)\nFiber Guild — $400.00 (30.0%)",
             # A two-bar sample so the live copy preview shows the real chart, not escaped
@@ -1153,14 +1159,14 @@ _CURATED: dict[str, EventCopy] = {
             Channel.EMAIL: ChannelCopy(
                 subject="Changes requested: {{ event_title }}",
                 body_text=(
-                    "A reviewer took a look at your proposed event, {{ event_title }}, and asked for a change "
-                    "before it goes live:\n\n{{ reviewer_notes }}\n\n"
+                    "We've reviewed your proposed event, {{ event_title }}, and have a change request:\n\n"
+                    "{{ reviewer_notes }}\n\n"
                     "Update and resubmit it: {{ edit_url }}\n\nPast Lives Makerspace"
                 ),
                 body_html=(
-                    "<p>A reviewer took a look at your proposed event, "
-                    '<strong><a href="{{ edit_url }}">{{ event_title }}</a></strong>, and asked for a change '
-                    "before it goes live:</p>"
+                    "<p>We've reviewed your proposed event, "
+                    '<strong><a href="{{ edit_url }}">{{ event_title }}</a></strong>, and have a change '
+                    "request:</p>"
                     "<p>{{ reviewer_notes }}</p>"
                     '<p><a href="{{ edit_url }}">Update and resubmit your event</a></p>'
                     "<p>Past Lives Makerspace</p>"
@@ -1209,13 +1215,13 @@ _CURATED: dict[str, EventCopy] = {
             Channel.EMAIL: ChannelCopy(
                 subject="About your event proposal: {{ event_title }}",
                 body_text=(
-                    "Thanks for proposing {{ event_title }}. After a look, a reviewer decided not to add it to "
-                    "the calendar this time:\n\n{{ reviewer_notes }}\n\n"
+                    "Thanks for proposing {{ event_title }}. We can't approve the event at this "
+                    "time:\n\n{{ reviewer_notes }}\n\n"
                     "You're welcome to propose another event any time: {{ propose_url }}\n\nPast Lives Makerspace"
                 ),
                 body_html=(
-                    "<p>Thanks for proposing <strong>{{ event_title }}</strong>. After a look, a reviewer decided "
-                    "not to add it to the calendar this time:</p>"
+                    "<p>Thanks for proposing <strong>{{ event_title }}</strong>. We can't approve the "
+                    "event at this time:</p>"
                     "<p>{{ reviewer_notes }}</p>"
                     '<p><a href="{{ propose_url }}">Propose another event</a></p>'
                     "<p>Past Lives Makerspace</p>"
@@ -1413,15 +1419,13 @@ _CURATED: dict[str, EventCopy] = {
                 body_text=(
                     "Good news — your request was approved.\n\n"
                     "{{ space_code }} · {{ price_display }}\n\n"
-                    "{{ audience_label }} will be in touch to finalize the paperwork; nothing is "
-                    "charged automatically.\n\n"
+                    "We'll be in touch soon to finalize the paperwork.\n\n"
                     "See it on the map: {{ space_url }}\n\nPast Lives Makerspace"
                 ),
                 body_html=(
                     "<p>Good news — your request was approved.</p>"
                     '<p><strong><a href="{{ space_url }}">{{ space_code }}</a></strong> · {{ price_display }}</p>'
-                    "<p>{{ audience_label }} will be in touch to finalize the paperwork; nothing is "
-                    "charged automatically.</p>"
+                    "<p>We'll be in touch soon to finalize the paperwork.</p>"
                     '<p><a href="{{ space_url }}">See it on the map</a></p>'
                     "<p>Past Lives Makerspace</p>"
                 ),
@@ -1445,16 +1449,19 @@ _CURATED: dict[str, EventCopy] = {
             Channel.EMAIL: ChannelCopy(
                 subject="Update on your {{ space_code }} request",
                 body_text=(
-                    "Thanks for asking about {{ space_code }}. A reviewer wasn't able to say yes "
-                    "this time:\n\n{{ reviewer_notes }}\n\n"
-                    "You're welcome to ask about another space any time: {{ space_url }}\n\n"
+                    "Thanks for asking about {{ space_code }}. That space is not available at this "
+                    "time:\n\n{{ reviewer_notes }}\n\n"
+                    "Find a space: {{ space_url }}\n\n"
                     "Past Lives Makerspace"
                 ),
                 body_html=(
-                    "<p>Thanks for asking about <strong>{{ space_code }}</strong>. A reviewer wasn't able "
-                    "to say yes this time:</p>"
+                    "<p>Thanks for asking about <strong>{{ space_code }}</strong>. That space is not "
+                    "available at this time. Click below to find another space.</p>"
                     "<p>{{ reviewer_notes }}</p>"
-                    '<p><a href="{{ space_url }}">See what else is open on the map</a></p>'
+                    '<p style="text-align:center;margin:24px 0 8px;"><a href="{{ space_url }}" '
+                    'style="display:inline-block;padding:12px 28px;background-color:#EEB44B;color:#092E4C;'
+                    'font-size:14px;font-weight:700;text-decoration:none;border-radius:6px;">'
+                    "Find a Space</a></p>"
                     "<p>Past Lives Makerspace</p>"
                 ),
             ),

--- a/core/forms.py
+++ b/core/forms.py
@@ -69,7 +69,7 @@ class FindAccountForm(forms.Form):
             trigger_kind="core.find_account",
             text_body=(
                 f"Hi {member.preferred_name or member.full_legal_name},\n\n"
-                f"Your account email is: {member.primary_email}\n\n"
+                f"Welcome back! Your account email is: {member.primary_email}\n\n"
                 f"You can log in here:\n{login_url}\n\n"
                 f"If you didn't request this, you can safely ignore this email."
             ),

--- a/core/management/commands/send_release_email.py
+++ b/core/management/commands/send_release_email.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
             scope = ", ".join(lines) if lines else _current_minor(VERSION)
             raise CommandError(f"No changelog entries for line(s) {scope} — nothing to send.")
 
-        subject = (options["subject"] or "").strip() or f"What's new at Past Lives: {cards[0].title}"
+        subject = (options["subject"] or "").strip() or f"Heads-Up: New Member Portal Features — {cards[0].title}"
         intro = self._resolve_intro(options["intro"])
         html, text = render_release_email(
             VERSION,

--- a/core/management/commands/send_release_email_test.py
+++ b/core/management/commands/send_release_email_test.py
@@ -47,7 +47,11 @@ class Command(BaseCommand):
                 raise CommandError(str(exc))
 
         cards = build_release_cards(VERSION, lines=lines)
-        subject = f"What's new at Past Lives: {cards[0].title}" if cards else "What's new at Past Lives"
+        subject = (
+            f"Heads-Up: New Member Portal Features — {cards[0].title}"
+            if cards
+            else "Heads-Up: New Member Portal Features"
+        )
         html, text = render_release_email(
             VERSION,
             subject=subject,

--- a/core/release_email.py
+++ b/core/release_email.py
@@ -269,7 +269,7 @@ def _release_text(subject: str, intro: str, cards: list[Card], cta_url: str) -> 
         lines += [f"• {bullet}" for bullet in card.bullets]
         lines.append("")
     lines += [f"{_CTA_LABEL}: {cta_url}", ""]
-    lines.append("You're getting this because you have a Past Lives account.")
+    lines.append("You're getting this message because you have a Past Lives Makerspace account.")
     lines.append(f"Manage your email preferences or unsubscribe: {settings.MEMBER_BASE_URL}/settings/")
     return "\n".join(lines)
 

--- a/hub/views.py
+++ b/hub/views.py
@@ -4548,7 +4548,7 @@ def _release_announcement_initial() -> dict[str, str]:
     entries = current_line_entries(VERSION)
     latest_title = str(entries[0]["title"]) if entries else "What's new"
     return {
-        "subject": f"What's new at Past Lives: {latest_title}",
+        "subject": f"Heads-Up: New Member Portal Features — {latest_title}",
         "preheader": latest_title,
         "intro": "<p>We've just shipped an update — here's what's new.</p>",
     }

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
-VERSION = "0.23.60"
+VERSION = "0.23.61"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "0.23.61",
+        "date": "2026-08-11",
+        "title": "Emails got a fresh coat of paint and clearer wording",
+        "changes": [
+            "Emails from Past Lives now use a clean white background around the navy card, so they're "
+            "easier to read — especially on phones.",
+            "Every email now says Past Lives Makerspace, and the wording across dozens of emails is "
+            "shorter and friendlier: class confirmations, waitlist updates, orientation emails, tab and "
+            "lease notices, voting reminders, and more.",
+            "If a class is cancelled or a space request doesn't work out, the email now has a button to "
+            "help you find another class or space.",
+        ],
+    },
     {
         "version": "0.23.60",
         "date": "2026-08-10",

--- a/templates/account/email/account_already_exists_message.html
+++ b/templates/account/email/account_already_exists_message.html
@@ -3,23 +3,25 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <!-- Header -->
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <!-- Card -->
     <tr>
     <td style="background-color: #092E4C; border-radius: 12px; padding: 40px 32px; text-align: center;">
         <p style="margin: 0 0 16px; font-size: 18px; font-weight: 700; color: #F4EFDD;">Account Already Exists</p>
-        <p style="margin: 0 0 8px; font-size: 14px; color: #96ACBB; line-height: 1.6;">Someone tried to create a new account with this email address (<span style="color: #F4EFDD;">{{ email }}</span>), but you already have one.</p>
+        <p style="margin: 0 0 8px; font-size: 14px; color: #96ACBB; line-height: 1.6;">Someone has already created an account with this email address.</p>
         <p style="margin: 16px 0 0; font-size: 14px; color: #96ACBB; line-height: 1.6;">To sign in, just visit the login page and enter your email — we'll send you a code.</p>
         {% if login_url %}<div style="margin: 24px 0 0;">
             <a href="{{ login_url }}" style="display: inline-block; padding: 12px 32px; background-color: #EEB44B; color: #092E4C; font-size: 14px; font-weight: 700; text-decoration: none; border-radius: 6px;">Sign In</a>

--- a/templates/account/email/account_already_exists_message.txt
+++ b/templates/account/email/account_already_exists_message.txt
@@ -1,7 +1,7 @@
 {% extends "account/email/base_message.txt" %}
 {% load i18n %}
 
-{% block content %}{% autoescape off %}Someone tried to create a new Past Lives Makerspace account with this email address ({{ email }}), but you already have an account.
+{% block content %}{% autoescape off %}Someone has already created an account with this email address.
 
 To sign in, just visit the login page and enter your email — we'll send you a code.
 {% if login_url %}

--- a/templates/account/email/login_code_message.html
+++ b/templates/account/email/login_code_message.html
@@ -3,16 +3,18 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <!-- Header -->
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <!-- Card -->

--- a/templates/account/email/unknown_account_message.html
+++ b/templates/account/email/unknown_account_message.html
@@ -3,16 +3,18 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <!-- Header -->
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <!-- Card -->

--- a/templates/billing/email/charge_failed_admin.html
+++ b/templates/billing/email/charge_failed_admin.html
@@ -3,16 +3,18 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <!-- Header -->
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <!-- Card -->

--- a/templates/billing/email/receipt.html
+++ b/templates/billing/email/receipt.html
@@ -3,16 +3,18 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <!-- Header -->
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <!-- Card -->

--- a/templates/classes/emails/admin_validation_request.html
+++ b/templates/classes/emails/admin_validation_request.html
@@ -2,9 +2,11 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <title>Executive validation needed: {{ offering.title }}</title>
 </head>
-<body style="margin:0;padding:24px;background:#12121f;font-family:Helvetica,Arial,sans-serif;color:#F4EFDD;">
+<body style="margin:0;padding:24px;background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;color:#33424F;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;background:#092E4C;border-radius:10px;overflow:hidden;">
     <tr><td style="padding:24px 28px 8px;">
       <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.18em;color:#EEB44B;">Executive validation requested</div>
@@ -14,7 +16,7 @@
     <tr><td style="padding:14px 28px;">
       <p style="margin:0 0 14px;color:#F4EFDD;font-size:15px;line-height:1.55;">
         <strong>{{ guild_lead_name }}</strong> and {{ instructor_name }} request executive validation to publish this class.
-        The guild lead has already approved it; your sign-off is the final step before it goes live.
+        The Guild Lead has approved this class. Please review to approve.
       </p>
       <p style="margin:18px 0;">
         <a href="{{ review_url }}"
@@ -34,6 +36,8 @@
     <tr><td style="padding:18px 28px 24px;border-top:1px solid rgba(255,255,255,0.08);font-size:12px;color:#96ACBB;">
       You're getting this because your address is configured as a class reviewer at Past Lives Makerspace.
     </td></tr>
+  </table>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;">
     {% include "membership/emails/_footer.html" %}
   </table>
 </body>

--- a/templates/classes/emails/admin_validation_request.txt
+++ b/templates/classes/emails/admin_validation_request.txt
@@ -6,8 +6,8 @@ Price {{ offering.price_cents }} cents · Capacity {{ offering.capacity }}
 {% if offering.member_discount_pct %}{{ offering.member_discount_pct }}% member discount{% endif %}
 
 {{ guild_lead_name }} and {{ instructor_name }} request executive validation
-to publish this class. The guild lead has already approved it; your sign-off
-is the final step before it goes live.
+to publish this class. The Guild Lead has approved this class. Please
+review to approve.
 
 Open the review page:
 {{ review_url }}

--- a/templates/classes/emails/confirmation.html
+++ b/templates/classes/emails/confirmation.html
@@ -3,16 +3,18 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <!-- Header -->
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <!-- Card -->
@@ -54,7 +56,7 @@
         <div style="text-align: center; margin: 24px 0 0;">
             <a href="{{ self_serve_url }}" style="display: inline-block; padding: 12px 32px; background-color: #EEB44B; color: #092E4C; font-size: 14px; font-weight: 700; text-decoration: none; border-radius: 6px;">Manage Registration</a>
         </div>
-        <p style="margin: 12px 0 0; font-size: 12px; color: #96ACBB; text-align: center;">Manage from the button above, or <a href="{{ class_url }}" style="color: #EEB44B; text-decoration: none;">see the full class details</a> — what to bring, parking, and more.</p>
+        <p style="margin: 12px 0 0; font-size: 12px; color: #96ACBB; text-align: center;"><a href="{{ class_url }}" style="color: #EEB44B; text-decoration: none;">Click to see full class details</a></p>
 
         {% if footer %}<div style="margin: 24px 0 0; padding: 16px 0 0; border-top: 1px solid rgba(244, 239, 221, 0.1);">
             <p style="margin: 0; font-size: 13px; color: #96ACBB; line-height: 1.6;">{{ footer }}</p>

--- a/templates/classes/emails/confirmation.txt
+++ b/templates/classes/emails/confirmation.txt
@@ -12,7 +12,7 @@ This is a series package — your one sign-up enrolls you in all {{ offering.ser
 Location: Past Lives Makerspace, 2808 SE 9th Ave, Portland, OR 97202
 
 {% if amount_paid_cents %}You paid: ${{ amount_paid_dollars }}
-{% endif %}Full class details (what to bring, parking, and more):
+{% endif %}Click to see full class details:
 {{ class_url }}
 
 Manage your registration:

--- a/templates/classes/emails/reminder.html
+++ b/templates/classes/emails/reminder.html
@@ -3,23 +3,25 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <!-- Header -->
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <!-- Card -->
     <tr>
     <td style="background-color: #092E4C; border-radius: 12px; padding: 40px 32px;">
         <p style="margin: 0 0 8px; font-size: 14px; color: #96ACBB; font-weight: 400;">Hi {{ registration.first_name }},</p>
-        <p style="margin: 0 0 24px; font-size: 18px; font-weight: 700; color: #F4EFDD;">Your class is coming up!</p>
+        <p style="margin: 0 0 24px; font-size: 18px; font-weight: 700; color: #F4EFDD;">It's almost time for class!</p>
 
         <!-- Class info card -->
         <div style="margin: 0 0 24px; padding: 16px 20px; background-color: rgba(238, 180, 75, 0.1); border-radius: 8px;">
@@ -49,7 +51,7 @@
         <div style="text-align: center; margin: 24px 0 0;">
             <a href="{{ self_serve_url }}" style="display: inline-block; padding: 12px 32px; background-color: #EEB44B; color: #092E4C; font-size: 14px; font-weight: 700; text-decoration: none; border-radius: 6px;">Manage Registration</a>
         </div>
-        <p style="margin: 12px 0 0; font-size: 12px; color: #96ACBB; text-align: center;">Manage from the button above, or <a href="{{ class_url }}" style="color: #EEB44B; text-decoration: none;">see the full class details</a> — what to bring, parking, and more.</p>
+        <p style="margin: 12px 0 0; font-size: 12px; color: #96ACBB; text-align: center;"><a href="{{ class_url }}" style="color: #EEB44B; text-decoration: none;">Click to see full class details</a></p>
     </td>
     </tr>
     <!-- Footer -->

--- a/templates/classes/emails/reminder.txt
+++ b/templates/classes/emails/reminder.txt
@@ -7,7 +7,7 @@ Location: Past Lives Makerspace, 2808 SE 9th Ave, Portland, OR 97202
 A note from your instructor:
 {{ offering.welcome_email_body|rich_email_text }}
 {% endif %}
-Full class details (what to bring, parking, and more):
+Click to see full class details:
 {{ class_url }}
 
 Manage your registration:

--- a/templates/classes/emails/review_decision.html
+++ b/templates/classes/emails/review_decision.html
@@ -2,9 +2,11 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <title>Review update on {{ offering.title }}</title>
 </head>
-<body style="margin:0;padding:24px;background:#12121f;font-family:Helvetica,Arial,sans-serif;color:#F4EFDD;">
+<body style="margin:0;padding:24px;background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;color:#33424F;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;background:#092E4C;border-radius:10px;overflow:hidden;">
     <tr><td style="padding:24px 28px 8px;">
       <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.18em;color:#EEB44B;">
@@ -19,7 +21,7 @@
     <tr><td style="padding:14px 28px;">
       {% if fully_approved %}
         <p style="margin:0 0 14px;color:#F4EFDD;font-size:15px;line-height:1.55;">
-          Every required reviewer has approved your class. It's now live on the public site.
+          Your class is approved and is now live on the website's public Classes page.
         </p>
         <p style="margin:18px 0;">
           <a href="{{ public_url }}" style="display:inline-block;padding:12px 22px;background:#EEB44B;color:#092E4C;font-weight:800;letter-spacing:0.04em;text-decoration:none;border-radius:6px;font-size:13px;text-transform:uppercase;">View public page</a>
@@ -56,6 +58,8 @@
       </p>
       {% endif %}
     </td></tr>
+  </table>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;">
     {% include "membership/emails/_footer.html" %}
   </table>
 </body>

--- a/templates/classes/emails/review_decision.txt
+++ b/templates/classes/emails/review_decision.txt
@@ -2,7 +2,7 @@
 
 {{ offering.title }}
 
-{% if fully_approved %}Every required reviewer has approved your class. It's now live on the public site.
+{% if fully_approved %}Your class is approved and is now live on the website's public Classes page.
 
 View public page:
 {{ public_url }}

--- a/templates/classes/emails/review_request.html
+++ b/templates/classes/emails/review_request.html
@@ -2,9 +2,11 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <title>Review request: {{ offering.title }}</title>
 </head>
-<body style="margin:0;padding:24px;background:#12121f;font-family:Helvetica,Arial,sans-serif;color:#F4EFDD;">
+<body style="margin:0;padding:24px;background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;color:#33424F;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;background:#092E4C;border-radius:10px;overflow:hidden;">
     <tr><td style="padding:24px 28px 8px;">
       <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.18em;color:#EEB44B;">{{ role_label }} review requested</div>
@@ -13,8 +15,8 @@
     </td></tr>
     <tr><td style="padding:14px 28px;">
       <p style="margin:0 0 14px;color:#F4EFDD;font-size:15px;line-height:1.55;">
-        An instructor submitted a class for review and you've been asked to weigh in as <strong>{{ role_label }}</strong>.
-        Open the review page to see the full class details, decide approve, request changes, or decline, and leave optional notes.
+        An instructor submitted a class for review, and you've been asked to approve the date.
+        Open the review page to see details.
       </p>
       <p style="margin:18px 0;">
         <a href="{{ review_url }}"
@@ -32,8 +34,10 @@
       </p>
     </td></tr>
     <tr><td style="padding:18px 28px 24px;border-top:1px solid rgba(255,255,255,0.08);font-size:12px;color:#96ACBB;">
-      You're getting this because your address is configured as a class reviewer at Past Lives Makerspace.
+      You're receiving this email because you're a {{ role_label }} at Past Lives Makerspace.
     </td></tr>
+  </table>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;">
     {% include "membership/emails/_footer.html" %}
   </table>
 </body>

--- a/templates/classes/emails/review_request.txt
+++ b/templates/classes/emails/review_request.txt
@@ -5,14 +5,12 @@ by {{ offering.instructor.display_name }}{% if offering.category %} · {{ offeri
 Price {{ offering.price_cents }} cents · Capacity {{ offering.capacity }}
 {% if offering.member_discount_pct %}{{ offering.member_discount_pct }}% member discount{% endif %}
 
-An instructor submitted this class for review and you've been asked to
-weigh in as {{ role_label }}. Open the review page to see the full class
-details, decide approve / request changes / decline, and leave optional
-notes.
+An instructor submitted this class for review, and you've been asked
+to approve the date. Open the review page to see details.
 
 Open the review page:
 {{ review_url }}
 
-You're getting this because your address is configured as a class
-reviewer at Past Lives Makerspace.
+You're receiving this email because you're a {{ role_label }} at
+Past Lives Makerspace.
 {% include "membership/emails/_footer.txt" %}

--- a/templates/classes/emails/review_submitted_instructor.html
+++ b/templates/classes/emails/review_submitted_instructor.html
@@ -2,9 +2,11 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <title>Your class is in review</title>
 </head>
-<body style="margin:0;padding:24px;background:#12121f;font-family:Helvetica,Arial,sans-serif;color:#F4EFDD;">
+<body style="margin:0;padding:24px;background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;color:#33424F;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;background:#092E4C;border-radius:10px;overflow:hidden;">
     <tr><td style="padding:24px 28px 8px;">
       <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.18em;color:#EEB44B;">In review</div>
@@ -12,14 +14,8 @@
     </td></tr>
     <tr><td style="padding:14px 28px;">
       <p style="margin:0 0 14px;color:#F4EFDD;font-size:15px;line-height:1.55;">
-        Your class submission is now in front of the reviewers. Here's what happens next.
+        Your class submission is being reviewed. Click below to view status.
       </p>
-      <ol style="padding-left:20px;color:#F4EFDD;font-size:15px;line-height:1.7;margin:0 0 16px;">
-        <li>Each reviewer (admin{% for row in approvals %}{% if row.role == 'guild_lead' %}, plus the Guild Lead{% endif %}{% endfor %}) gets a link to your class.</li>
-        <li>They can <strong>Approve</strong>, <strong>Request changes</strong>, or <strong>Decline</strong>.</li>
-        <li>You'll get an email at each step. If anyone requests changes, the class drops back to Draft so you can edit and resubmit.</li>
-        <li>Once <em>every</em> required reviewer has approved, your class publishes automatically.</li>
-      </ol>
       <p style="margin:18px 0;">
         <a href="{{ instructor_url }}"
            style="display:inline-block;padding:12px 22px;background:#EEB44B;color:#092E4C;font-weight:800;letter-spacing:0.04em;text-decoration:none;border-radius:6px;font-size:13px;text-transform:uppercase;">
@@ -27,6 +23,8 @@
         </a>
       </p>
     </td></tr>
+  </table>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;">
     {% include "membership/emails/_footer.html" %}
   </table>
 </body>

--- a/templates/classes/emails/review_submitted_instructor.txt
+++ b/templates/classes/emails/review_submitted_instructor.txt
@@ -2,16 +2,7 @@ IN REVIEW
 
 {{ offering.title }}
 
-Your class submission is now in front of the reviewers. Here's what
-happens next.
-
-1. Each reviewer (admin{% for row in approvals %}{% if row.role == 'guild_lead' %}, plus the Guild Lead{% endif %}{% endfor %}) gets a link
-   to your class.
-2. They can Approve, Request changes, or Decline.
-3. You'll get an email at each step. If anyone requests changes, the
-   class drops back to Draft so you can edit and resubmit.
-4. Once every required reviewer has approved, your class publishes
-   automatically.
+Your class submission is being reviewed. View status below.
 
 View status:
 {{ instructor_url }}

--- a/templates/classes/emails/waitlist_joined.html
+++ b/templates/classes/emails/waitlist_joined.html
@@ -2,9 +2,11 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <title>You're on the waitlist</title>
 </head>
-<body style="margin:0;padding:24px;background:#12121f;font-family:Helvetica,Arial,sans-serif;color:#F4EFDD;">
+<body style="margin:0;padding:24px;background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;color:#33424F;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;background:#092E4C;border-radius:10px;overflow:hidden;">
     <tr><td style="padding:24px 28px 8px;">
       <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.18em;color:#EEB44B;">On the waitlist</div>
@@ -16,13 +18,15 @@
         we'll email you a link to register. There's no charge to hold your spot on the waitlist.
       </p>
       <p style="margin:14px 0;color:#96ACBB;font-size:14px;line-height:1.55;">
-        You can leave the waitlist at any time from your self-serve page.
+        To manage your spot on the waitlist, click below.
       </p>
       <p style="margin:18px 0;">
         <a href="{{ self_serve_url }}"
            style="display:inline-block;padding:12px 22px;background:#EEB44B;color:#092E4C;font-weight:800;letter-spacing:0.04em;text-decoration:none;border-radius:6px;font-size:13px;text-transform:uppercase;">View my waitlist spot</a>
       </p>
     </td></tr>
+  </table>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;">
     {% include "membership/emails/_footer.html" %}
   </table>
 </body>

--- a/templates/classes/emails/waitlist_joined.txt
+++ b/templates/classes/emails/waitlist_joined.txt
@@ -6,9 +6,9 @@ You're number {{ position }} in line for this class. If a spot opens,
 we'll email you a link to register. There's no charge to hold your
 spot on the waitlist.
 
-Full class details (what to bring, parking, and more):
+Click to see full class details:
 {{ class_url }}
 
-You can leave the waitlist any time from your self-serve page:
+To manage your spot on the waitlist:
 {{ self_serve_url }}
 {% include "membership/emails/_footer.txt" %}

--- a/templates/classes/emails/waitlist_spot_opened.html
+++ b/templates/classes/emails/waitlist_spot_opened.html
@@ -2,20 +2,20 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <title>A spot opened!</title>
 </head>
-<body style="margin:0;padding:24px;background:#12121f;font-family:Helvetica,Arial,sans-serif;color:#F4EFDD;">
+<body style="margin:0;padding:24px;background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;color:#33424F;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;background:#092E4C;border-radius:10px;overflow:hidden;">
     <tr><td style="padding:24px 28px 8px;">
       <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.18em;color:#EEB44B;">Spot opened</div>
-      <h1 style="font-family:'Lato',sans-serif;font-size:26px;font-weight:800;margin:8px 0 4px;color:#F4EFDD;">A seat is yours if you want it</h1>
+      <h1 style="font-family:'Lato',sans-serif;font-size:26px;font-weight:800;margin:8px 0 4px;color:#F4EFDD;">Congratulations, you got in!</h1>
       <div style="color:#96ACBB;font-size:14px;"><a href="{{ class_url }}" style="color:#EEB44B;text-decoration:none;">{{ offering.title }}</a></div>
     </td></tr>
     <tr><td style="padding:14px 28px;">
       <p style="margin:0 0 14px;color:#F4EFDD;font-size:16px;line-height:1.55;">
-        A confirmed spot just opened up and you're next in line. You have
-        <strong>{{ claim_window_hours }} hours</strong> to claim it before we move on to the next
-        person on the waitlist.
+        Still want to attend? You have <strong>{{ claim_window_hours }} hours</strong> to confirm your spot.
       </p>
       <p style="margin:18px 0;">
         <a href="{{ register_url }}"
@@ -26,6 +26,8 @@
         <span style="color:#F4EFDD;word-break:break-all;">{{ register_url }}</span>
       </p>
     </td></tr>
+  </table>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;">
     {% include "membership/emails/_footer.html" %}
   </table>
 </body>

--- a/templates/classes/emails/waitlist_spot_opened.txt
+++ b/templates/classes/emails/waitlist_spot_opened.txt
@@ -1,14 +1,13 @@
-SPOT OPENED
+CONGRATULATIONS, YOU GOT IN!
 
 {{ offering.title }}
 
-A confirmed spot just opened up and you're next in line. You have
-{{ claim_window_hours }} hours to claim it before we move on to the
-next person on the waitlist.
+Still want to attend? You have {{ claim_window_hours }} hours to
+confirm your spot.
 
 Claim my spot:
 {{ register_url }}
 
-Full class details (what to bring, parking, and more):
+Click to see full class details:
 {{ class_url }}
 {% include "membership/emails/_footer.txt" %}

--- a/templates/classes/emails/welcome.html
+++ b/templates/classes/emails/welcome.html
@@ -3,16 +3,18 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <!-- Header -->
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <!-- Card -->
@@ -38,7 +40,7 @@
         <div style="text-align: center; margin: 24px 0 0;">
             <a href="{{ class_url }}" style="display: inline-block; padding: 12px 32px; background-color: #EEB44B; color: #092E4C; font-size: 14px; font-weight: 700; text-decoration: none; border-radius: 6px;">View Class Details</a>
         </div>
-        <p style="margin: 12px 0 0; font-size: 12px; color: #96ACBB; text-align: center;">Already signed up — <a href="{{ self_serve_url }}" style="color: #EEB44B; text-decoration: none;">manage your registration</a> any time.</p>
+        <p style="margin: 12px 0 0; font-size: 12px; color: #96ACBB; text-align: center;"><a href="{{ class_url }}" style="color: #EEB44B; text-decoration: none;">Click to see all class details</a></p>
     </td>
     </tr>
     <!-- Footer -->

--- a/templates/membership/emails/_base.html
+++ b/templates/membership/emails/_base.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 </head>
-<body style="margin: 0; padding: 0; background-color: #12121f; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #12121f; padding: 40px 20px;">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; padding: 40px 20px;">
 <tr>
 <td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width: 480px; width: 100%;">
     <tr>
     <td style="text-align: center; padding-bottom: 32px;">
-        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; text-decoration:none;">Past Lives</a>
+        <a href="https://members.pastlives.space" style="font-size: 22px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration:none;">Past Lives Makerspace</a>
     </td>
     </tr>
     <tr>

--- a/templates/membership/emails/_footer.html
+++ b/templates/membership/emails/_footer.html
@@ -1,7 +1,6 @@
 {% load site_urls %}<tr>
 <td style="text-align: center; padding-top: 32px;">
-    <a href="{% member_base_url %}" style="font-size:15px; font-weight:700; color:#EEB44B; text-decoration:none;">Past Lives Federation of Guilds</a>
-    <p style="margin: 14px 0 0; font-size: 12px; color: #96ACBB; font-style: italic;">Do It Together</p>
-    <p style="margin: 10px 0 0; font-size: 11px; color: #96ACBB; line-height: 1.5;">You're getting this because you have a Past Lives account.<br><a href="{% member_base_url %}/settings/" style="color:#EEB44B; text-decoration:none;">Manage your email preferences or unsubscribe</a></p>
+    <a href="{% member_base_url %}" style="font-size:15px; font-weight:700; color:#092E4C; text-decoration:none;">Past Lives Makerspace</a>
+    <p style="margin: 10px 0 0; font-size: 11px; color: #5B6B77; line-height: 1.5;">You're getting this message because you have a Past Lives Makerspace account.<br><a href="{% member_base_url %}/settings/" style="color:#092E4C; text-decoration:underline;">Manage your email preferences or unsubscribe</a></p>
 </td>
 </tr>

--- a/templates/membership/emails/_footer.txt
+++ b/templates/membership/emails/_footer.txt
@@ -1,4 +1,4 @@
 
 {% load site_urls %}—
-Past Lives Federation of Guilds — {% member_base_url %}
+Past Lives Makerspace — {% member_base_url %}
 Manage your email preferences or unsubscribe: {% member_base_url %}/settings/

--- a/templates/membership/emails/_hero.html
+++ b/templates/membership/emails/_hero.html
@@ -7,7 +7,7 @@ Params: minor_label — e.g. "v0.20"; release_date — the release date string.
 <tr>
 <td style="background-color: #092E4C; border-radius: 12px 12px 0 0; padding: 32px 28px; text-align: center;">
     <span style="display: inline-block; background-color: #EEB44B; color: #092E4C; font-size: 12px; font-weight: 700; letter-spacing: 0.04em; padding: 4px 12px; border-radius: 20px;">{{ minor_label }}</span>
-    <h1 style="margin: 16px 0 4px; font-size: 26px; font-weight: 800; color: #FFFFFF;">What's new</h1>
+    <h1 style="margin: 16px 0 4px; font-size: 26px; font-weight: 800; color: #FFFFFF;">Heads-Up: New Member Portal Features</h1>
     {% if release_date %}<p style="margin: 0; font-size: 13px; color: #B9C7D3;">{{ release_date }}</p>{% endif %}
 </td>
 </tr>

--- a/templates/membership/emails/_release_shell.html
+++ b/templates/membership/emails/_release_shell.html
@@ -1,7 +1,7 @@
 {% comment %}
 Hybrid layout for the member-facing release-update email: dark brand hero band →
-light feature body → the reused _footer inside its own dark band (its cream/gold
-copy fails AA on white, so it needs a dark band to sit legibly). Standalone document
+light feature body → the reused _footer (navy-on-light styling) on the pale page
+background below. Standalone document
 (does NOT extend the dark _base.html, which is tuned for transactional copy). ~600px.
 Inline styles throughout — email clients strip <style> blocks.
 Context: preheader, minor_label, release_date, intro_html (safe), cards, cta_url, cta_label.
@@ -12,7 +12,7 @@ Context: preheader, minor_label, release_date, intro_html (safe), cards, cta_url
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="color-scheme" content="light dark">
 <meta name="supported-color-schemes" content="light dark">
-<title>What's new at Past Lives</title>
+<title>Heads-Up: New Member Portal Features</title>
 </head>
 <body style="margin: 0; padding: 0; background-color: #eef0f3; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
 <div style="display: none; max-height: 0; overflow: hidden; mso-hide: all;">{{ preheader }}</div>
@@ -22,7 +22,7 @@ Context: preheader, minor_label, release_date, intro_html (safe), cards, cta_url
     <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; width: 100%;">
     <tr>
         <td style="text-align: center; padding-bottom: 16px;">
-            <a href="{{ cta_url }}" style="font-size: 20px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration: none;">Past Lives</a>
+            <a href="{{ cta_url }}" style="font-size: 20px; font-weight: 700; color: #092E4C; letter-spacing: 0.02em; text-decoration: none;">Past Lives Makerspace</a>
         </td>
     </tr>
     {% include "membership/emails/_hero.html" with minor_label=minor_label release_date=release_date %}
@@ -33,13 +33,7 @@ Context: preheader, minor_label, release_date, intro_html (safe), cards, cta_url
             {% include "membership/emails/_button.html" with href=cta_url label=cta_label %}
         </td>
     </tr>
-    <tr>
-        <td style="background-color: #092E4C; border-radius: 0 0 12px 12px; padding: 4px 20px 12px;">
-            <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-            {% include "membership/emails/_footer.html" %}
-            </table>
-        </td>
-    </tr>
+    {% include "membership/emails/_footer.html" %}
     </table>
 </td>
 </tr>

--- a/templates/membership/emails/notification_shell_light.html
+++ b/templates/membership/emails/notification_shell_light.html
@@ -1,7 +1,7 @@
 {% comment %}
 Light variant of the branded notification shell (EventType.email_shell == "light"):
 the hybrid release-email look for spine copy — lantern-logo hero band → white body →
-the reused _footer inside its own dark band (its cream/gold copy fails AA on white).
+the reused _footer (navy-on-light styling) on the pale page background below.
 The copy fragment arrives pre-styled for the light body by
 core.events.templates._style_copy_fragment(shell="light"); the wrapper div carries
 the slate text color it inherits. Standalone document, inline styles throughout —
@@ -26,24 +26,18 @@ Context: body_html (safe fragment).
     <td style="background-color: #092E4C; border-radius: 12px 12px 0 0; padding: 28px 28px 24px; text-align: center;">
         <a href="{% member_base_url %}" style="text-decoration: none;">
             <img src="{% member_base_url %}{% static 'img/favicon.png' %}" width="64" height="64" alt="Past Lives lantern" style="display: block; margin: 0 auto 10px; border: 0;">
-            <span style="font-size: 20px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em;">Past Lives</span>
+            <span style="font-size: 20px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em;">Past Lives Makerspace</span>
         </a>
     </td>
     </tr>
     <!-- White body -->
     <tr>
-    <td style="background-color: #FFFFFF; padding: 32px 28px 24px;">
+    <td style="background-color: #FFFFFF; border-radius: 0 0 12px 12px; padding: 32px 28px 24px;">
         <div style="color: #33424F; font-size: 15px; line-height: 1.6;">{{ body_html|safe }}</div>
     </td>
     </tr>
-    <!-- Footer band -->
-    <tr>
-    <td style="background-color: #092E4C; border-radius: 0 0 12px 12px; padding: 4px 20px 28px;">
-        <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-        {% include "membership/emails/_footer.html" %}
-        </table>
-    </td>
-    </tr>
+    <!-- Footer -->
+    {% include "membership/emails/_footer.html" %}
 </table>
 </td>
 </tr>

--- a/templates/membership/emails/orientation_cancelled.html
+++ b/templates/membership/emails/orientation_cancelled.html
@@ -2,9 +2,9 @@
 {% block content %}
 <p style="margin: 0 0 8px; font-size: 14px; color: #96ACBB;">Hi {{ greeting_name }},</p>
 <p style="margin: 0 0 16px; font-size: 18px; font-weight: 700; color: #F4EFDD;">Orientation cancelled</p>
-<p style="margin: 0 0 8px; font-size: 14px; color: #F4EFDD; line-height: 1.6;">Your orientation for <strong><a href="{{ guild_url }}" style="color: #EEB44B; text-decoration: none;">{{ guild.name }}</a></strong> has been cancelled.</p>
+<p style="margin: 0 0 8px; font-size: 14px; color: #F4EFDD; line-height: 1.6;">We're so sorry for the inconvenience! We've had to cancel your orientation for <strong><a href="{{ guild_url }}" style="color: #EEB44B; text-decoration: none;">{{ guild.name }}</a></strong>.</p>
 {% include "membership/emails/_slot.html" %}
-<p style="margin: 0 0 16px; font-size: 13px; color: #96ACBB; line-height: 1.6;">You can request a new orientation any time on the guild page.</p>
+<p style="margin: 0 0 16px; font-size: 13px; color: #96ACBB; line-height: 1.6;">We'd love to get you oriented ASAP, so visit your Guild's page to choose a new time.</p>
 <div style="text-align: center; margin: 24px 0 0;">
     <a href="{{ guild_url }}" style="display: inline-block; padding: 12px 32px; background-color: #EEB44B; color: #092E4C; font-size: 14px; font-weight: 700; text-decoration: none; border-radius: 6px;">View guild page</a>
 </div>

--- a/templates/membership/emails/orientation_cancelled.txt
+++ b/templates/membership/emails/orientation_cancelled.txt
@@ -1,10 +1,12 @@
 Hi {{ greeting_name }},
 
-Your orientation for {{ guild.name }} has been cancelled.
+We're so sorry for the inconvenience! We've had to cancel your orientation
+for {{ guild.name }}.
 
   Was: {{ slot.starts_at|date:"l, F j" }} at {{ slot.starts_at|time:"g:i A" }}
 
-You can request a new orientation any time on the guild page:
+We'd love to get you oriented ASAP, so visit your Guild's page to choose
+a new time:
 {{ guild_url }}
 
 {% include "membership/emails/_footer.txt" %}

--- a/templates/membership/emails/orientation_declined.html
+++ b/templates/membership/emails/orientation_declined.html
@@ -7,7 +7,7 @@
     <p style="margin: 0 0 4px; font-size: 12px; color: #96ACBB; text-transform: uppercase; letter-spacing: 0.08em;">A note from the guild lead</p>
     <p style="margin: 0; font-size: 14px; color: #F4EFDD; line-height: 1.6;">{{ booking.lead_note }}</p>
 </div>{% endif %}
-<p style="margin: 0 0 16px; font-size: 14px; color: #F4EFDD; line-height: 1.6;">You're welcome to pick another time.</p>
+<p style="margin: 0 0 16px; font-size: 14px; color: #F4EFDD; line-height: 1.6;">We'd love to get you oriented ASAP. Please click below to pick another time.</p>
 <div style="text-align: center; margin: 24px 0 0;">
     <a href="{{ guild_url }}" style="display: inline-block; padding: 12px 32px; background-color: #EEB44B; color: #092E4C; font-size: 14px; font-weight: 700; text-decoration: none; border-radius: 6px;">Pick another time</a>
 </div>

--- a/templates/membership/emails/orientation_declined.txt
+++ b/templates/membership/emails/orientation_declined.txt
@@ -6,7 +6,7 @@ confirm your requested orientation time.
 A note from the guild lead:
 {{ booking.lead_note }}
 {% endif %}
-You're welcome to pick another time on the guild page:
+We'd love to get you oriented ASAP. Pick another time on the guild page:
 {{ guild_url }}
 
 {% include "membership/emails/_footer.txt" %}

--- a/templates/membership/emails/orientation_request.html
+++ b/templates/membership/emails/orientation_request.html
@@ -6,7 +6,7 @@
 {% include "membership/emails/_slot.html" %}
 <div style="background: rgba(238, 180, 75, 0.15); border-radius: 8px; padding: 12px 16px; margin: 16px 0;">
     <p style="margin: 0; font-size: 13px; color: #EEB44B; font-weight: 700;">This is not an official booking yet.</p>
-    <p style="margin: 6px 0 0; font-size: 13px; color: #F4EFDD; line-height: 1.6;">The guild lead will review your request and confirm a time. We've attached a calendar hold so you don't lose track of it — you'll get an updated invite once it's confirmed.</p>
+    <p style="margin: 6px 0 0; font-size: 13px; color: #F4EFDD; line-height: 1.6;">The Guild Lead will review your request and respond ASAP to confirm. We've attached a tentative calendar invite so you can hold the date.</p>
 </div>
 <div style="text-align: center; margin: 24px 0 0;">
     <a href="{{ guild_url }}" style="display: inline-block; padding: 12px 32px; background-color: #EEB44B; color: #092E4C; font-size: 14px; font-weight: 700; text-decoration: none; border-radius: 6px;">View guild page</a>

--- a/templates/membership/emails/orientation_request.txt
+++ b/templates/membership/emails/orientation_request.txt
@@ -6,9 +6,8 @@ We received your orientation request for {{ guild.name }}.
 {% if slot.location %}  Where: {{ slot.location }}
 {% endif %}
 *** THIS IS NOT AN OFFICIAL BOOKING YET. ***
-The guild lead will review your request and confirm a time. We've attached a
-calendar hold so you don't lose track of it — you'll get an updated invite once
-it's confirmed.
+The Guild Lead will review your request and respond ASAP to confirm. We've
+attached a tentative calendar invite so you can hold the date.
 
 Manage your request: {{ guild_url }}
 Need to cancel? {{ cancel_url }}

--- a/tests/auth/allauth_spec.py
+++ b/tests/auth/allauth_spec.py
@@ -153,7 +153,7 @@ def describe_auto_create_user_on_login():
 def describe_email_templates():
     def it_base_message_uses_past_lives_branding():
         content = render_to_string("account/email/base_message.txt", {"current_site": None})
-        assert "Past Lives Federation of Guilds" in content
+        assert "Past Lives Makerspace" in content
         assert "example.com" not in content
 
     def it_unknown_account_txt_is_branded():

--- a/tests/core/events/invite_email_spec.py
+++ b/tests/core/events/invite_email_spec.py
@@ -9,7 +9,7 @@ Email bodies are asserted on ``django.core.mail.outbox`` (the locmem backend the
 env installs) — ``TransactionalEmailLog`` stores no body, only the send metadata.
 The HTML alternative is ``mail.outbox[0].alternatives[0][0]``.
 
-Shell-presence is asserted with a SHELL-ONLY marker (footer ``Do It Together`` / the
+Shell-presence is asserted with a SHELL-ONLY marker (footer ``because you have a … Makerspace account`` footer line / the
 card ``#092E4C``), never the ``Past Lives`` wordmark — that also appears in the invite
 body copy and would false-positive.
 """
@@ -37,7 +37,7 @@ def describe_invite_email_is_branded():
         assert len(mail.outbox) == 1
         html = mail.outbox[0].alternatives[0][0]
         # Shell-only markers prove the wrap.
-        assert "Do It Together" in html
+        assert "because you have a Past Lives Makerspace account" in html
         assert "#092E4C" in html
         # The invite copy itself is still present inside the card.
         assert "Create your account" in html
@@ -55,12 +55,12 @@ def describe_invite_email_is_branded():
         _invite("noaccount@example.com").send_invite_email()
         message = mail.outbox[0]
         assert message.to == ["noaccount@example.com"]
-        assert "Do It Together" in message.alternatives[0][0]
+        assert "because you have a Past Lives Makerspace account" in message.alternatives[0][0]
 
     def it_leaves_the_plain_text_body_unwrapped():
         _invite().send_invite_email()
         text = mail.outbox[0].body
-        assert "Do It Together" not in text
+        assert "because you have a Past Lives Makerspace account" not in text
         assert "<html" not in text.lower()
         assert "#092E4C" not in text
         # The plain-text copy is intact.
@@ -83,7 +83,7 @@ def describe_invite_gold_cta_on_a_seeded_row():
         assert "Create your account" in html
         assert "/accounts/signup/" in html
         # Still branded.
-        assert "Do It Together" in html
+        assert "because you have a Past Lives Makerspace account" in html
 
     def it_keeps_a_plain_link_on_an_admin_overridden_row_but_still_brands_it():
         # An admin-overridden row keeps its hand-edited (old, plain-link) body after a
@@ -101,8 +101,8 @@ def describe_invite_gold_cta_on_a_seeded_row():
 
         _invite().send_invite_email()
         html = mail.outbox[0].alternatives[0][0]
-        # Branded by the shell (footer + tagline)...
-        assert "Do It Together" in html
+        # Branded by the shell (footer line)...
+        assert "because you have a Past Lives Makerspace account" in html
         # ...and the admin's own body is preserved verbatim.
         assert "Create your account" in html
         # ...but no gold CTA *button* reached the overridden row — only the seeded copy

--- a/tests/core/events/senders_spec.py
+++ b/tests/core/events/senders_spec.py
@@ -5,7 +5,7 @@ The branded shell wrap lives *inside* ``rendered_message`` (copy mode only). The
 ``emit_with_email_shell`` override and the explicit ``html_body`` fixed message — never
 call ``rendered_message``, so they must be delivered verbatim with no card-inside-a-card.
 
-Shell-presence is asserted with the SHELL-ONLY footer marker ``Do It Together`` (unique
+Shell-presence is asserted with the SHELL-ONLY footer marker ``because you have a … Makerspace account`` footer line (unique
 to ``_base.html``), never the ``Past Lives`` wordmark.
 """
 
@@ -37,7 +37,7 @@ def describe_email_shell_override_is_not_double_wrapped():
         )
         html = mail.outbox[0].alternatives[0][0]
         # Exactly one footer → exactly one card → no card-inside-a-card.
-        assert html.count("Do It Together") == 1
+        assert html.count("because you have a Past Lives Makerspace account") == 1
 
 
 def describe_fixed_html_body_is_not_wrapped():
@@ -56,4 +56,4 @@ def describe_fixed_html_body_is_not_wrapped():
         )
         html = mail.outbox[0].alternatives[0][0]
         assert html == doc
-        assert html.count("Do It Together") == 1
+        assert html.count("because you have a Past Lives Makerspace account") == 1

--- a/tests/core/events/templates_spec.py
+++ b/tests/core/events/templates_spec.py
@@ -70,7 +70,7 @@ def describe_wrap_email_html():
         # ...inside the branded shell (wordmark + navy card + footer).
         assert "Past Lives" in wrapped
         assert "#092E4C" in wrapped
-        assert "Do It Together" in wrapped
+        assert "because you have a Past Lives Makerspace account" in wrapped
 
     def it_returns_a_plain_str_not_a_safestring():
         # The admin preview iframe relies on this being attribute-escapable plain str.
@@ -87,7 +87,7 @@ def describe_wrap_email_html():
             assert "favicon.png" in wrapped
             assert "#FFFFFF" in wrapped
             # Its footer band still carries the brand line.
-            assert "Do It Together" in wrapped
+            assert "because you have a Past Lives Makerspace account" in wrapped
 
         def it_colors_bare_paragraphs_slate_not_cream():
             # On the white body the copy paragraph must be slate (#33424F), not the dark
@@ -125,7 +125,7 @@ def describe_rendered_message_email_wrapping():
         assert message.html_body is not None
         # Shell-only markers prove the wrap (use the footer / card color, NOT the
         # "Past Lives" wordmark, which also appears in the copy body).
-        assert "Do It Together" in message.html_body
+        assert "because you have a Past Lives Makerspace account" in message.html_body
         assert "#092E4C" in message.html_body
         # The rendered fragment content is still present inside the shell.
         assert "Casting" in message.html_body
@@ -137,7 +137,7 @@ def describe_rendered_message_email_wrapping():
             {"member_name": "Jo", "class_title": "Casting", "class_starts_at": "Sat", "class_url": "/c/1/"},
         )
         assert message.html_body is not None
-        assert "Do It Together" in message.html_body
+        assert "because you have a Past Lives Makerspace account" in message.html_body
         assert "Casting" in message.html_body
 
     def it_does_not_wrap_a_non_email_channel_even_when_it_has_an_html_body():
@@ -149,7 +149,7 @@ def describe_rendered_message_email_wrapping():
             {"member_name": "Jo", "class_title": "Casting", "class_starts_at": "Sat", "class_url": "/c/1/"},
         )
         assert message.html_body is not None
-        assert "Do It Together" not in message.html_body
+        assert "because you have a Past Lives Makerspace account" not in message.html_body
         assert "#092E4C" not in message.html_body
         assert "Casting" in message.html_body
 
@@ -162,7 +162,7 @@ def describe_rendered_message_email_wrapping():
         # In-app copy carries no HTML body, so there is nothing to (and we never) wrap.
         assert message.html_body is None
         assert "Casting" in message.body
-        assert "Do It Together" not in message.body
+        assert "because you have a Past Lives Makerspace account" not in message.body
 
     def it_uses_the_events_registered_shell_for_a_light_shell_event():
         # voting.closing_soon declares email_shell="light" — its email must render in the
@@ -177,7 +177,9 @@ def describe_rendered_message_email_wrapping():
         assert message.html_body is not None
         assert "favicon.png" in message.html_body  # light shell only
         assert "#33424F" in message.html_body  # slate copy on the white body
-        assert "Do It Together" in message.html_body  # wrapped in the branded shell (footer band present)
+        assert (
+            "because you have a Past Lives Makerspace account" in message.html_body
+        )  # wrapped in the branded shell (footer band present)
 
     def it_leaves_an_empty_html_body_as_none_without_rendering_the_shell():
         # An email row with a blank HTML body must NOT render the shell around nothing.

--- a/tests/core/release_email_spec.py
+++ b/tests/core/release_email_spec.py
@@ -297,7 +297,7 @@ def describe_render_release_email():
         assert "display: none" in html  # preheader is hidden
         assert "v0.20" in html  # version badge
         assert "2026-07-10" in html  # release date
-        assert "What's new" in html
+        assert "Heads-Up: New Member Portal Features" in html
         assert "A home base when you sign in" in html
         assert "See what&#x27;s coming up." in html or "See what's coming up." in html  # bullet
         assert "Open Past Lives" in html  # CTA button
@@ -355,7 +355,7 @@ def describe_render_release_email():
             # A line with no changelog entries (near-unreachable) → empty hero date, no cards.
             html, _text = render_release_email("3.0.0", subject="s", preheader="p", intro="", cards=[])
             assert "v3.0" in html
-            assert "What's new" in html
+            assert "Heads-Up: New Member Portal Features" in html
 
 
 def describe_save_feature_shot():

--- a/tests/hub/admin_views_spec.py
+++ b/tests/hub/admin_views_spec.py
@@ -992,7 +992,7 @@ def describe_admin_site_settings_announcements():
         # "Draft from latest release" enters the sectioned Release composer with a
         # prefilled subject from the current release line's changelog.
         assert response.context["release_mode"] is True
-        assert b"What&#x27;s new at Past Lives:" in response.content
+        assert b"Heads-Up: New Member Portal Features" in response.content
 
 
 def describe_fog_admin_required():

--- a/tests/hub/notification_catalogue_spec.py
+++ b/tests/hub/notification_catalogue_spec.py
@@ -144,7 +144,7 @@ def describe_preview_copy():
         wrapped = response.context["wrapped_html"]
         # The fragment, inside the branded shell (shell-only footer marker).
         assert "Intro to Lost-Wax Casting" in wrapped
-        assert "Do It Together" in wrapped
+        assert "because you have a Past Lives Makerspace account" in wrapped
         # Rendered as an iframe panel.
         assert b"As it arrives (branded)" in response.content
         assert b"srcdoc=" in response.content

--- a/tests/hub/release_announcement_spec.py
+++ b/tests/hub/release_announcement_spec.py
@@ -210,7 +210,7 @@ def describe_release_compose_view():
             # The HTML alternative is the sectioned release email, not the flat card.
             member_msg = next(m for m in mailoutbox if "act@x.com" in m.to)
             html_alt = next(body for body, mime in member_msg.alternatives if mime == "text/html")
-            assert "What's new" in html_alt
+            assert "Heads-Up: New Member Portal Features" in html_alt
             assert "Home dashboard" in html_alt
 
         def it_delivers_a_corrective_resend(client, release_env, mailoutbox):

--- a/tests/membership/login_invite_spec.py
+++ b/tests/membership/login_invite_spec.py
@@ -27,10 +27,10 @@ def describe_send_login_invite():
         assert msg.to == ["newbie@example.com"]
         html = msg.alternatives[0][0]
         # Branded shell marker (proves it inherited the v0.19.11 branded email shell).
-        assert "Do It Together" in html
+        assert "because you have a Past Lives Makerspace account" in html
         # The CTA points at the login-code page with the member's email pre-filled.
         assert "/accounts/login/code/?email=newbie%40example.com" in html
-        assert "Sign in for the first time" in html
+        assert "Activate your account" in html
 
     def it_provisions_the_member_before_sending(mailoutbox):
         member = MemberFactory(_pre_signup_email="provisionme@example.com")


### PR DESCRIPTION
Applies every concrete copy change requested on https://copy-review.pastlives.space/ (comments by Karamy and Lee, Aug 10 and 11). Questions and "let's discuss" comments are listed at the bottom; they are not changed here.

## Design changes (requested on the Registration confirmed card, applied everywhere)

* All emails now render on a **white page background** instead of the dark blue/black one. The brand navy card stays as the main container. Added `color-scheme: light dark` metas so clients that support a nighttime view can adapt.
* Header wordmark is now **Past Lives Makerspace** (navy on white) in every email.
* Footer rewritten for the light background: "Past Lives Makerspace" replaces the "Past Lives Federation of Guilds" line, the "Do It Together" tagline is removed, and the notice now reads "You're getting this message because you have a Past Lives Makerspace account."
* The light release/notification shells no longer need their dark footer band; the footer sits on the page background.

## Copy changes by email

**Classes**
* Registration confirmed: sub line is now "Click to see full class details" (same change on the class reminder; text parts updated to match).
* Class welcome: the "Already signed up" line is now "Click to see all class details" (links to the class page).
* Added to the waitlist: "To manage your spot on the waitlist, click below."
* Waitlist spot opened: headline "Congratulations, you got in!" and body "Still want to attend? You have 24 hours to confirm your spot."
* Class reminder: "It's almost time for class!"
* Class cancelled: new "Life happens..." wording, refund "in full" plus apology, and a new "We'd still love to see you in our space" line with a **Find a Class** button (new `classes_url` placeholder supplied from `BOOK_BASE_URL`).
* Refund issued: "Refunds typically process within 5–10 business days."

**Teaching**
* Class review request: body is now "An instructor submitted a class for review, and you've been asked to approve the date. Open the review page to see details." Footer note: "You're receiving this email because you're a {{ role_label }} at Past Lives Makerspace." (kept the role placeholder since this same template also goes to admins when a category has no guild lead).
* Your class is in review: content replaced with "Your class submission is being reviewed. Click below to view status." (the 4 step explainer list is removed, as requested).
* Executive validation request: "The Guild Lead has approved this class. Please review to approve."
* Review decision: "Your class is approved and is now live on the website's public Classes page."

**Orientations**
* Request received: "The Guild Lead will review your request and respond ASAP to confirm. We've attached a tentative calendar invite so you can hold the date."
* Not confirmed: "We'd love to get you oriented ASAP. Please click below to pick another time."
* Cancelled: "We're so sorry for the inconvenience! We've had to cancel your orientation... visit your Guild's page to choose a new time."

**Guilds**
* Guild announcement email now opens with a "{{ guild_name }} Announcement!" title line.

**Billing and membership**
* Tab approaching limit: dropped "so it's worth settling up before then."
* Lease expiring: "If you'd like to renew, reply to this email."
* Member invite: "You've been invited to join the Past Lives Makerspace Member Portal." The "If you didn't expect this invite" line is removed.
* First sign in invite: "now it's time to sign in", "Click below, and we'll email you a one-time login code", button renamed **Activate your account**.
* Space request approved: "We'll be in touch soon to finalize the paperwork."
* Space request declined: "That space is not available at this time" plus a **Find a Space** button (was a text link).

**Voting**
* Polls closing soon: "Results will be shared in the first week of the month."
* Vote soon: "voting closes June 30, 2026" phrasing (email and in app).
* Results published: the "Heads-up: this one's a little late" sample note is cleared (it was a one off organizer note; the field stays available).

**Events**
* Changes requested: "We've reviewed your proposed event and have a change request."
* Not approved: "Thanks for proposing X. We can't approve the event at this time."

**Release and auth**
* Release update email: hero and subject now "Heads-Up: New Member Portal Features".
* Account already exists: "Someone has already created an account with this email address."
* Find my account: "Welcome back! Your account email is: ..."

## Notes

* Non overridden `NotificationTemplate` rows re seed from `copy.py` during the Render build, so these changes reach the DB backed emails on deploy. **Admin overridden rows keep their old copy** and would need a manual touch.
* Specs that asserted the old copy were updated; the shell presence marker in tests moved from the removed "Do It Together" tagline to the new footer sentence.
* Full suite: 7076 passed, coverage 98.35%. ruff and mypy clean.

## Questions from the review, answered where possible

* **Class cancelled: "does this also go to waitlist people?"** No. The email goes to everyone holding an active registration (including guests); waitlisted people are not emailed.
* **Review request: "once the Guild Lead approves, does an email go to the class administrator?"** Yes, that is the "Executive validation request" email; today it goes to all FOG admins.
* **Results ready: "can results be sent automatically?"** Already done as of v0.23.58; results email out automatically when the vote closes.
* **"Announcement" vs guild announcement:** they are different emails; one is the site wide announcement composer, the other is per guild.

## Discussion items NOT changed here (need a decision)

1. Unsubscribe link on transactional emails (class welcome comment): policy question about what members can opt out of.
2. Executive validation routing: send to a single "Class Administrator" instead of all FOG admins; there is no such role in the system today.
3. Orientation confirmed: the "Meet by the kilns" detail is written by the person scheduling the slot; standardizing to "Meet in your Guild area" is a product decision.
4. Orientation thank you and guild welcome: making these system wide standard messages instead of guild authored ones.
5. Orientation lead request: whether it should target a tagged "orienter" group rather than staff.
6. Discord guilds imported email: Lee wants to discuss.
7. Guild announcements: restricting who can propose them and whether Discord should trigger official emails at all.
8. Release "A new version is out" email: whether app store update nudges belong in email.
9. The public website (home page, hub footer) still says "Past Lives Federation of Guilds" and "Do It Together". This PR only touched emails.
10. "Generic notification copy" question on the no email table: that copy lives in the event registry defaults (`core/events/copy.py`).

https://claude.ai/code/session_01AtXwrwaWkGGGAaAAyEWg1w
