### PR TITLE
fix(push): set csrftoken cookie on hub home so native FCM registration works

### DIFF
--- a/hub/views.py
+++ b/hub/views.py
@@ -24,6 +24,7 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBadReque
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST, require_http_methods
 
 from billing.exceptions import NoPaymentMethodError, TabLimitExceededError, TabLockedError
@@ -4064,6 +4065,7 @@ def _get_calendar_context(
 
 
 @login_required
+@ensure_csrf_cookie
 def home(request: HttpRequest) -> HttpResponse:
     """Member Home / Dashboard — the post-login landing page.
 
@@ -4071,6 +4073,14 @@ def home(request: HttpRequest) -> HttpResponse:
     shortcuts, and profile-completeness from the ``hub.home`` service. An unlinked
     account (a User with no ``Member``) renders a friendly "not linked yet" state and
     skips the personalized blocks — the hub's established graceful-``None`` pattern.
+
+    ``@ensure_csrf_cookie``: this is the native app's post-login landing page (``/``
+    redirects here), and it is where ``static/js/native-push.js`` runs to register the
+    device's FCM token. That registration POSTs to ``/push/fcm/register/`` with the CSRF
+    token read from the ``csrftoken`` cookie. Django only sets that cookie when a view
+    uses it, so without this the WebView had no cookie and every registration POST was
+    rejected ("CSRF cookie not set"), leaving native push silently broken. Forcing the
+    cookie here (it persists for the rest of the session) lets the token register.
     """
     member = _get_member(request)
     ctx = _get_hub_context(request)

--- a/tests/hub/home_spec.py
+++ b/tests/hub/home_spec.py
@@ -79,6 +79,19 @@ def describe_hub_home_view():
         assert response.status_code == 200
         assert b"isn't linked to a membership" in response.content
 
+    def it_sets_the_csrftoken_cookie_for_the_native_push_registration_post(client: Client):
+        # The native app lands here after login; static/js/native-push.js reads the
+        # csrftoken cookie to POST the device's FCM token to /push/fcm/register/. Django
+        # only sets that cookie when a view uses it, so @ensure_csrf_cookie must force it
+        # here or every registration POST is rejected ("CSRF cookie not set").
+        _member_user("csrf")
+        client.login(username="csrf", password="pass")
+
+        response = client.get(reverse("hub_home"))
+
+        assert response.status_code == 200
+        assert "csrftoken" in response.cookies
+
     def describe_upcoming():
         def it_lists_soonest_first_capped(client: Client):
             user = _member_user("soon")


### PR DESCRIPTION
## What

Native Android push never registered. The app's post-login landing page (`hub.views.home`, where `/` redirects) is where `static/js/native-push.js` runs to register the device's FCM token. It POSTs the token to `/push/fcm/register/` with the CSRF token read from the `csrftoken` cookie.

Django only sets `csrftoken` when a view actually uses it. `hub_home` never did, so the WebView had no cookie, the `X-CSRFToken` header was empty, and every registration POST was rejected. Prod web logs confirm it:

```
Forbidden (CSRF cookie not set.): /push/fcm/register/
```

Result: 0 `FcmDevice` rows, so `PushAdapter` had nothing to send to. Diagnosed live via adb against the physical device (permission granted, plugin present, Firebase healthy) plus the prod Render logs above.

## Fix

Add `@ensure_csrf_cookie` to `hub.views.home`. The cookie is then set on the landing page and persists for the session, so the registration POST (and any other same-origin JS `fetch` POST) carries a valid token. `CSRF_COOKIE_HTTPONLY` is unset (defaults False), so the JS can read it.

Server-side only. Ships via Render, no new Play Store build required.

## Test

`tests/hub/home_spec.py::it_sets_the_csrftoken_cookie_for_the_native_push_registration_post` asserts the cookie is present on the authenticated `hub_home` response.

## Not in this PR

No `VERSION` bump, deliberately: this deploys the fix so it can be verified on a real device before the "push notifications work in the app" changelog entry (and its automatic Discord announcement) go out in a follow-up.

https://claude.ai/code/session_01HN7dS138QscwjZbUTUpQnt