### PR TITLE
test: unbreak main after #214 title-cased headings

### DIFF
--- a/classes/spec/views/teach_orientation_spec.py
+++ b/classes/spec/views/teach_orientation_spec.py
@@ -15,10 +15,10 @@ from classes.forms import InstructorOrientationCompleteForm
 from core.models import SiteActivity
 from membership.models import Member, OrgInfoPage, WikiArticle
 
-BANNER = "One quick step before you can teach"
+BANNER = "One Quick Step Before You Can Teach"
 UNLOCK_BUTTON = "Unlock teaching"
 # Template-literal copy is NOT autoescaped (only variables are), so these match verbatim.
-COMPLETED_CARD = "You're an instructor"
+COMPLETED_CARD = "You're an Instructor"
 PLACEHOLDER = "Orientation content hasn't been loaded yet"
 FORM_ERROR = "Please confirm you&#x27;ve read the orientation before unlocking teaching."
 

--- a/tests/hub/calendar_config_forms_spec.py
+++ b/tests/hub/calendar_config_forms_spec.py
@@ -53,7 +53,7 @@ def describe_site_settings_calendar_fields():
         resp = client.get(reverse("hub_admin_site_settings") + "?tab=calendar")
         assert resp.status_code == 200
         body = resp.content
-        assert b"Member events &amp; Google sync" in body
+        assert b"Member Events &amp; Google Sync" in body
         assert b'name="member_event_policy"' in body
         assert b'name="member_google_calendar_id"' in body
         assert b'name="public_google_calendar_id"' in body


### PR DESCRIPTION
## Why

`test` (the full suite + mutation) has been **red on `main`** since #214 merged (2026-08-19 01:10 UTC). #214 title-cased three headings but left the asserting specs on the old lowercase copy, so three content assertions fail. No PR can reach a green CI until this is fixed.

## Fix

Sync the three stale assertions to the current template text. Pure test-copy, no behavior change:

| Spec | Old assertion | Template now |
|---|---|---|
| `classes/spec/views/teach_orientation_spec.py` | `One quick step before you can teach` | `One Quick Step Before You Can Teach` |
| `classes/spec/views/teach_orientation_spec.py` | `You're an instructor` | `You're an Instructor` |
| `tests/hub/calendar_config_forms_spec.py` | `Member events &amp; Google sync` | `Member Events &amp; Google Sync` |

All three verified passing locally.

https://claude.ai/code/session_01HN7dS138QscwjZbUTUpQnt