### PR TITLE
docs: add 'How the calendar syncs' Help Center article

### DIFF
--- a/membership/help_content.py
+++ b/membership/help_content.py
@@ -1697,4 +1697,61 @@ Linking tells FOG which Discord user is you. Two ways:
 Linking is safe by design: a Discord account can only ever be linked to one member, and FOG will never silently swap or reassign a link. You can disconnect anytime from the same settings tab.""",
         "screenshots": [],
     },
+    {
+        "slug": "calendar-sync",
+        "category": "contributing",
+        "title": "How the calendar syncs: FOG, Google, and Discord",
+        "sort_order": 60,
+        "related": ["discord-and-fog", "how-fog-runs", "community-calendar"],
+        "body": """One calendar, three systems. Events at Past Lives live in FOG (this app), on two shared **Google calendars** (Member and Public), and in **Discord's event list**. This is how they stay in sync — and, just as important, where you should create or edit an event so it behaves.
+
+## The one rule that matters
+
+**Where an event is born decides where you manage it.** FOG can push events *out*, but it only *reads* the Google calendars — so an event created in Google can't be edited from FOG, and an event created in FOG can't be edited from Google. Pick one home per event and stick with it.
+
+## Create it in FOG (recommended)
+
+When you add an event in the FOG app, FOG owns it and fans it out:
+
+- It's pushed to the right **Google calendar** (Member or Public) automatically.
+- It's pushed to **Discord** as a scheduled event.
+- Edit it in FOG and both copies update. Delete it in FOG and both copies disappear.
+
+Because FOG owns it end to end, this is the path that gives you "create once, shows up everywhere; delete once, gone everywhere." If you want a single place to manage everything, make it FOG. (FOG won't double-list its own events: the one it pushes to Google comes back through the import below, and FOG recognizes it by ID and drops the echo.)
+
+## Create it on a Google calendar
+
+Anyone with edit access to the Member or Public Google calendar can add an event there. FOG then:
+
+- **Imports** it (read-only) on the nightly sync, so it appears on the Community Calendar.
+- **Mirrors** it into Discord's event list.
+
+The catch: FOG treats these as read-only. You **cannot edit or delete a Google-born event from FOG** — editing the FOG copy just gets overwritten on the next sync. To change its date, time, or details, or to remove it, do that **on the Google calendar**; FOG picks up the change on the next sync.
+
+## Discord is downstream
+
+Discord's event list is a mirror, never a source. FOG pushes to it; nothing you do in Discord flows back to FOG or Google. Don't create or delete events directly in Discord — treat it as a read-only display.
+
+## What deletes what
+
+- Delete a **FOG** event in FOG → removed from Google and Discord.
+- Delete a **Google** event in Google → removed from FOG and Discord on the next sync.
+- Delete an event in **Discord** → nothing else changes, and FOG may re-push it.
+- Try to delete a **Google** event from FOG → it doesn't stick; the next sync re-imports it.
+
+## Timing
+
+FOG → Google and Discord happens the moment you save. Google → FOG runs on the **nightly** sync (a scheduled job on Render — see [How FOG runs](/help/contributing/how-fog-runs/)), so an event added straight to a Google calendar can take until the next sync to appear in FOG and Discord.
+
+## The all-day gotcha (for the curious)
+
+An all-day event is a date with no time, but FOG stores every event as a precise moment — so it has to choose one for "all day." It anchors an all-day event to **local midnight** (Portland time). That sounds trivial, but it's a classic trap: anchor to midnight **UTC** instead and the event renders on the *previous* evening for anyone west of UTC — an all-day event on the 22nd shows up on the 21st. FOG anchors to local midnight so the day is always right. If you ever see an all-day event landing a day early, that's the shape of the bug.
+
+A practical tip that follows from this: if an event happens at a specific time, give it that time instead of marking it all-day. "All day" is for genuinely all-day things (a work party, a social); a 7–9pm event should be entered as 7–9pm, or it will show as an all-day block.
+
+## Where the code lives
+
+The feed import and the outbound pushes live in `hub/calendar_service.py` (the Google-calendar feeds) and `core/integrations/google_calendar.py` and `core/integrations/discord_events.py` (the Google and Discord pushes). As always, [the repository](https://github.com/Past-Lives-Makerspace/plfog) is the full story.""",
+        "screenshots": [],
+    },
 ]

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "1.1.2"
+VERSION = "1.1.3"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.1.3",
+        "date": "2026-08-17",
+        "title": "New guide: how the calendar syncs",
+        "changes": [
+            "A new Help Center guide explains how events stay in sync across FOG, the Google "
+            "calendars, and Discord, and where to create or edit an event so it behaves. Find it "
+            "under Help, in the 'Contributing & under the hood' section.",
+        ],
+    },
     {
         "version": "1.1.2",
         "date": "2026-08-17",

--- a/tests/membership/help_content_spec.py
+++ b/tests/membership/help_content_spec.py
@@ -123,6 +123,7 @@ def describe_help_content():
                 "how-fog-runs": "contributing",
                 "logins-and-usernames": "contributing",
                 "discord-and-fog": "contributing",
+                "calendar-sync": "contributing",
             }
             listed = {a["slug"]: a["category"] for a in _articles() if a["slug"] not in help_content.UNLISTED_SLUGS}
             assert listed == approved


### PR DESCRIPTION
## What

Adds a developer-audience Help Center article, **"How the calendar syncs: FOG, Google, and Discord"**, under the **Contributing & under the hood** section (`/help/contributing/calendar-sync/`). Documents the sync topology so devs (and event-creating leads/admins) understand where to create and edit events.

## Why

This session surfaced real confusion about how calendar events flow across the three systems (an event created in Google behaves differently from one created in FOG; an all-day event showed a day early). This captures the mental model as durable docs.

## Contents

- **The one rule:** where an event is born decides where you manage it.
- **Create in FOG** (recommended): FOG owns it and pushes to Google + Discord; edit/delete propagates; own-event echoes are de-duped by ID.
- **Create in a Google calendar:** FOG imports it read-only (nightly) and mirrors to Discord; you must edit/delete it in Google.
- **Discord is downstream** — a mirror, never a source.
- **Delete-propagation table**, **sync timing** (FOG→out is instant, Google→FOG is nightly), and the **all-day local-midnight gotcha** (why UTC-midnight renders a day early), plus a pointer to the code.

## Notes

- New article `calendar-sync` (slug), `contributing` category, sort_order 60, no screenshots.
- Test map in `help_content_spec.py` updated to list the new article.
- 185 help + release specs pass; ruff clean; no migration.
- VERSION 1.1.3, member-facing changelog entry.
- Post-merge: the article needs `seed_help_center` to reach prod. The Render build seed has been unreliable — I'll run the local seed-against-prod step after merge so it goes live at `/help/contributing/calendar-sync/`.

https://claude.ai/code/session_01RFfZcwdaJHFnSAGsQFHYDn
