### PR TITLE
fix(mobile): ship FCM push plugin (versionCode 6) + gate on plugin presence

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "app.pastlives.hub"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 5
-        versionName "1.1.0"
+        versionCode 6
+        versionName "1.1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/verify-aab.sh
+++ b/mobile/verify-aab.sh
@@ -56,6 +56,30 @@ else
   fail=1
 fi
 
+# --- Native push plugin must be compiled into the binary ---------------------
+# Push is the one feature the server-URL architecture CANNOT ship on its own:
+# native-push.js is served from members.pastlives.space, but it no-ops unless
+# the @capacitor/push-notifications plugin is inside the APK's dex. The
+# versionCode-5 release announced "push on your phone" while shipping a binary
+# that lacked the plugin, so the app never prompted and prod logged zero device
+# registrations. This asserts the plugin's class descriptor is actually present.
+# Use `grep -c` (reads to EOF), NOT `grep -q` (early close -> SIGPIPE -> pipefail
+# false failure), per the note at the top. Multidex: the plugin can land in any
+# classesN.dex, so scan every dex entry.
+push_found=0
+for dex in ${(f)"$(print -r -- "$listing" | grep -oE 'base/dex/[^[:space:]]+\.dex' || true)"}; do
+  if [[ "$(unzip -p "$AAB" "$dex" | grep -ac 'capacitorjs/plugins/pushnotifications' || true)" -gt 0 ]]; then
+    push_found=1
+    break
+  fi
+done
+if [[ "$push_found" -eq 1 ]]; then
+  echo "  ok   native push plugin in dex (capacitorjs/plugins/pushnotifications)"
+else
+  echo "  MISS native push plugin absent from dex (app cannot receive push; run: npx cap sync android, then rebuild)"
+  fail=1
+fi
+
 if [[ "$fail" -ne 0 ]]; then
   echo ""
   echo "GATE FAILED. Do NOT upload this AAB. Run: npx cap sync android, then rebuild."


### PR DESCRIPTION
## What
- Bump the Android app to **versionCode 6 / versionName 1.1.1** with `@capacitor/push-notifications` synced into the native project.
- Add a **dex-level plugin-presence assertion** to `mobile/verify-aab.sh`.

## Why
versionCode 5 announced native push (the 1.1.4 changelog line "you get it as a push on your phone") but the shipped APK did **not** contain the push plugin. Because the app runs in server-URL mode, `native-push.js` is served live from members.pastlives.space but no-ops when `Cap.Plugins.PushNotifications` is absent from the binary. Result: no permission prompt, and **zero** `FcmDevice` registrations in production across the entire user base. The server half (endpoints, FCM sender, Firebase config) already shipped in #212; the binary was the missing piece.

## The gate
`verify-aab.sh` previously checked assets, `server.url`, and signature, but not the plugin. It now greps every `base/dex/classesN.dex` for the `capacitorjs/plugins/pushnotifications` class descriptor, using the pipefail-safe `grep -c` form (documented: `grep -q` closes the pipe early and SIGPIPEs `unzip` under `set -o pipefail`). Wired as the existing `verifyReleaseBundle` gradle finalizer, so it runs on every `bundleRelease`.

Proven both directions:
- Real AAB -> `ok native push plugin in dex`, GATE PASSED.
- Synthetic plugin-less AAB (config + assets + signature all present) -> `MISS native push plugin absent from dex`, GATE FAILED (exit 1).

## Verification
Live FCM v1 dry-run with the production service account authenticated to project `pastlives-fog` and was accepted (rejected only the dummy token), confirming Cloud Messaging is enabled and the send path works. App-side `google-services.json` and the server SA are the same project.

## Scope / risk
Two files, mobile build only. No Python, no templates, no `plfog/version.py` change -> no Django runtime impact and no Discord announce on merge. The signed AAB for upload is already built from this change.

https://claude.ai/code/session_01SCPe229cq4iRZbNLLUoqB5