### PR TITLE
fix(discord): point #classes links at the legacy Drupal site for now

### DIFF
--- a/classes/models.py
+++ b/classes/models.py
@@ -574,6 +574,20 @@ class ClassOffering(HeroCropMixin, models.Model):
         return _absolute_url(reverse("classes:public_class_detail", kwargs={"slug": self.slug}))
 
     @property
+    def legacy_public_url(self) -> str:
+        """This class's page on the legacy Drupal site, or ``""`` for locally-authored offerings.
+
+        The import derives ``slug`` from the Drupal path alias (``/class/<alias>``), appending a
+        ``-legacy`` suffix only when that alias collides with an existing local slug — so stripping
+        the suffix recovers the alias.
+        """
+        from classes.import_service import LEGACY_CMS_BASE
+
+        if not self.legacy_cms_id:
+            return ""
+        return f"{LEGACY_CMS_BASE}/class/{self.slug.removesuffix('-legacy')}"
+
+    @property
     def qr_url(self) -> str:
         """Stable, slug-independent permalink the QR encodes — it redirects to the current
         public page, so a printed QR keeps working even after the class's slug changes."""

--- a/classes/spec/models/class_offering_legacy_spec.py
+++ b/classes/spec/models/class_offering_legacy_spec.py
@@ -20,3 +20,16 @@ def describe_ClassOffering():
             offering = ClassOfferingFactory(legacy_cms_id="node-abc-123")
             offering.refresh_from_db()
             assert offering.legacy_cms_id == "node-abc-123"
+
+    def describe_legacy_public_url():
+        def it_points_at_the_drupal_class_page(db):
+            offering = ClassOfferingFactory(legacy_cms_id="node-abc-123", slug="sewing-pattern")
+            assert offering.legacy_public_url == "https://classes.pastlives.space/class/sewing-pattern"
+
+        def it_is_empty_for_a_locally_authored_offering(db):
+            offering = ClassOfferingFactory(slug="sewing-pattern")
+            assert offering.legacy_public_url == ""
+
+        def it_strips_the_collision_suffix_to_recover_the_drupal_alias(db):
+            offering = ClassOfferingFactory(legacy_cms_id="node-abc-123", slug="sewing-pattern-legacy")
+            assert offering.legacy_public_url == "https://classes.pastlives.space/class/sewing-pattern"

--- a/hub/discord_class_posts.py
+++ b/hub/discord_class_posts.py
@@ -11,7 +11,9 @@ Source of truth is :class:`classes.models.ClassOffering`, not the calendar cache
 — published, non-private, flexible or first session still upcoming) and not yet stamped
 ``channel_announced_at``. The stamp is set when announced (or silently, past the per-run
 cap) and never cleared, so a draft→published→unpublished→republished class can never
-announce twice. All links are absolute onto the public class site (``BOOK_BASE_URL``).
+announce twice. For now all links point at the legacy Drupal site (still the public
+sign-up surface) via :func:`_showcase_url`; locally-authored classes with no Drupal page
+fall back to the new class site (``BOOK_BASE_URL``).
 """
 
 from __future__ import annotations
@@ -38,12 +40,19 @@ _FLEXIBLE_WHEN = "Flexible scheduling — arrange with the instructor"
 _FOOTER_LABEL = "Browse all classes"
 
 
-def _class_absolute(path: str) -> str:
-    """Absolutize a path onto the public class site (classes live on the book host,
-    not the members hub) — Discord renders URLs as-is, so a bare path is a dead link."""
-    from classes.emails import _absolute_url
+def _showcase_url(offering: ClassOffering) -> str:
+    """Where a #classes link sends members: the class's legacy Drupal page while that site
+    is still the public sign-up surface, falling back to our own public page for
+    locally-authored classes that never existed on Drupal. When the new class site takes
+    over, this collapses back to ``offering.public_url``."""
+    return offering.legacy_public_url or offering.public_url
 
-    return _absolute_url(path)
+
+def _legacy_site_root() -> str:
+    """The legacy Drupal class site's root — the "Browse all classes" target for now."""
+    from classes.import_service import LEGACY_CMS_BASE
+
+    return LEGACY_CMS_BASE
 
 
 def _posting_channel_id() -> str:
@@ -58,7 +67,7 @@ def _posting_channel_id() -> str:
 
 def _class_line(offering: ClassOffering, *, time_prefix: str = "") -> str:
     """One digest bullet: optional time, linked title, and the instructor's name."""
-    title_part = f"[{offering.title}]({offering.public_url})"
+    title_part = f"[{offering.title}]({_showcase_url(offering)})"
     line = f"• {time_prefix}{title_part}"
     if offering.instructor is not None:
         line += f" · with {offering.instructor.display_name}"
@@ -108,7 +117,7 @@ def build_weekly_classes_digest_embeds(now: datetime) -> list[dict[str, Any]]:
     blocks = _digest_blocks(now)
     if not blocks:
         return []
-    blocks.append(f"[{_FOOTER_LABEL} →]({_class_absolute('/')})")
+    blocks.append(f"[{_FOOTER_LABEL} →]({_legacy_site_root()})")
     chunks = _chunk_blocks(blocks)
     local_start = timezone.localtime(now)
     local_end = timezone.localtime(now + timedelta(days=DIGEST_WINDOW_DAYS - 1))
@@ -118,7 +127,7 @@ def build_weekly_classes_digest_embeds(now: datetime) -> list[dict[str, Any]]:
             "title": title if i == 0 else f"{_DIGEST_TITLE} (continued)",
             "description": chunk,
             "color": _EMBED_COLOR,
-            "url": _class_absolute("/"),
+            "url": _legacy_site_root(),
         }
         for i, chunk in enumerate(chunks)
     ]
@@ -163,17 +172,18 @@ def _class_announcement_embed(offering: ClassOffering) -> dict[str, Any]:
     """One compact new-class embed: category, next date (or flexible), price, sign-up link."""
     from classes.templatetags.classes_tags import cents_as_price
 
+    link = _showcase_url(offering)
     lines = [
         f"*New class in {offering.category.name}*",
         f"**When:** {_class_when(offering)}",
         f"**Price:** {cents_as_price(offering.price_cents)}",
-        f"[Sign up →]({offering.public_url})",
+        f"[Sign up →]({link})",
     ]
     return {
         "title": offering.title,
         "description": "\n".join(lines),
         "color": _EMBED_COLOR,
-        "url": offering.public_url,
+        "url": link,
     }
 
 

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "1.6.0"
+VERSION = "1.6.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.6.1",
+        "date": "2026-08-24",
+        "title": "Class links in Discord go to the right place",
+        "changes": [
+            "Links in the #classes Discord channel (new class announcements and the weekly "
+            "digest) now take you straight to classes.pastlives.space, where class sign-ups "
+            "currently live.",
+        ],
+    },
     {
         "version": "1.6.0",
         "date": "2026-08-24",

--- a/tests/hub/discord_class_posts_spec.py
+++ b/tests/hub/discord_class_posts_spec.py
@@ -74,18 +74,25 @@ def describe_build_weekly_classes_digest_embeds():
         assert offering.public_url.startswith("http")
         assert f"with {offering.instructor.display_name}" in description
 
+    def it_links_a_legacy_imported_class_to_its_drupal_page():
+        offering = _published_class("Intro to Welding", days=2, legacy_cms_id="node-abc", slug="intro-welding")
+        description = dcp.build_weekly_classes_digest_embeds(timezone.now())[0]["description"]
+        assert "[Intro to Welding](https://classes.pastlives.space/class/intro-welding)" in description
+        assert offering.public_url not in description
+
     def it_lists_bookable_flexible_classes_in_their_own_section():
         flexible = _flexible_class("Open Studio Ceramics")
         description = dcp.build_weekly_classes_digest_embeds(timezone.now())[0]["description"]
         assert "**Flexible scheduling — book anytime**" in description
         assert f"[Open Studio Ceramics]({flexible.public_url})" in description
 
-    def it_footers_with_a_browse_all_classes_link():
+    def it_footers_with_a_browse_all_classes_link_to_the_legacy_site():
         _published_class("Intro to Welding", days=2)
-        from classes.emails import _absolute_url
+        from classes.import_service import LEGACY_CMS_BASE
 
-        description = dcp.build_weekly_classes_digest_embeds(timezone.now())[0]["description"]
-        assert f"[Browse all classes →]({_absolute_url('/')})" in description
+        embed = dcp.build_weekly_classes_digest_embeds(timezone.now())[0]
+        assert f"[Browse all classes →]({LEGACY_CMS_BASE})" in embed["description"]
+        assert embed["url"] == LEGACY_CMS_BASE
 
     def it_excludes_private_draft_and_beyond_window_sessions():
         _published_class("Secret Workshop", days=2, is_private=True)
@@ -179,6 +186,18 @@ def describe_announce_new_classes():
         assert f"[Sign up →]({offering.public_url})" in embed["description"]
         offering.refresh_from_db()
         assert offering.channel_announced_at is not None
+
+    @respx.mock
+    def it_links_a_legacy_imported_class_to_its_drupal_page(settings):
+        settings.DISCORD_BOT_TOKEN = "tok"
+        route = respx.post(_MESSAGES_URL).mock(return_value=httpx.Response(200, json={}))
+        _enable_posts()
+        _published_class("Forge Basics", days=3, legacy_cms_id="node-abc", slug="forge-basics")
+
+        assert dcp.announce_new_classes() == 1
+        embed = _sent_embeds(route)[0]
+        assert embed["url"] == "https://classes.pastlives.space/class/forge-basics"
+        assert "[Sign up →](https://classes.pastlives.space/class/forge-basics)" in embed["description"]
 
     @respx.mock
     def it_never_announces_the_same_class_twice(settings):


### PR DESCRIPTION
## What

Class links posted to the #classes Discord channel (the 15 minute new class announcer and the weekly Monday digest) now send members to the legacy Drupal site at classes.pastlives.space instead of the new class CMS, since Drupal is still the public sign up surface for now.

- Adds `ClassOffering.legacy_public_url`: the offering's Drupal page (`https://classes.pastlives.space/class/<alias>`), rebuilt from the imported slug (the import derived the slug from the Drupal path alias; a `-legacy` collision suffix is stripped to recover the alias). Empty for locally authored offerings.
- `hub/discord_class_posts.py` links every class through `_showcase_url`: the Drupal page when one exists, falling back to our own public page for classes that never existed on Drupal (a Drupal link for those would 404).
- The "Browse all classes" digest footer and digest embed URL now point at the Drupal site root.
- When the new class site takes over, reverting is one swap back to `offering.public_url`.

## Testing

- New specs: Drupal links in the digest and announcer embeds, plus `legacy_public_url` model specs (Drupal page, empty for local offerings, collision suffix stripping). Existing specs double as the fallback coverage.
- Full suite: 8423 passed, coverage 98.37% (gate 98%).
- `ruff format --check`, `ruff check`, `manage.py check` all clean. Local mypy still crashes on the django-stubs plugin (pre-existing; CI runs the real check).
- Verified live: `https://classes.pastlives.space/class/sewing-pattern` returns 200 and matches the alias shape the import stores.

Version 1.6.1 with a member facing changelog entry (the announcer has been live since 1.2.x, so the link change is member visible).

https://claude.ai/code/session_01XAn31uCEN65NrCCa2BvNsA