### PR TITLE
fix: calendar announcement accuracy (3-month window + prune rescheduled-event orphans)

### DIFF
--- a/hub/calendar_service.py
+++ b/hub/calendar_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 import urllib.request
 from collections.abc import Callable
@@ -19,6 +20,8 @@ from membership.models import CalendarEvent, CommunityEvent, Guild
 
 if TYPE_CHECKING:
     from core.integrations.discord_events import DiscordScheduledEventsClient
+
+logger = logging.getLogger(__name__)
 
 
 def _to_datetime(val: Any) -> datetime:
@@ -149,6 +152,7 @@ def _upsert_events(
     guild: Guild | None,
     source: str,
     feed: CalendarFeed | None = None,
+    window: tuple[datetime, datetime] | None = None,
 ) -> int:
     """Insert or update CalendarEvent records for the given source.
 
@@ -156,12 +160,17 @@ def _upsert_events(
     series gets its own row, and two ``CalendarFeed`` rows whose upstream calendars happen to
     share a UID don't clobber each other. Echoes of our own Google-pushed CommunityEvents
     (see :func:`_pushed_event_uids`) are skipped, not imported.
+
+    When ``window`` (the span this fetch expanded over) is given, stale occurrences left by a
+    reschedule are pruned afterward — see :func:`_prune_stale_occurrences`.
     """
     now = timezone.now()
     echo_uids = _pushed_event_uids()
     events = [evt for evt in events if evt["uid"] not in echo_uids]
+    kept_pks: list[int] = []
+    fetched_uids: set[str] = set()
     for evt in events:
-        CalendarEvent.objects.update_or_create(
+        obj, _created = CalendarEvent.objects.update_or_create(
             guild=guild,
             feed=feed,
             uid=evt["uid"],
@@ -178,16 +187,85 @@ def _upsert_events(
                 "fetched_at": now,
             },
         )
+        kept_pks.append(obj.pk)
+        fetched_uids.add(evt["uid"])
+    if window is not None:
+        _prune_stale_occurrences(guild, feed, fetched_uids, kept_pks, window, now)
     return len(events)
+
+
+def _prune_stale_occurrences(
+    guild: Guild | None,
+    feed: CalendarFeed | None,
+    fetched_uids: set[str],
+    kept_pks: list[int],
+    window: tuple[datetime, datetime],
+    now: datetime,
+) -> None:
+    """Delete stale occurrence rows a reschedule left behind.
+
+    Each occurrence of a recurring series is its own row keyed by ``recurrence_id`` — the
+    occurrence's DTSTART (see :func:`_event_dict`). Move or single-instance-override an
+    occurrence and its DTSTART changes, so the next fetch writes a NEW row and the old one is
+    orphaned: it never updates again, and the calendar, the #public-calendar announcer, and the
+    Discord Scheduled Events mirror all double-list it. Mirroring :func:`sync_local_class_events`,
+    drop the rows this fetch did not just write.
+
+    Scoped deliberately to **UIDs the fetch returned**, inside the expansion ``window`` only: a
+    series that vanished entirely — or a transient empty/partial fetch — leaves its rows
+    untouched, so an upstream blip can never wipe a feed's calendar. Any pruned row's Discord
+    copy is deleted first (best-effort) so the mirror doesn't keep a ghost event.
+    """
+    if not fetched_uids:
+        return
+    window_start, window_end = window
+    stale = list(
+        CalendarEvent.objects.filter(
+            guild=guild,
+            feed=feed,
+            uid__in=fetched_uids,
+            start_dt__gte=window_start,
+            start_dt__lte=window_end,
+        ).exclude(pk__in=kept_pks)
+    )
+    if not stale:
+        return
+    _delete_stale_discord_copies(stale, now)
+    CalendarEvent.objects.filter(pk__in=[event.pk for event in stale]).delete()
+
+
+def _delete_stale_discord_copies(events: list[CalendarEvent], now: datetime) -> None:
+    """Best-effort delete of the Discord Scheduled Event copies of soon-to-be-pruned rows.
+
+    Only a *future* row that still holds a ``discord_event_id`` needs a call — a past orphan's
+    Discord event has already auto-completed and cannot be deleted. A delete failure is logged
+    and left as a minor remote residue; it never blocks the row prune (mirrors
+    :func:`remove_community_event`). No-ops when Discord Events sync is off.
+    """
+    targets = [event for event in events if event.discord_event_id and event.start_dt >= now]
+    if not targets:
+        return
+    from core.integrations.discord_events import DiscordEventsError, DiscordScheduledEventsClient
+
+    client = DiscordScheduledEventsClient.from_settings()
+    if not client.enabled:
+        return
+    for event in targets:
+        try:
+            _delete_feed_event_copy(client, event)
+        except DiscordEventsError:
+            logger.warning(
+                "Failed to delete Discord copy for stale feed event %s; leaving a stale remote event.", event.pk
+            )
 
 
 def sync_guild_calendar(guild: Guild) -> int:
     """Fetch and sync a guild's iCal calendar. Returns events synced (0 if no URL)."""
     if not guild.calendar_url:
         return 0
-    window_start, window_end = _sync_window()
-    events = _fetch_and_parse(guild.calendar_url, window_start, window_end)
-    count = _upsert_events(events, guild=guild, source="guild")
+    window = _sync_window()
+    events = _fetch_and_parse(guild.calendar_url, *window)
+    count = _upsert_events(events, guild=guild, source="guild", window=window)
     guild.calendar_last_fetched_at = timezone.now()
     guild.save(update_fields=["calendar_last_fetched_at"])
     return count
@@ -197,9 +275,9 @@ def sync_calendar_feed(feed: CalendarFeed) -> int:
     """Fetch and sync one named CalendarFeed. Returns events synced (0 if no URL)."""
     if not feed.ical_url:
         return 0
-    window_start, window_end = _sync_window()
-    events = _fetch_and_parse(feed.ical_url, window_start, window_end)
-    count = _upsert_events(events, guild=None, source="general", feed=feed)
+    window = _sync_window()
+    events = _fetch_and_parse(feed.ical_url, *window)
+    count = _upsert_events(events, guild=None, source="general", feed=feed, window=window)
     feed.last_fetched_at = timezone.now()
     feed.save(update_fields=["last_fetched_at"])
     return count

--- a/hub/discord_calendar_posts.py
+++ b/hub/discord_calendar_posts.py
@@ -37,6 +37,12 @@ EMBED_DESCRIPTION_MAX = 4096
 MESSAGE_EMBED_TOTAL_MAX = 6000
 # Max new-event announcements posted per run; the rest are stamped silently.
 ANNOUNCE_CAP = 10
+# New-event announcements are held until the event starts within this window. The nightly
+# sync materializes one CalendarEvent row per occurrence out to a 180-day horizon, so a
+# recurring series' leading edge keeps surfacing months out — a weekly meeting shows up as
+# a February row in August. A row past this horizon is left UNstamped (not announced), so it
+# announces once it rolls inside the window instead of being pre-announced a quarter early.
+ANNOUNCE_HORIZON = timedelta(days=90)
 DIGEST_WINDOW_DAYS = 7
 # The community-calendar blue (matches the calendar legend's community color).
 _EMBED_COLOR = 0x3D8BD4
@@ -309,9 +315,12 @@ def announce_new_events() -> int:
     rows, oldest-starting first. A recurring feed series (and a multi-session class)
     materializes one row *per occurrence* sharing a uid — those collapse to a single
     announcement at the earliest upcoming occurrence, with every sibling row stamped in
-    the same pass. Posts up to :data:`ANNOUNCE_CAP`, stamping ``channel_announced_at``
-    right after each post; anything past the cap is stamped silently (and logged) so a
-    backlog can never flood the channel later.
+    the same pass. A group whose earliest occurrence starts beyond :data:`ANNOUNCE_HORIZON`
+    is held: it is left unstamped and re-checked each run, so it announces only once it
+    rolls inside the window (this is what stops a recurring series' 180-day leading edge
+    from being announced a quarter early). Posts up to :data:`ANNOUNCE_CAP`, stamping
+    ``channel_announced_at`` right after each post; anything past the cap is stamped
+    silently (and logged) so a backlog can never flood the channel later.
     """
     from membership.models import CalendarEvent, CommunityEvent
 
@@ -321,6 +330,7 @@ def announce_new_events() -> int:
     if not channel_id:
         return 0
     now = timezone.now()
+    horizon = now + ANNOUNCE_HORIZON
 
     # (start of the announced occurrence, the embed to post, every row to stamp)
     pending: list[tuple[datetime, dict[str, Any], list[Any]]] = []
@@ -340,6 +350,11 @@ def announce_new_events() -> int:
         series.setdefault((row.source, row.guild_id, row.uid), []).append(row)
     for rows in series.values():
         first = rows[0]
+        # Hold far-future occurrences: the query is start-ordered, so `first` is the group's
+        # earliest unannounced occurrence. Leave the whole group UNstamped when it's past the
+        # horizon so it announces once its next occurrence rolls inside the window, not now.
+        if first.start_dt > horizon:
+            continue
         url = _absolute(first.url) if first.url else ""
         embed = _announcement_embed(
             first.title, "New on the calendar", _when(first.start_dt, first.end_dt, first.all_day), url

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -8,12 +8,15 @@ CHANGELOG: list[dict[str, str | list[str]]] = [
     {
         "version": "1.1.1",
         "date": "2026-08-17",
-        "title": "Calendar announcements stay closer to now",
+        "title": "Cleaner, more accurate calendar announcements",
         "changes": [
             "The Discord calendar channel now only announces events happening within the next three "
             "months. It had been surfacing recurring meetings that were still months away, so those "
             "far-off notices are gone. An event still gets its announcement once it comes within three "
             "months, so nothing is lost.",
+            "When an event is rescheduled to a new day or time, it no longer leaves a leftover copy on "
+            "the old date. The calendar, the announcements, and the Discord event list now show it once, "
+            "on the right day.",
         ],
     },
     {

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.1.1",
+        "date": "2026-08-17",
+        "title": "Calendar announcements stay closer to now",
+        "changes": [
+            "The Discord calendar channel now only announces events happening within the next three "
+            "months. It had been surfacing recurring meetings that were still months away, so those "
+            "far-off notices are gone. An event still gets its announcement once it comes within three "
+            "months, so nothing is lost.",
+        ],
+    },
     {
         "version": "1.1.0",
         "date": "2026-08-15",

--- a/tests/hub/calendar_service_spec.py
+++ b/tests/hub/calendar_service_spec.py
@@ -327,6 +327,179 @@ def _with_client(client: MagicMock):
     return patch.object(DiscordScheduledEventsClient, "from_settings", return_value=client)
 
 
+def _evt(uid: str, recurrence_id: str, days: float, **kwargs: object) -> dict:
+    """A parsed-event dict (the shape `_event_dict` yields) for `_upsert_events`."""
+    start = timezone.now() + timedelta(days=days)
+    event: dict = {
+        "uid": uid,
+        "recurrence_id": recurrence_id,
+        "title": "Guild Lead Meeting",
+        "description": "",
+        "location": "",
+        "url": "",
+        "start_dt": start,
+        "end_dt": start + timedelta(hours=1),
+        "all_day": False,
+    }
+    event.update(kwargs)
+    return event
+
+
+def _stored_occurrence(feed, recurrence_id: str, days: float, **kwargs: object) -> CalendarEvent:
+    """An already-stored feed occurrence row (guild=None, general source), for orphan setups."""
+    start = timezone.now() + timedelta(days=days)
+    defaults: dict[str, object] = {
+        "source": CalendarEvent.Source.GENERAL,
+        "feed": feed,
+        "guild": None,
+        "uid": "council",
+        "recurrence_id": recurrence_id,
+        "title": "Guild Lead Meeting",
+        "start_dt": start,
+        "end_dt": start + timedelta(hours=1),
+        "fetched_at": timezone.now() - timedelta(days=1),
+    }
+    defaults.update(kwargs)
+    return CalendarEvent.objects.create(**defaults)
+
+
+def describe_prune_stale_occurrences():
+    """A rescheduled recurring occurrence must not leave an orphan row behind."""
+
+    def _feed():
+        from core.models import CalendarFeed
+
+        return CalendarFeed.objects.create(name="Council", ical_url="https://example.com/c.ics")
+
+    def it_prunes_a_stale_occurrence_a_reschedule_left_behind():
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        orphan = _stored_occurrence(feed, "rec-0600", days=30)  # the old 6:00 PM row
+        # The next fetch returns the same instance moved to 6:15 PM — a new recurrence_id.
+        _upsert_events(
+            [_evt("council", "rec-0615", days=30)], guild=None, source="general", feed=feed, window=_sync_window()
+        )
+
+        assert not CalendarEvent.objects.filter(pk=orphan.pk).exists()  # orphan gone
+        assert CalendarEvent.objects.filter(uid="council").count() == 1  # only the live occurrence remains
+        assert CalendarEvent.objects.filter(uid="council", recurrence_id="rec-0615").exists()
+
+    def it_leaves_a_clean_series_untouched():
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        _stored_occurrence(feed, "rec-0615", days=30)  # already matches what the fetch returns
+        _upsert_events(
+            [_evt("council", "rec-0615", days=30)], guild=None, source="general", feed=feed, window=_sync_window()
+        )
+
+        assert CalendarEvent.objects.filter(uid="council").count() == 1  # updated in place, nothing pruned
+
+    def it_never_prunes_a_uid_the_fetch_did_not_return():
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        # A different series' row — a transient empty/partial fetch of `council` must not wipe it.
+        survivor = _stored_occurrence(feed, "other-rec", days=30, uid="studio-hours")
+        _upsert_events(
+            [_evt("council", "rec-0615", days=30)], guild=None, source="general", feed=feed, window=_sync_window()
+        )
+
+        assert CalendarEvent.objects.filter(pk=survivor.pk).exists()
+
+    def it_prunes_nothing_when_the_fetch_returned_no_events():
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        orphan = _stored_occurrence(feed, "rec-0600", days=30)
+        # An empty fetch (feed unreachable / momentarily blank) must never delete the calendar.
+        _upsert_events([], guild=None, source="general", feed=feed, window=_sync_window())
+
+        assert CalendarEvent.objects.filter(pk=orphan.pk).exists()
+
+    def it_does_not_prune_rows_outside_the_expansion_window():
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        far_future = _stored_occurrence(feed, "rec-far", days=400)  # beyond the 180-day horizon
+        long_past = _stored_occurrence(feed, "rec-past", days=-10)  # before the 1-day look-back
+        _upsert_events(
+            [_evt("council", "rec-0615", days=30)], guild=None, source="general", feed=feed, window=_sync_window()
+        )
+
+        assert CalendarEvent.objects.filter(pk=far_future.pk).exists()
+        assert CalendarEvent.objects.filter(pk=long_past.pk).exists()
+
+    def it_does_not_prune_when_no_window_is_given():
+        from hub.calendar_service import _upsert_events
+
+        feed = _feed()
+        orphan = _stored_occurrence(feed, "rec-0600", days=30)
+        _upsert_events([_evt("council", "rec-0615", days=30)], guild=None, source="general", feed=feed)
+
+        assert CalendarEvent.objects.filter(pk=orphan.pk).exists()  # prune is opt-in via `window`
+
+    def it_deletes_the_discord_copy_of_a_pruned_future_orphan():
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        orphan = _stored_occurrence(feed, "rec-0600", days=10, discord_event_id="disc-ghost")
+        client = _events_client()
+        with _with_client(client):
+            _upsert_events(
+                [_evt("council", "rec-0615", days=10)], guild=None, source="general", feed=feed, window=_sync_window()
+            )
+
+        client.delete_event.assert_called_once()  # the ghost scheduled-event is removed
+        assert client.delete_event.call_args.args[1] == "disc-ghost"
+        assert not CalendarEvent.objects.filter(pk=orphan.pk).exists()
+
+    def it_skips_the_discord_delete_for_a_past_orphan():
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        # In-window but already started: its Discord event has auto-completed — no call, still pruned.
+        orphan = _stored_occurrence(feed, "rec-0600", days=-0.5, discord_event_id="disc-done")
+        client = _events_client()
+        with _with_client(client):
+            _upsert_events(
+                [_evt("council", "rec-0615", days=10)], guild=None, source="general", feed=feed, window=_sync_window()
+            )
+
+        client.delete_event.assert_not_called()
+        assert not CalendarEvent.objects.filter(pk=orphan.pk).exists()
+
+    def it_prunes_the_row_but_skips_discord_when_sync_is_off():
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        orphan = _stored_occurrence(feed, "rec-0600", days=10, discord_event_id="disc-ghost")
+        client = _events_client(enabled=False)
+        with _with_client(client):
+            _upsert_events(
+                [_evt("council", "rec-0615", days=10)], guild=None, source="general", feed=feed, window=_sync_window()
+            )
+
+        client.delete_event.assert_not_called()
+        assert not CalendarEvent.objects.filter(pk=orphan.pk).exists()  # row still pruned
+
+    def it_prunes_the_row_even_when_the_discord_delete_fails():
+        from core.integrations.discord_events import DiscordEventsError
+        from hub.calendar_service import _sync_window, _upsert_events
+
+        feed = _feed()
+        orphan = _stored_occurrence(feed, "rec-0600", days=10, discord_event_id="disc-ghost")
+        client = _events_client()
+        client.delete_event.side_effect = DiscordEventsError("boom")  # non-404 → surfaces to our handler
+        with _with_client(client):
+            _upsert_events(
+                [_evt("council", "rec-0615", days=10)], guild=None, source="general", feed=feed, window=_sync_window()
+            )
+
+        assert not CalendarEvent.objects.filter(pk=orphan.pk).exists()  # a stale remote event never blocks the prune
+
+
 def describe_sync_discord_feed_events():
     def it_is_a_noop_when_sync_is_disabled():
         from hub.calendar_service import sync_discord_feed_events

--- a/tests/hub/discord_calendar_posts_spec.py
+++ b/tests/hub/discord_calendar_posts_spec.py
@@ -352,6 +352,44 @@ def describe_announce_new_events():
         assert dcp.announce_new_events() == 0
 
     @respx.mock
+    def it_holds_an_event_past_the_three_month_horizon_then_announces_it_once_inside(settings):
+        settings.DISCORD_BOT_TOKEN = "tok"
+        route = respx.post(_MESSAGES_URL).mock(return_value=httpx.Response(200, json={}))
+        _enable_posts()
+        # The nightly sync's leading edge: an occurrence ~5 months out, past the 90-day window.
+        event = _feed_event("Tech Guild Meeting", days=150)
+
+        assert dcp.announce_new_events() == 0  # held — not pre-announced a quarter early
+        assert not route.called
+        event.refresh_from_db()
+        assert event.channel_announced_at is None  # left unstamped so a later run can post it
+
+        # A later sync brings its next occurrence inside the window; now it announces.
+        event.start_dt = timezone.now() + timedelta(days=80)
+        event.end_dt = event.start_dt + timedelta(hours=1)
+        event.save(update_fields=["start_dt", "end_dt"])
+
+        assert dcp.announce_new_events() == 1
+        assert route.call_count == 1
+
+    @respx.mock
+    def it_does_not_reannounce_a_series_leading_edge_that_lands_past_the_horizon(settings):
+        settings.DISCORD_BOT_TOKEN = "tok"
+        route = respx.post(_MESSAGES_URL).mock(return_value=httpx.Response(200, json={}))
+        _enable_posts()
+        now = timezone.now()
+        # The exact "February in August" case: a weekly series whose near occurrences already
+        # went out, and the nightly sync just materialized a fresh far-edge occurrence. That
+        # lone far row must not be announced on its own.
+        _feed_event("Weekly Guild Meeting", days=3, uid="uid-guild", recurrence_id="near", channel_announced_at=now)
+        far = _feed_event("Weekly Guild Meeting", days=150, uid="uid-guild", recurrence_id="far")
+
+        assert dcp.announce_new_events() == 0
+        assert not route.called
+        far.refresh_from_db()
+        assert far.channel_announced_at is None
+
+    @respx.mock
     def it_still_announces_two_distinct_events_separately(settings):
         settings.DISCORD_BOT_TOKEN = "tok"
         route = respx.post(_MESSAGES_URL).mock(return_value=httpx.Response(200, json={}))


### PR DESCRIPTION
Two related fixes to calendar-event announcements. VERSION 1.1.1, one folded member-facing changelog entry.

## Fix 1 — hold announcements to events within 3 months

The #public-calendar Discord channel kept announcing events months out (a weekly guild meeting showing up with a February date back in August).

**Why:** the nightly sync (`hub/calendar_service.py`) materializes one `CalendarEvent` row per occurrence out to a **180-day horizon**. `announce_new_events` posts the earliest *unannounced* occurrence per series and stamps it. Once the near occurrences are announced, the only unstamped row left is the one at the window's leading edge (a February date), and each week the rolling window pushes a fresh far-edge row in.

**Fix:** `announce_new_events` skips any series whose earliest upcoming occurrence starts beyond a 90-day `ANNOUNCE_HORIZON`, left **unstamped** so it announces once it rolls inside the window. A recurring series now announces about once a quarter, always within 3 months.

## Fix 2 — prune stale feed occurrences left by a rescheduled meeting

Reported: the "Guild Lead Meeting" showed on **two** days (Tue Sep 1 and Wed Sep 2), correct on Google Calendar.

**Root cause (confirmed in prod):** a recurring iCal feed stores one `CalendarEvent` row per occurrence, keyed by `recurrence_id` (the occurrence DTSTART). Move or single-instance-override an occurrence and its DTSTART changes, so the next sync writes a **new** row and the old one is orphaned. Unlike `sync_local_class_events`, `_upsert_events` never pruned, so the orphan lingered and the calendar, the announcer, and the Discord Scheduled Events mirror all double-listed it. Prod evidence: the Guild Lead Meeting had a 6:00 PM orphan row (`pk=894`) beside its moved 6:15 PM row (`pk=4708`), same UID, different `recurrence_id`.

**Fix:** `sync_guild_calendar` / `sync_calendar_feed` pass their expansion window to `_upsert_events`, which prunes rows a fetch did not just write — scoped to **UIDs the fetch returned**, inside the window only, so a transient empty/partial fetch can never wipe a feed's calendar. A pruned future orphan has its Discord scheduled-event copy deleted first (best-effort, guarded by the Discord sync toggle, never raises).

## Tests

- Fix 1: held-past-90-days then announced once inside; the exact "February in August" case.
- Fix 2: prune on reschedule; never prune a UID the fetch didn't return; never prune outside the window; empty fetch is a no-op; Discord copy deleted for a future orphan, skipped for a past one, skipped when sync is off, and prune proceeds when the Discord delete fails.

Full run across the calendar-service, calendar-posts, release-announcement and sync-all-sources specs is green; ruff clean; new code fully covered.

## Not in this PR (data/process, flagged to the reporter)

- The current visible Sep 1/Sep 2 duplicate is a **stale artifact** from an earlier edit, not a live row — code can't retro-delete a past announcement. The prune stops it recurring.
- The meeting is also **double-entered**: a FOG-native lead-meeting event (`Council — Monthly Meeting`, 6:30 PM) plus a separate Google-feed `Guild Lead Meeting` (6:00 PM). That is a manual cleanup, not a code bug.

https://claude.ai/code/session_01RFfZcwdaJHFnSAGsQFHYDn
