### PR TITLE
fix: correct enabled_channels specs for push-on-by-default class_reminder

### DIFF
--- a/tests/core/events/preferences_spec.py
+++ b/tests/core/events/preferences_spec.py
@@ -72,14 +72,20 @@ def describe_wants():
 
 
 def describe_enabled_channels():
-    def it_lists_in_app_only_by_default():
-        # class_reminder: in_app on, email off, push off, no discord → only in_app.
-        assert preferences.enabled_channels(_user(), "class_reminder") == [Channel.IN_APP]
+    def it_lists_the_default_on_channels_with_no_rows():
+        # class_reminder is time-sensitive, so it's in the curated push-on set: with no
+        # preference rows, in_app on + push on (email off, discord_dm off) → [in_app, push].
+        assert preferences.enabled_channels(_user(), "class_reminder") == [Channel.IN_APP, Channel.PUSH]
 
     def it_includes_email_when_opted_in():
         user = _user()
         _pref(user, "class_reminder", Channel.EMAIL, True)
-        assert preferences.enabled_channels(user, "class_reminder") == [Channel.IN_APP, Channel.EMAIL]
+        # Opting into email adds it in declared order, alongside the default-on push.
+        assert preferences.enabled_channels(user, "class_reminder") == [
+            Channel.IN_APP,
+            Channel.EMAIL,
+            Channel.PUSH,
+        ]
 
     def it_includes_forced_email_without_a_row():
         # member.invited forces email (and is email-only), so it's included with no row.


### PR DESCRIPTION
## Why

Main is red. PR #210 (native push) put `class_reminder` in the curated push-on-by-default set (correct: a class reminder is time-sensitive and worth a push). But two pre-existing specs in `tests/core/events/preferences_spec.py` still expected the pre-push channel lists, so the `test` job failed on main (`2 failed, 8149 passed`) after #210 merged.

## What

- `it_lists_in_app_only_by_default` -> `it_lists_the_default_on_channels_with_no_rows`: `enabled_channels("class_reminder")` now returns `[IN_APP, PUSH]` with no preference rows. Renamed because it no longer describes an in-app-only default.
- `it_includes_email_when_opted_in`: opting into email now yields `[IN_APP, EMAIL, PUSH]` (push stays on by default).

Test-only change. No `VERSION` bump on purpose: this is an invisible intra-cycle fix to unshipped work, so there is nothing to announce and the version.py-triggered Discord workflow stays quiet.

Verified locally: `preferences_spec.py` 12 passed.

https://claude.ai/code/session_01SCPe229cq4iRZbNLLUoqB5