### PR TITLE
polish(hub): account deletion confirmation page + mypy fix (1.6.1)

### DIFF
--- a/hub/urls.py
+++ b/hub/urls.py
@@ -326,6 +326,7 @@ urlpatterns = [
         name="hub_profile_photo_delete",
     ),
     path("settings/delete-account/", views.account_delete, name="hub_account_delete"),
+    path("account-deleted/", views.account_deleted, name="hub_account_deleted"),
     path("settings/skills/add/", views.skill_add, name="hub_skill_add"),
     path("settings/skills/<int:skill_pk>/remove/", views.skill_remove, name="hub_skill_remove"),
     path("settings/skills/suggest/", views.skill_suggest, name="hub_skill_suggest"),

--- a/hub/views.py
+++ b/hub/views.py
@@ -1732,9 +1732,19 @@ def account_delete(request: HttpRequest) -> HttpResponse:
         return redirect(f"{reverse('hub_user_settings')}?tab=account")
 
     delete_own_account(member)
-    messages.success(request, "Your account has been deleted. You've been signed out.")
     auth_logout(request)
-    return redirect("account_login")
+    return redirect("hub_account_deleted")
+
+
+def account_deleted(request: HttpRequest) -> HttpResponse:
+    """Public confirmation shown after self-service deletion has signed the member out.
+
+    Deliberately undecorated (no ``@login_required``): the member is already logged out
+    by the time they land here, so this must render for an anonymous visitor. It confirms
+    the deletion on its own — it does not rely on a flash message, which ``auth_logout``'s
+    session flush would discard before the redirect.
+    """
+    return render(request, "hub/account_deleted.html")
 
 
 def _skill_categories_with_approved() -> QuerySet[SkillCategory]:

--- a/membership/services/account_deletion.py
+++ b/membership/services/account_deletion.py
@@ -35,7 +35,8 @@ def delete_own_account(member: "Member") -> None:
     if member.deleted_at is not None:
         logger.info("delete_own_account: member pk=%s already deleted, no-op.", member.pk)
         return
-    if member.user_id is None:
+    user = member.user
+    if user is None:
         raise ValueError(f"Member {member.pk} has no linked User; cannot self-delete.")
 
     from allauth.account.models import EmailAddress
@@ -50,7 +51,6 @@ def delete_own_account(member: "Member") -> None:
     )
     from membership.models import Guild, GuildStaffMembership, MemberContact, MemberEmail
 
-    user = member.user
     placeholder = f"deleted-user-{user.pk}@deleted.pastlives.invalid"
 
     with transaction.atomic():

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "1.6.0"
+VERSION = "1.6.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "1.6.0",
+        "version": "1.6.1",
         "date": "2026-08-24",
         "title": "Delete your account, right from the app",
         "changes": [

--- a/templates/hub/account_deleted.html
+++ b/templates/hub/account_deleted.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Account Deleted - Past Lives{% endblock %}
+
+{% block content %}
+<div class="auth-page">
+  <h1 class="auth-page__title">Your account has been deleted</h1>
+  <p class="auth-page__subtitle">Your personal information has been removed from Past Lives and you've been signed out on this device.</p>
+  <div class="auth-card">
+    <p>Thanks for being part of the space. If you'd like to come back, a guild lead or admin can send you a new invite.</p>
+    <a href="{% url 'account_login' %}" class="btn btn--primary btn--full">Back to sign in</a>
+  </div>
+</div>
+{% endblock %}

--- a/tests/hub/account_delete_spec.py
+++ b/tests/hub/account_delete_spec.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.auth.models import User
-from django.contrib.messages import get_messages
 from django.test import Client
 from django.urls import reverse
 
@@ -82,7 +81,7 @@ def describe_account_delete():
             response = client.post(reverse("hub_account_delete"), {"confirm_text": "DELETE"})
 
             assert response.status_code == 302
-            assert response["Location"] == reverse("account_login")
+            assert response["Location"] == reverse("hub_account_deleted")
             member.refresh_from_db()
             user.refresh_from_db()
             assert member.status == Member.Status.FORMER
@@ -98,13 +97,3 @@ def describe_account_delete():
             client.post(reverse("hub_account_delete"), {"confirm_text": "DELETE"})
 
             assert "_auth_user_id" not in client.session
-
-        def it_reports_success_to_the_member():
-            user = _member_user("del_msg")
-            client = Client()
-            client.force_login(user)
-
-            response = client.post(reverse("hub_account_delete"), {"confirm_text": "DELETE"})
-
-            messages = [m.message for m in get_messages(response.wsgi_request)]
-            assert any("has been deleted" in m for m in messages)

--- a/tests/hub/account_deleted_spec.py
+++ b/tests/hub/account_deleted_spec.py
@@ -1,0 +1,28 @@
+"""BDD specs for the post-deletion confirmation page (hub.views.account_deleted).
+
+Public and anonymous-accessible: the member is signed out before landing here, so the
+page must render for an anonymous visitor without bouncing to the login screen, and
+confirm the deletion on its own (no reliance on a flash message).
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def describe_account_deleted():
+    def it_renders_for_an_anonymous_user():
+        response = Client().get(reverse("hub_account_deleted"))
+
+        assert response.status_code == 200
+        assert b"Your account has been deleted" in response.content
+
+    def it_does_not_redirect_to_login():
+        response = Client().get(reverse("hub_account_deleted"))
+
+        assert response.status_code == 200
+        assert "/accounts/login/" not in response.get("Location", "")


### PR DESCRIPTION
## What

Two changes to the just-shipped account deletion feature, released together as 1.6.1:

1. **Confirmation page (UX).** After confirming deletion, the member was dropped on the login screen with no visible feedback (the success flash message never survived `auth_logout`'s session flush). Now deletion signs them out and redirects to a dedicated public `/account-deleted/` page that renders its own "Your account has been deleted" confirmation and links back to sign in. This gives a clear, recordable confirmation step (App Store 5.1.1(v) reviewers need to see it).
2. **mypy fix.** The `lint` job on main failed after #222: `member.user` is `User | None` and the `member.user_id` guard did not narrow it, tripping 6 union-attr errors. Guard on `user` directly to narrow the type. No runtime change.

## Details
- New public view `account_deleted` (undecorated; this app gates login per-view, there is no global login middleware) rendering `templates/hub/account_deleted.html`, mirroring the existing `discord_link_callback` anonymous landing precedent.
- `account_delete` drops the flash message and redirects to `hub_account_deleted`.
- VERSION 1.6.1; the account deletion changelog entry re-stamped to 1.6.1.
- Tests added/updated; ruff, `manage.py check`, and the hub specs green locally. CI mypy verifies the type fix.

https://claude.ai/code/session_01BuyoZKiSENczcxAv1GYN2g