### PR TITLE
[discord] /poll slash command for sesh parity (v1.9.0)

### DIFF
--- a/core/events/discord_interactions.py
+++ b/core/events/discord_interactions.py
@@ -101,7 +101,11 @@ def reply(
     ``poll`` (a native Discord poll object) is valid **only on this non-deferred path**:
     :func:`send_followup` (the deferred PATCH) cannot carry a poll, so a deferred command
     that returned one would silently drop it. A ``/poll`` handler must therefore stay
-    ``defer=False`` and post its poll straight from the interaction response.
+    ``defer=False`` and post its poll straight from the interaction response. A poll reply
+    is public and credits a member-controlled display name in its content, so this path
+    also pins ``allowed_mentions`` to ``{"parse": []}`` — a name like ``@everyone`` can
+    never ping the channel. Plain (non-poll) replies are untouched, so no other command's
+    mention behavior changes.
     """
     data: dict = {"content": content, "flags": _flags(ephemeral)}
     if embeds is not None:
@@ -110,6 +114,7 @@ def reply(
         data["components"] = components
     if poll is not None:
         data["poll"] = poll
+        data["allowed_mentions"] = {"parse": []}
     return {"type": 4, "data": data}
 
 

--- a/core/events/discord_interactions.py
+++ b/core/events/discord_interactions.py
@@ -91,17 +91,25 @@ def reply(
     ephemeral: bool = True,
     embeds: list[dict] | None = None,
     components: list[dict] | None = None,
+    poll: dict | None = None,
 ) -> dict:
     """A type-4 (CHANNEL_MESSAGE_WITH_SOURCE) reply the view returns as its HTTP body.
 
     Ephemeral by default (only the invoking member sees it) — commands surface personal
-    data. ``embeds`` / ``components`` are included only when provided.
+    data. ``embeds`` / ``components`` / ``poll`` are included only when provided.
+
+    ``poll`` (a native Discord poll object) is valid **only on this non-deferred path**:
+    :func:`send_followup` (the deferred PATCH) cannot carry a poll, so a deferred command
+    that returned one would silently drop it. A ``/poll`` handler must therefore stay
+    ``defer=False`` and post its poll straight from the interaction response.
     """
     data: dict = {"content": content, "flags": _flags(ephemeral)}
     if embeds is not None:
         data["embeds"] = embeds
     if components is not None:
         data["components"] = components
+    if poll is not None:
+        data["poll"] = poll
     return {"type": 4, "data": data}
 
 

--- a/docs/superpowers/plans/2026-08-26-discord-poll-command.md
+++ b/docs/superpowers/plans/2026-08-26-discord-poll-command.md
@@ -1,0 +1,116 @@
+# Discord `/poll` command (sesh parity) — Spec & Implementation Plan
+
+**Status:** Approved to build (fog-quick-feature run, v1.9.0).
+**Date:** 2026-08-26
+**Size:** Small — one slash command, no models, no migrations, no UI.
+**Related:** `docs/superpowers/plans/2026-08-25-discord-create-command.md` (the sesh-replacement release this completes), PR #226.
+
+## Why
+
+Sesh is being removed from the Discord server, and the hard requirement is **no lost functionality for sesh users**. `/create` shipped in v1.8.0; `/poll` is the last sesh command members actually use (Tech Guild movie-night vote, 2026-08-20). Fog Bot gets its own `/poll` so the muscle memory keeps working; sesh is not removed until this is live.
+
+## What we're building
+
+`/poll` posts a **native Discord poll** in the channel where it's invoked, visible to everyone there. The invoker types the question and answers as options; the bot posts the poll as its interaction response, credited to the asker in the message content.
+
+### Locked decisions
+
+| Decision | Choice |
+|---|---|
+| Post mechanism | The interaction response itself carries the poll (`type: 4` with `data.poll`) — no extra REST call, no per-channel permission dance. Public (flags 0), unlike every other Fog Bot reply. |
+| Answers input | One `answers` string option. Split on `;` when the input contains any `;`, else split on `\|` — so an answer may contain a literal pipe as long as semicolons separate the list. Trimmed, empties dropped. 2–10 answers required, no exact duplicates (after trim + emoji extraction). |
+| Duration | **Type 4 (INTEGER)** choice option in hours (a string option with int values fails command registration): 1 hour / 4 hours / 8 hours / 1 day (default) / 3 days / 1 week / 2 weeks / 32 days → values `1,4,8,24,72,168,336,768` (768 is Discord's max). |
+| Multi-select | Boolean option (Discord type 5), default false. |
+| Attribution / visual header | Styled content line above the native poll widget: `📊 **Poll from <member display name>**  ·  open for <duration label>  ·  <pick one / pick any>` — plain text, no @mention, no ping. The poll itself renders in Discord's native widget (live progress bars, counts, voter avatars, countdown, View Votes) — visually richer than sesh's static reaction embeds. |
+| Answer emoji | If an answer begins with a unicode emoji or a custom emoji token (`<:name:id>` / `<a:name:id>`), strip it from the text and set it as the answer's `poll_media.emoji` (`{"name": <emoji>}` for unicode, `{"id": <id>}` for custom) so it renders as the answer's icon. **Empty-remainder rules (Discord rejects empty answer text):** a unicode-emoji-only answer (incl. trailing whitespace) keeps the original string as its text with NO emoji field; a custom-token-only answer uses the token's `name` part as text with `{"id": <id>}` as emoji. |
+| Ephemeral mechanics | `SlashCommand.ephemeral` is declarative (used only by the deferred ack path) — actual visibility is per-reply. Every validation reply passes `ephemeral=True` explicitly; the happy-path payload sets flags 0. `defer` must stay `False`: `send_followup` cannot carry a poll, so a deferred `/poll` would silently drop it (note this in the `reply(poll=...)` docstring). |
+| Confirm step | None — posts immediately, matching sesh. Polls don't ping anyone; a mistake can be ended/deleted by mods. Discord polls cannot be edited after posting, so the validation errors must be airtight instead. |
+| Gating | `requires_link=True` like every other posting command (`/create-announcement`, `/create`). |
+| Version | `VERSION` 1.8.0 → **1.9.0**, one new member-facing CHANGELOG entry. |
+
+## What already exists (reuse, don't reinvent)
+
+| Need | Existing thing | Location |
+|---|---|---|
+| Command declaration/registration/dispatch | `SlashCommand`, `register`, autodiscover | `core/events/discord_commands.py:37-145` |
+| Reply builder to extend | `reply()` (type 4; content/embeds/components) | `core/events/discord_interactions.py:88-105` |
+| Member resolution + display name | `resolve_member` (dispatch-level via `requires_link`), `Member.__str__` / display-name property (check what `/members` uses) | `core/events/discord_commands.py:151-165`, `membership/discord_commands.py` |
+| `/guide` auto-listing | `_guide` builds from `all_commands()` | `core/events/discord_commands.py:346-370` |
+| Registration to Discord | `register_discord_commands` mgmt command (bulk PUT) | `core/management/commands/register_discord_commands.py` |
+| Bot permission | `send_polls` already granted on the Fog Bot role (verified 2026-07-28) | Discord server settings |
+
+Genuine gaps (net-new): the `/poll` command module section, an answers-splitting helper, and a `poll=` kwarg on `reply()`.
+
+## Where the code lives
+
+```
+membership/discord_commands.py     # /poll section (or hub/ — builder's call; membership hosts the other member commands)
+core/events/discord_interactions.py  # reply() gains an optional poll= kwarg (included only when provided)
+tests/core/events/poll_command_spec.py  # NEW
+plfog/version.py                   # 1.9.0 + changelog entry
+```
+
+## Behavior
+
+### Options (required first, per Discord)
+
+| # | Option | Type | Req | Description (copy-ready, ≤100 chars, no dashes) |
+|---|---|---|---|---|
+| 1 | `question` | 3 str | yes | What you are asking, like Which movie should we watch? |
+| 2 | `answers` | 3 str | yes | The choices, separated by semicolons, like Alien; Clue; The Thing. Between 2 and 10. |
+| 3 | `duration` | 4 int choices | no | How long voting stays open. Default is 1 day. |
+| 4 | `multiselect` | 5 bool | no | Let people pick more than one answer. Off by default. |
+
+Duration choices: `1 hour`/`4 hours`/`8 hours`/`1 day (default)`/`3 days`/`1 week`/`2 weeks`/`32 days`.
+
+### Validation (each an immediate **ephemeral** reply naming the fix; nothing posts)
+
+| State | Copy |
+|---|---|
+| < 2 answers after splitting/trimming | Give me at least 2 answers, separated by semicolons. Like: Alien; Clue; The Thing |
+| > 10 answers | Discord polls allow at most 10 answers. Trim the list and try again. |
+| An answer longer than 55 chars | Each answer has to fit in 55 characters. Shorten "<first offender, truncated>" and try again. |
+| Question longer than 300 chars | The question has to fit in 300 characters. Shorten it and try again. |
+| Duplicate answers (exact match after trim + emoji extraction) | You have the same answer twice. Make each one different and try again. |
+
+(Discord's poll limits: question text ≤300, answer text ≤55, ≤10 answers, duration ≤768h — the builder must verify these against the current API docs constants and encode them as module constants, not magic numbers.)
+
+### Happy path
+
+Returns `{"type": 4, "data": {"content": "📊 Poll from <name>", "poll": {"question": {"text": q}, "answers": [{"poll_media": {"text": a}}, ...], "duration": <hours int>, "allow_multiselect": <bool>}}}` with **flags 0** (public — a poll must be visible/votable by the channel). `SlashCommand(..., ephemeral=False, requires_link=True, defer=False, scope="guild")`.
+
+### States checklist (UX completeness for a chat surface)
+
+- Happy: public poll message, native Discord voting UI, auto-expires at duration. ✓
+- Error states: the four ephemeral validation replies above; unlinked → dispatch's existing connect prompt; malformed/empty question is impossible (Discord requires the option). ✓
+- Empty state: n/a (no listing surface). `/guide` lists the command automatically. ✓
+- No dead ends: every rejection names the accepted format with an example. ✓
+
+## Testing (BDD `*_spec.py`, 100% coverage)
+
+`tests/core/events/poll_command_spec.py`:
+- command definition: name, `ephemeral=False`, `requires_link=True`, option set, required-first ordering, duration choice values, multiselect is type 5.
+- answers helper: semicolons, pipes, mixed, trimming, empty segments dropped.
+- emoji extraction: leading unicode emoji → `poll_media.emoji` ({"name": <emoji>}), leading custom emoji token → ({"id": <id>}, token name becomes the text), unicode-emoji-only answer (incl. trailing whitespace) keeps the original string as text with no emoji field, custom-token-only answer gets the token name as text, no-emoji answer untouched; the 55-char limit applies to the text AFTER emoji extraction.
+- separator: input with `;` splits only on `;` (pipes survive inside answers); input with no `;` splits on `|`; duplicate detection runs after trim + emoji extraction.
+- header line: contains the display name, the duration label, and "pick one" vs "pick any" matching multiselect.
+- each validation error (1 answer, 11 answers, 56-char answer, 301-char question) is ephemeral and posts nothing.
+- happy path: type 4, flags 0, poll payload shape (question/answers/duration default 24/multiselect false), explicit duration and multiselect honored, attribution line contains the member's display name.
+- `reply(poll=...)` includes the key only when provided (existing replies unaffected).
+- `/guide` lists `poll`.
+- dispatch integration: unlinked member gets the connect prompt.
+
+## Out of scope
+
+- Recurring polls, role-restricted polls (sesh features never used on this server).
+- Answers containing the active separator character (a `;` inside an answer can't be expressed; a `|` can, when semicolons separate the list). Documented limitation, revisit only if someone hits it.
+- A results/end subcommand (native Discord UI handles both).
+- Web/hub surface for polls.
+
+## Versioning & changelog
+
+`VERSION` → **1.9.0**. One member-facing entry: title "Post polls with /poll", body: "Ask the room anything with /poll in Discord. Type your question and answers, pick how long voting stays open, and the bot posts a native Discord poll right in the channel. This replaces the old sesh bot's /poll."
+
+## Post-deploy
+
+`python manage.py register_discord_commands` as a Render one-off (quote-free startCommand), then verify `/poll` appears in the guild command list via the Discord API.

--- a/membership/discord_commands.py
+++ b/membership/discord_commands.py
@@ -1,5 +1,5 @@
 """Membership's Discord slash commands: ``/whats-on``, ``/info``, ``/schedule-orientation``,
-``/voting``, ``/members``, ``/create``, and ``/cancel``.
+``/voting``, ``/members``, ``/create``, ``/cancel``, and ``/poll``.
 
 Autodiscovered by :func:`core.events.discord_commands.autodiscover`. Each handler stays thin
 — it resolves a guild/window, calls an existing manager/service method, and hands the result
@@ -10,6 +10,7 @@ models/managers and :mod:`membership.orientations`; nothing new lands in the han
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date, datetime, timedelta
 from math import ceil
 from typing import TYPE_CHECKING, cast
@@ -1624,3 +1625,233 @@ CANCEL = SlashCommand(
 
 register(CANCEL)
 register_component(ComponentHandler(prefix="cancel", handler=_cancel_component, requires_link=True))
+
+
+# --- /poll --------------------------------------------------------------------
+
+# Discord native-poll limits (verified against the API docs, 2026-08-26).
+_POLL_QUESTION_MAX = 300
+_POLL_ANSWER_MAX = 55
+_POLL_MIN_ANSWERS = 2
+_POLL_MAX_ANSWERS = 10
+_POLL_DEFAULT_DURATION_HOURS = 24
+# Duration options in hours → the label shown in the styled header. 768h is Discord's max.
+_POLL_DURATION_LABELS: dict[int, str] = {
+    1: "1 hour",
+    4: "4 hours",
+    8: "8 hours",
+    24: "1 day",
+    72: "3 days",
+    168: "1 week",
+    336: "2 weeks",
+    768: "32 days",
+}
+
+# A Discord custom-emoji token at the start of an answer: <:name:id> or <a:name:id> (animated).
+_CUSTOM_EMOJI_RE = re.compile(r"^<a?:(\w+):(\d+)>")
+# Codepoint ranges whose leading character starts a unicode emoji.
+_EMOJI_BASE_RANGES: tuple[tuple[int, int], ...] = (
+    (0x1F000, 0x1FAFF),  # the emoji SMP blocks: pictographs, faces, flags, symbols A/B
+    (0x2600, 0x27BF),  # miscellaneous symbols + dingbats (✅ ✨ ☀ ✂)
+    (0x2300, 0x23FF),  # technical symbols used as emoji (⌚ ⏰ ⏳)
+    (0x2B00, 0x2BFF),  # stars and block arrows (⭐ ⬆ ⬅)
+)
+# Codepoints that continue (but never start) an emoji grapheme: ZWJ, VS16, keycap, skin
+# tones, and regional-indicator partners (the second half of a flag).
+_EMOJI_CONTINUATION = frozenset({0x200D, 0xFE0F, 0x20E3, *range(0x1F3FB, 0x1F400), *range(0x1F1E6, 0x1F1FF + 1)})
+
+_POLL_TOO_FEW = "Give me at least 2 answers, separated by semicolons. Like: Alien; Clue; The Thing"
+_POLL_TOO_MANY = "Discord polls allow at most 10 answers. Trim the list and try again."
+_POLL_QUESTION_TOO_LONG = "The question has to fit in 300 characters. Shorten it and try again."
+_POLL_DUPLICATE = "You have the same answer twice. Make each one different and try again."
+
+
+def _split_answers(raw: str) -> list[str]:
+    """Split the ``answers`` option into trimmed, non-empty answer strings.
+
+    Semicolons win: when the input contains any ``;`` it splits on ``;`` (so an answer may
+    carry a literal ``|``); otherwise it splits on ``|``. Each piece is trimmed and empty
+    pieces are dropped.
+    """
+    separator = ";" if ";" in raw else "|"
+    return [piece.strip() for piece in raw.split(separator) if piece.strip()]
+
+
+def _in_ranges(code: int, ranges: tuple[tuple[int, int], ...]) -> bool:
+    """Whether ``code`` falls in any inclusive ``(low, high)`` range."""
+    return any(low <= code <= high for low, high in ranges)
+
+
+def _emoji_prefix(text: str) -> str:
+    """The leading unicode-emoji grapheme of ``text``, or ``""`` if it doesn't start with one.
+
+    Consumes an emoji base plus any trailing skin-tone modifiers, variation selectors,
+    keycaps, regional-indicator partners, and ZWJ-joined segments, so a multi-codepoint
+    emoji (a flag, a skin-toned thumb, a ZWJ family) is captured whole. Custom Discord
+    tokens are matched separately in :func:`_answer_media`.
+    """
+    if not text or not _in_ranges(ord(text[0]), _EMOJI_BASE_RANGES):
+        return ""
+    end = 1
+    while end < len(text):
+        code = ord(text[end])
+        if code == 0x200D and end + 1 < len(text) and _in_ranges(ord(text[end + 1]), _EMOJI_BASE_RANGES):
+            end += 2  # a ZWJ plus the emoji base it joins (family / profession sequences)
+        elif code in _EMOJI_CONTINUATION:
+            end += 1  # VS16, a keycap, a skin-tone modifier, or a regional-indicator partner
+        else:
+            break
+    return text[:end]
+
+
+def _answer_media(answer: str) -> dict:
+    """The ``poll_media`` object for one trimmed answer, pulling a leading emoji into its icon.
+
+    A leading custom-emoji token (``<:name:id>`` / ``<a:name:id>``) becomes ``{"id": <id>}``
+    with the token stripped from the text, falling back to the token's name when nothing else
+    remains (Discord rejects empty answer text). A leading unicode emoji becomes
+    ``{"name": <emoji>}`` with the emoji stripped, except an emoji-only answer keeps its
+    original text and carries no emoji field.
+    """
+    custom = _CUSTOM_EMOJI_RE.match(answer)
+    if custom is not None:
+        name, emoji_id = custom.group(1), custom.group(2)
+        remainder = answer[custom.end() :].strip()
+        return {"text": remainder or name, "emoji": {"id": emoji_id}}
+    prefix = _emoji_prefix(answer)
+    if prefix:
+        remainder = answer[len(prefix) :].strip()
+        if remainder:
+            return {"text": remainder, "emoji": {"name": prefix}}
+        return {"text": answer}  # emoji-only: keep the original string, no emoji field
+    return {"text": answer}
+
+
+def _poll_duration_hours(interaction: Interaction) -> int:
+    """The ``duration`` option in hours, defaulting to :data:`_POLL_DEFAULT_DURATION_HOURS`.
+
+    Discord constrains the integer option to the registered choices, so a supplied value is
+    always one of :data:`_POLL_DURATION_LABELS`; an omitted value falls back to one day.
+    """
+    raw = option_value(interaction, "duration")
+    return int(raw) if raw else _POLL_DEFAULT_DURATION_HOURS
+
+
+def _poll_multiselect(interaction: Interaction) -> bool:
+    """The raw boolean ``multiselect`` option (default ``False`` when omitted).
+
+    Read straight from the interaction, not via :func:`option_value`, which stringifies
+    every value — ``str(False)`` is truthy. Discord sends a JSON boolean for a type-5 option.
+    """
+    for option in interaction.get("data", {}).get("options", []):
+        if option.get("name") == "multiselect":
+            return bool(option.get("value"))
+    return False
+
+
+def _answer_too_long_reply(answer_text: str) -> dict:
+    """The ephemeral "shorten this answer" reply, quoting the first over-long answer."""
+    shown = truncate(answer_text, _POLL_ANSWER_MAX)
+    return reply(
+        f'Each answer has to fit in {_POLL_ANSWER_MAX} characters. Shorten "{shown}" and try again.', ephemeral=True
+    )
+
+
+def _poll_header(display_name: str, hours: int, multiselect: bool) -> str:
+    """The styled content line above the native poll widget — attribution, no ping."""
+    pick = "pick any" if multiselect else "pick one"
+    return f"📊 **Poll from {display_name}**  ·  open for {_POLL_DURATION_LABELS[hours]}  ·  {pick}"
+
+
+def _poll(interaction: Interaction, member: Member | None) -> dict:
+    """Post a native Discord poll in the channel, credited to the asker in the header line.
+
+    Every guard returns an immediate ephemeral reply naming the fix and posts nothing; a
+    poll can't be edited once live, so validation is airtight up front. The happy path
+    returns a public (flags 0) type-4 reply carrying the poll object itself — no extra REST
+    call. ``requires_link=True`` guarantees ``member`` is non-``None`` (dispatch shows the
+    connect prompt for an unlinked caller first), and ``defer=False`` because the deferred
+    followup path cannot carry a poll.
+    """
+    member = cast("Member", member)  # requires_link=True: dispatch resolved a linked member before this runs
+    question = (option_value(interaction, "question") or "").strip()
+    if len(question) > _POLL_QUESTION_MAX:
+        return reply(_POLL_QUESTION_TOO_LONG, ephemeral=True)
+
+    pieces = _split_answers(option_value(interaction, "answers") or "")
+    if len(pieces) < _POLL_MIN_ANSWERS:
+        return reply(_POLL_TOO_FEW, ephemeral=True)
+    if len(pieces) > _POLL_MAX_ANSWERS:
+        return reply(_POLL_TOO_MANY, ephemeral=True)
+
+    media = [_answer_media(piece) for piece in pieces]
+    for item in media:
+        if len(item["text"]) > _POLL_ANSWER_MAX:
+            return _answer_too_long_reply(item["text"])
+    texts = [item["text"] for item in media]
+    if len(set(texts)) != len(texts):
+        return reply(_POLL_DUPLICATE, ephemeral=True)
+
+    hours = _poll_duration_hours(interaction)
+    multiselect = _poll_multiselect(interaction)
+    poll = {
+        "question": {"text": question},
+        "answers": [{"poll_media": item} for item in media],
+        "duration": hours,
+        "allow_multiselect": multiselect,
+    }
+    return reply(_poll_header(member.display_name, hours, multiselect), ephemeral=False, poll=poll)
+
+
+def _poll_options() -> list[dict]:
+    """The ``/poll`` options — required ``question`` + ``answers`` first, then duration + multiselect.
+
+    ``duration`` is a type-4 INTEGER choice option with integer choice values (a string
+    option with int values fails Discord's command registration); ``multiselect`` is a
+    type-5 BOOLEAN. Neither touches the DB, so this is a pure, import-safe builder.
+    """
+    duration_choices = [
+        {"name": f"{label} (default)" if hours == _POLL_DEFAULT_DURATION_HOURS else label, "value": hours}
+        for hours, label in _POLL_DURATION_LABELS.items()
+    ]
+    return [
+        {
+            "name": "question",
+            "description": "What you are asking, like Which movie should we watch?",
+            "type": 3,
+            "required": True,
+        },
+        {
+            "name": "answers",
+            "description": "The choices, separated by semicolons, like Alien; Clue; The Thing. Between 2 and 10.",
+            "type": 3,
+            "required": True,
+        },
+        {
+            "name": "duration",
+            "description": "How long voting stays open. Default is 1 day.",
+            "type": 4,
+            "required": False,
+            "choices": duration_choices,
+        },
+        {
+            "name": "multiselect",
+            "description": "Let people pick more than one answer. Off by default.",
+            "type": 5,
+            "required": False,
+        },
+    ]
+
+
+POLL = SlashCommand(
+    name="poll",
+    description="Post a poll for the channel to vote on.",
+    handler=_poll,
+    options_builder=_poll_options,
+    requires_link=True,
+    ephemeral=False,
+    defer=False,
+    scope="guild",
+)
+
+register(POLL)

--- a/membership/discord_commands.py
+++ b/membership/discord_commands.py
@@ -1649,16 +1649,39 @@ _POLL_DURATION_LABELS: dict[int, str] = {
 
 # A Discord custom-emoji token at the start of an answer: <:name:id> or <a:name:id> (animated).
 _CUSTOM_EMOJI_RE = re.compile(r"^<a?:(\w+):(\d+)>")
-# Codepoint ranges whose leading character starts a unicode emoji.
+# Leading-emoji extraction is deliberately CONSERVATIVE: an answer's leading emoji is
+# pulled into the poll answer's icon only when it is confidently a single, well-formed,
+# Discord-acceptable emoji. A missed icon is cosmetic; a malformed poll_media.emoji makes
+# Discord reject the whole interaction, so anything ambiguous (a non-emoji symbol, a lone
+# or doubled flag, a tag-sequence flag, a dangling joiner) keeps the answer text untouched.
+_ZWJ = 0x200D
+_VS16 = 0xFE0F  # variation selector 16 — forces emoji presentation
+_SKIN_TONES = frozenset(range(0x1F3FB, 0x1F400))
+_REGIONAL = frozenset(range(0x1F1E6, 0x1F1FF + 1))  # regional indicators; a flag is exactly a pair
+_TAG_RANGE = range(0xE0020, 0xE007F + 1)  # tag characters — only appear inside tag-sequence flags
+# Unambiguous default-emoji SMP blocks. The non-emoji SMP blocks below 0x1F300 (mahjong,
+# dominoes, playing cards, enclosed alphanumerics) are intentionally excluded.
 _EMOJI_BASE_RANGES: tuple[tuple[int, int], ...] = (
-    (0x1F000, 0x1FAFF),  # the emoji SMP blocks: pictographs, faces, flags, symbols A/B
-    (0x2600, 0x27BF),  # miscellaneous symbols + dingbats (✅ ✨ ☀ ✂)
-    (0x2300, 0x23FF),  # technical symbols used as emoji (⌚ ⏰ ⏳)
-    (0x2B00, 0x2BFF),  # stars and block arrows (⭐ ⬆ ⬅)
+    (0x1F300, 0x1F5FF),  # miscellaneous symbols & pictographs (🔥 🎬 🎲 🏴 …)
+    (0x1F600, 0x1F64F),  # emoticons
+    (0x1F680, 0x1F6FF),  # transport & map symbols
+    (0x1F7E0, 0x1F7EB),  # large colored circles and squares
+    (0x1F900, 0x1F9FF),  # supplemental symbols & pictographs
+    (0x1FA70, 0x1FAFF),  # symbols & pictographs extended-A
 )
-# Codepoints that continue (but never start) an emoji grapheme: ZWJ, VS16, keycap, skin
-# tones, and regional-indicator partners (the second half of a flag).
-_EMOJI_CONTINUATION = frozenset({0x200D, 0xFE0F, 0x20E3, *range(0x1F3FB, 0x1F400), *range(0x1F1E6, 0x1F1FF + 1)})
+# Curated default-emoji-presentation BMP codepoints. Their text-presentation neighbours
+# (☀ U+2600, ✏ U+270F, ⌘ U+2318, …) are deliberately absent — bare, they are not emoji.
+_EMOJI_BASE_BMP: frozenset[int] = frozenset(
+    {
+        0x231A, 0x231B, 0x23E9, 0x23EA, 0x23EB, 0x23EC, 0x23F0, 0x23F3,
+        0x25FD, 0x25FE, 0x2614, 0x2615, *range(0x2648, 0x2654), 0x267F,
+        0x2693, 0x26A1, 0x26AA, 0x26AB, 0x26BD, 0x26BE, 0x26C4, 0x26C5,
+        0x26CE, 0x26D4, 0x26EA, 0x26F2, 0x26F3, 0x26F5, 0x26FA, 0x26FD,
+        0x2705, 0x270A, 0x270B, 0x2728, 0x274C, 0x274E, 0x2753, 0x2754,
+        0x2755, 0x2757, 0x2795, 0x2796, 0x2797, 0x27B0, 0x27BF, 0x2B1B,
+        0x2B1C, 0x2B50, 0x2B55,
+    }
+)  # fmt: skip
 
 _POLL_TOO_FEW = "Give me at least 2 answers, separated by semicolons. Like: Alien; Clue; The Thing"
 _POLL_TOO_MANY = "Discord polls allow at most 10 answers. Trim the list and try again."
@@ -1677,31 +1700,51 @@ def _split_answers(raw: str) -> list[str]:
     return [piece.strip() for piece in raw.split(separator) if piece.strip()]
 
 
-def _in_ranges(code: int, ranges: tuple[tuple[int, int], ...]) -> bool:
-    """Whether ``code`` falls in any inclusive ``(low, high)`` range."""
-    return any(low <= code <= high for low, high in ranges)
+def _is_emoji_base(code: int) -> bool:
+    """Whether ``code`` unambiguously starts a default-emoji grapheme (curated ranges + BMP set)."""
+    return code in _EMOJI_BASE_BMP or any(low <= code <= high for low, high in _EMOJI_BASE_RANGES)
 
 
 def _emoji_prefix(text: str) -> str:
-    """The leading unicode-emoji grapheme of ``text``, or ``""`` if it doesn't start with one.
+    """A leading, confidently well-formed single emoji of ``text``, or ``""`` when not confident.
 
-    Consumes an emoji base plus any trailing skin-tone modifiers, variation selectors,
-    keycaps, regional-indicator partners, and ZWJ-joined segments, so a multi-codepoint
-    emoji (a flag, a skin-toned thumb, a ZWJ family) is captured whole. Custom Discord
-    tokens are matched separately in :func:`_answer_media`.
+    Recognizes a flag as exactly one regional-indicator pair, and a base emoji plus its
+    VS16 / skin-tone / ZWJ-joined sequence. Bails (returns ``""``) on anything ambiguous — a
+    lone or doubled flag, a tag-sequence flag, a dangling ZWJ, or a base outside the curated
+    emoji ranges — so :func:`_answer_media` keeps the original answer text rather than risk a
+    malformed ``poll_media.emoji``. Custom Discord tokens are matched separately.
     """
-    if not text or not _in_ranges(ord(text[0]), _EMOJI_BASE_RANGES):
+    if not text:
         return ""
+    first = ord(text[0])
+
+    # A flag is exactly two regional indicators; a lone one, or a third that would merge two
+    # flags, is not a confident single emoji.
+    if first in _REGIONAL:
+        pair = len(text) >= 2 and ord(text[1]) in _REGIONAL
+        tripled = len(text) >= 3 and ord(text[2]) in _REGIONAL
+        return text[:2] if pair and not tripled else ""
+
+    if not _is_emoji_base(first):
+        return ""
+
     end = 1
     while end < len(text):
         code = ord(text[end])
-        if code == 0x200D and end + 1 < len(text) and _in_ranges(ord(text[end + 1]), _EMOJI_BASE_RANGES):
+        if code in _TAG_RANGE:
+            return ""  # a tag-sequence flag (e.g. Scotland) — keep the whole answer untouched
+        if code == _VS16 or code in _SKIN_TONES:
+            end += 1
+        elif code == _ZWJ and end + 1 < len(text) and _is_emoji_base(ord(text[end + 1])):
             end += 2  # a ZWJ plus the emoji base it joins (family / profession sequences)
-        elif code in _EMOJI_CONTINUATION:
-            end += 1  # VS16, a keycap, a skin-tone modifier, or a regional-indicator partner
         else:
-            break
+            break  # a lone trailing ZWJ is left out of the prefix, never leaked into the icon
     return text[:end]
+
+
+def _clean_remainder(text: str) -> str:
+    """Trim whitespace plus any stray zero-width joiner / variation selector from a remainder."""
+    return text.strip().strip("\u200d\ufe0f").strip()
 
 
 def _answer_media(answer: str) -> dict:
@@ -1709,9 +1752,10 @@ def _answer_media(answer: str) -> dict:
 
     A leading custom-emoji token (``<:name:id>`` / ``<a:name:id>``) becomes ``{"id": <id>}``
     with the token stripped from the text, falling back to the token's name when nothing else
-    remains (Discord rejects empty answer text). A leading unicode emoji becomes
-    ``{"name": <emoji>}`` with the emoji stripped, except an emoji-only answer keeps its
-    original text and carries no emoji field.
+    remains (Discord rejects empty answer text). A confidently well-formed leading unicode
+    emoji becomes ``{"name": <emoji>}`` with the emoji stripped; an emoji-only answer, or one
+    whose leading glyph is not confidently a single emoji, keeps its original text and carries
+    no emoji field.
     """
     custom = _CUSTOM_EMOJI_RE.match(answer)
     if custom is not None:
@@ -1720,7 +1764,7 @@ def _answer_media(answer: str) -> dict:
         return {"text": remainder or name, "emoji": {"id": emoji_id}}
     prefix = _emoji_prefix(answer)
     if prefix:
-        remainder = answer[len(prefix) :].strip()
+        remainder = _clean_remainder(answer[len(prefix) :])
         if remainder:
             return {"text": remainder, "emoji": {"name": prefix}}
         return {"text": answer}  # emoji-only: keep the original string, no emoji field

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "1.8.0"
+VERSION = "1.9.0"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.9.0",
+        "date": "2026-08-26",
+        "title": "Post polls with /poll",
+        "changes": [
+            "Ask the room anything with /poll in Discord. Type your question and answers, pick "
+            "how long voting stays open, and the bot posts a native Discord poll right in the "
+            "channel. This replaces the old sesh bot's /poll.",
+        ],
+    },
     {
         "version": "1.8.0",
         "date": "2026-08-25",

--- a/tests/core/events/poll_command_spec.py
+++ b/tests/core/events/poll_command_spec.py
@@ -1,0 +1,282 @@
+"""Specs for the ``/poll`` slash command (membership.discord_commands).
+
+Covers the command definition, the answers-splitting helper, leading-emoji extraction
+(unicode and custom Discord tokens, with the empty-remainder rules), every ephemeral
+validation reply, the public happy-path poll payload, the ``reply(poll=…)`` kwarg, and
+the dispatch + ``/guide`` integration. No Discord REST is touched: ``/poll`` posts its
+poll straight from the interaction response (``defer=False``), so there is nothing to mock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.events import discord_interactions as di
+from core.events.discord_commands import _guide, all_commands, dispatch
+from membership.discord_commands import (
+    _POLL_ANSWER_MAX,
+    _POLL_DUPLICATE,
+    _POLL_QUESTION_TOO_LONG,
+    _POLL_TOO_FEW,
+    _POLL_TOO_MANY,
+    POLL,
+    _answer_media,
+    _emoji_prefix,
+    _poll,
+    _split_answers,
+)
+
+pytestmark = pytest.mark.django_db
+
+# Multi-codepoint emoji written with explicit escapes so the ZWJ / skin-tone / regional /
+# variation-selector joiners are unambiguous in source.
+_FAMILY = "\U0001f468‍\U0001f469‍\U0001f467"  # man + ZWJ + woman + ZWJ + girl
+_THUMB_TONED = "\U0001f44d\U0001f3fd"  # thumbs-up + medium skin tone
+_FLAG_US = "\U0001f1fa\U0001f1f8"  # regional-indicator U + S
+_SUN_VS16 = "☀️"  # sun + variation selector 16
+
+
+def _interaction(**options: object) -> dict:
+    opts = [{"name": name, "value": value} for name, value in options.items()]
+    return {"data": {"options": opts}}
+
+
+def _run(member: object, **options: object) -> dict:
+    return _poll(_interaction(**options), member)
+
+
+def _assert_ephemeral_no_poll(result: dict) -> None:
+    assert result["data"]["flags"] == 64  # ephemeral — only the invoker sees the rejection
+    assert "poll" not in result["data"]  # nothing was posted to the channel
+
+
+# --- Command definition -------------------------------------------------------
+
+
+def describe_command_definition():
+    def it_is_link_gated_public_and_not_deferred():
+        assert POLL.name == "poll"
+        assert (POLL.requires_link, POLL.ephemeral, POLL.defer) == (True, False, False)
+        assert POLL.scope == "guild"
+
+    def it_exposes_question_and_answers_first_then_optionals():
+        opts = POLL.to_api_dict()["options"]
+        assert [o["name"] for o in opts] == ["question", "answers", "duration", "multiselect"]
+        required = [o.get("required", False) for o in opts]
+        assert required[:2] == [True, True]
+        assert not any(required[2:])
+
+    def it_offers_the_documented_duration_choices_as_integers():
+        duration = next(o for o in POLL.to_api_dict()["options"] if o["name"] == "duration")
+        assert duration["type"] == 4  # INTEGER — a string option with int values fails registration
+        assert [c["value"] for c in duration["choices"]] == [1, 4, 8, 24, 72, 168, 336, 768]
+        assert all(isinstance(c["value"], int) for c in duration["choices"])
+        default = next(c for c in duration["choices"] if c["value"] == 24)
+        assert "(default)" in default["name"]
+
+    def it_makes_multiselect_a_boolean_option():
+        multiselect = next(o for o in POLL.to_api_dict()["options"] if o["name"] == "multiselect")
+        assert multiselect["type"] == 5
+        assert multiselect.get("required", False) is False
+
+
+# --- Answers splitting --------------------------------------------------------
+
+
+def describe_split_answers():
+    def it_splits_on_semicolons():
+        assert _split_answers("Alien; Clue; The Thing") == ["Alien", "Clue", "The Thing"]
+
+    def it_splits_on_pipes_when_there_is_no_semicolon():
+        assert _split_answers("Alien|Clue|The Thing") == ["Alien", "Clue", "The Thing"]
+
+    def it_prefers_semicolons_so_a_pipe_survives_inside_an_answer():
+        assert _split_answers("Alien; Clue|The Thing") == ["Alien", "Clue|The Thing"]
+
+    def it_trims_each_piece():
+        assert _split_answers("  Alien ;  Clue  ") == ["Alien", "Clue"]
+
+    def it_drops_empty_segments():
+        assert _split_answers("Alien;;Clue;") == ["Alien", "Clue"]
+
+
+# --- Emoji extraction ---------------------------------------------------------
+
+
+def describe_answer_media():
+    def it_leaves_a_plain_answer_untouched():
+        assert _answer_media("Alien") == {"text": "Alien"}
+
+    def it_pulls_a_leading_unicode_emoji_into_the_icon():
+        assert _answer_media("🎬 Alien") == {"text": "Alien", "emoji": {"name": "🎬"}}
+
+    def it_reads_a_dingbat_range_emoji():
+        assert _answer_media("✅ Yes") == {"text": "Yes", "emoji": {"name": "✅"}}
+
+    def it_keeps_a_skin_tone_modifier_with_its_base():
+        assert _answer_media(f"{_THUMB_TONED} Great") == {"text": "Great", "emoji": {"name": _THUMB_TONED}}
+
+    def it_keeps_a_variation_selector_with_its_base():
+        assert _answer_media(f"{_SUN_VS16} Sunny") == {"text": "Sunny", "emoji": {"name": _SUN_VS16}}
+
+    def it_keeps_a_regional_indicator_flag_whole():
+        assert _answer_media(f"{_FLAG_US} USA") == {"text": "USA", "emoji": {"name": _FLAG_US}}
+
+    def it_keeps_a_zwj_family_sequence_whole():
+        assert _answer_media(f"{_FAMILY} Family") == {"text": "Family", "emoji": {"name": _FAMILY}}
+
+    def it_keeps_an_emoji_only_answer_as_text_with_no_emoji_field():
+        assert _answer_media("🎬") == {"text": "🎬"}
+
+    def it_preserves_an_emoji_only_answer_including_trailing_whitespace():
+        assert _answer_media("🎬  ") == {"text": "🎬  "}
+
+    def it_pulls_a_leading_custom_emoji_token_into_the_icon():
+        assert _answer_media("<:thing:123> Yes") == {"text": "Yes", "emoji": {"id": "123"}}
+
+    def it_reads_an_animated_custom_emoji_token():
+        assert _answer_media("<a:party:42> Party") == {"text": "Party", "emoji": {"id": "42"}}
+
+    def it_uses_the_token_name_when_the_answer_is_only_a_custom_token():
+        assert _answer_media("<:alien:999>") == {"text": "alien", "emoji": {"id": "999"}}
+
+
+def describe_emoji_prefix():
+    def it_is_empty_for_an_empty_string():
+        assert _emoji_prefix("") == ""
+
+    def it_is_empty_when_the_answer_does_not_start_with_an_emoji():
+        assert _emoji_prefix("Alien") == ""
+
+    def it_stops_at_the_first_non_emoji_character():
+        assert _emoji_prefix("🎬 Alien") == "🎬"
+
+    def it_captures_a_zwj_sequence_whole():
+        assert _emoji_prefix(f"{_FAMILY} Family") == _FAMILY
+
+
+# --- Validation (each ephemeral, nothing posted) ------------------------------
+
+
+def describe_validation():
+    def it_rejects_fewer_than_two_answers(linked_member):
+        result = _run(linked_member(), question="Which?", answers="Alien")
+        assert result["data"]["content"] == _POLL_TOO_FEW
+        _assert_ephemeral_no_poll(result)
+
+    def it_rejects_more_than_ten_answers(linked_member):
+        answers = "; ".join(f"Choice {n}" for n in range(11))
+        result = _run(linked_member(), question="Which?", answers=answers)
+        assert result["data"]["content"] == _POLL_TOO_MANY
+        _assert_ephemeral_no_poll(result)
+
+    def it_rejects_an_answer_longer_than_the_limit(linked_member):
+        long_answer = "x" * (_POLL_ANSWER_MAX + 1)
+        result = _run(linked_member(), question="Which?", answers=f"{long_answer}; Clue")
+        assert f"{_POLL_ANSWER_MAX} characters" in result["data"]["content"]
+        assert 'Shorten "' in result["data"]["content"]
+        _assert_ephemeral_no_poll(result)
+
+    def it_measures_the_answer_limit_after_stripping_the_emoji(linked_member):
+        # 55 x's plus a leading emoji is 57 raw characters but exactly 55 after extraction,
+        # so it is accepted — proving the limit applies to the post-extraction text.
+        exactly_max = "x" * _POLL_ANSWER_MAX
+        result = _run(linked_member(), question="Which?", answers=f"🎬 {exactly_max}; Clue")
+        assert "poll" in result["data"]
+
+    def it_rejects_a_question_longer_than_the_limit(linked_member):
+        result = _run(linked_member(), question="q" * 301, answers="Alien; Clue")
+        assert result["data"]["content"] == _POLL_QUESTION_TOO_LONG
+        _assert_ephemeral_no_poll(result)
+
+    def it_rejects_duplicate_answers(linked_member):
+        result = _run(linked_member(), question="Which?", answers="Alien; Alien")
+        assert result["data"]["content"] == _POLL_DUPLICATE
+        _assert_ephemeral_no_poll(result)
+
+    def it_detects_duplicates_after_emoji_extraction(linked_member):
+        result = _run(linked_member(), question="Which?", answers="🎬 Alien; Alien")
+        assert result["data"]["content"] == _POLL_DUPLICATE
+        _assert_ephemeral_no_poll(result)
+
+
+# --- Happy path ---------------------------------------------------------------
+
+
+def describe_happy_path():
+    def it_posts_a_public_poll_with_the_default_duration_and_multiselect_off(linked_member):
+        member = linked_member(preferred_name="Nova")
+        result = _run(member, question="Which movie?", answers="Alien; Clue; The Thing")
+
+        assert result["type"] == 4
+        assert result["data"]["flags"] == 0  # public — a poll must be votable in the channel
+        poll = result["data"]["poll"]
+        assert poll["question"] == {"text": "Which movie?"}
+        assert poll["answers"] == [
+            {"poll_media": {"text": "Alien"}},
+            {"poll_media": {"text": "Clue"}},
+            {"poll_media": {"text": "The Thing"}},
+        ]
+        assert poll["duration"] == 24
+        assert poll["allow_multiselect"] is False
+
+    def it_credits_the_asker_and_labels_the_duration_and_pick_mode(linked_member):
+        member = linked_member(preferred_name="Nova")
+        content = _run(member, question="Which movie?", answers="Alien; Clue")["data"]["content"]
+        assert "Nova" in content
+        assert "1 day" in content
+        assert "pick one" in content
+
+    def it_honors_an_explicit_duration_and_multiselect(linked_member):
+        member = linked_member(preferred_name="Nova")
+        result = _run(member, question="Which?", answers="Alien; Clue", duration=72, multiselect=True)
+        poll = result["data"]["poll"]
+        assert poll["duration"] == 72
+        assert poll["allow_multiselect"] is True
+        content = result["data"]["content"]
+        assert "3 days" in content
+        assert "pick any" in content
+
+    def it_carries_answer_emoji_into_the_poll_media(linked_member):
+        member = linked_member(preferred_name="Nova")
+        result = _run(member, question="Which?", answers="🎬 Alien; <:fire:7> Clue")
+        assert result["data"]["poll"]["answers"] == [
+            {"poll_media": {"text": "Alien", "emoji": {"name": "🎬"}}},
+            {"poll_media": {"text": "Clue", "emoji": {"id": "7"}}},
+        ]
+
+
+# --- reply(poll=…) kwarg ------------------------------------------------------
+
+
+def describe_reply_poll_kwarg():
+    def it_includes_the_poll_only_when_given():
+        poll = {"question": {"text": "q"}}
+        assert di.reply("x", ephemeral=False, poll=poll)["data"]["poll"] == poll
+
+    def it_omits_the_poll_key_by_default():
+        assert "poll" not in di.reply("x")["data"]
+
+
+# --- Guide + dispatch integration ---------------------------------------------
+
+
+def describe_guide_listing():
+    def it_lists_poll_among_the_commands():
+        assert "poll" in [cmd.name for cmd in all_commands()]
+
+    def it_describes_poll_in_the_guide_embed():
+        embed = _guide({}, None)["data"]["embeds"][0]
+        assert "/poll" in embed["description"]
+
+
+def describe_dispatch_integration():
+    def it_shows_the_connect_prompt_for_an_unlinked_member(rf):
+        interaction = {
+            "type": 2,
+            "data": {"name": "poll", "options": []},
+            "member": {"user": {"id": "000"}},
+        }
+        result = dispatch(interaction, rf.post("/"))
+        button = result["data"]["components"][0]["components"][0]
+        assert button["url"].endswith("/discord/link/")

--- a/tests/core/events/poll_command_spec.py
+++ b/tests/core/events/poll_command_spec.py
@@ -29,11 +29,16 @@ from membership.discord_commands import (
 pytestmark = pytest.mark.django_db
 
 # Multi-codepoint emoji written with explicit escapes so the ZWJ / skin-tone / regional /
-# variation-selector joiners are unambiguous in source.
+# variation-selector / tag joiners are unambiguous in source.
 _FAMILY = "\U0001f468‍\U0001f469‍\U0001f467"  # man + ZWJ + woman + ZWJ + girl
 _THUMB_TONED = "\U0001f44d\U0001f3fd"  # thumbs-up + medium skin tone
+_STAR_VS16 = "⭐️"  # star (a curated emoji base) + variation selector 16
 _FLAG_US = "\U0001f1fa\U0001f1f8"  # regional-indicator U + S
-_SUN_VS16 = "☀️"  # sun + variation selector 16
+_FLAG_GB = "\U0001f1ec\U0001f1e7"  # regional-indicator G + B
+_SCOTLAND = "\U0001f3f4\U000e0067\U000e0062\U000e0073\U000e0063\U000e0074\U000e007f"  # tag-sequence flag
+_PENCIL = "✎"  # lower-right pencil — a non-emoji dingbat
+_MAHJONG = "\U0001f004"  # mahjong red dragon — excluded by the narrowed base ranges
+_DANGLING_ZWJ = "\U0001f3ac‍"  # clapper + a trailing (dangling) ZWJ
 
 
 def _interaction(**options: object) -> dict:
@@ -117,7 +122,7 @@ def describe_answer_media():
         assert _answer_media(f"{_THUMB_TONED} Great") == {"text": "Great", "emoji": {"name": _THUMB_TONED}}
 
     def it_keeps_a_variation_selector_with_its_base():
-        assert _answer_media(f"{_SUN_VS16} Sunny") == {"text": "Sunny", "emoji": {"name": _SUN_VS16}}
+        assert _answer_media(f"{_STAR_VS16} Star") == {"text": "Star", "emoji": {"name": _STAR_VS16}}
 
     def it_keeps_a_regional_indicator_flag_whole():
         assert _answer_media(f"{_FLAG_US} USA") == {"text": "USA", "emoji": {"name": _FLAG_US}}
@@ -141,6 +146,28 @@ def describe_answer_media():
         assert _answer_media("<:alien:999>") == {"text": "alien", "emoji": {"id": "999"}}
 
 
+def describe_answer_media_conservative_fallbacks():
+    def it_leaves_a_non_emoji_dingbat_answer_untouched():
+        assert _answer_media(f"{_PENCIL} Draw") == {"text": f"{_PENCIL} Draw"}
+
+    def it_leaves_a_mahjong_tile_answer_untouched():
+        assert _answer_media(f"{_MAHJONG} Tile") == {"text": f"{_MAHJONG} Tile"}
+
+    def it_does_not_set_an_emoji_for_two_adjacent_flags():
+        answer = f"{_FLAG_US}{_FLAG_GB} Both"
+        assert _answer_media(answer) == {"text": answer}
+
+    def it_keeps_a_tag_sequence_flag_answer_as_full_text():
+        answer = f"{_SCOTLAND} Scotland"
+        assert _answer_media(answer) == {"text": answer}
+
+    def it_keeps_a_tag_flag_only_answer_visible_as_full_text():
+        assert _answer_media(_SCOTLAND) == {"text": _SCOTLAND}
+
+    def it_never_leaks_a_dangling_zwj_into_the_icon_or_text():
+        assert _answer_media(f"{_DANGLING_ZWJ} Later") == {"text": "Later", "emoji": {"name": "🎬"}}
+
+
 def describe_emoji_prefix():
     def it_is_empty_for_an_empty_string():
         assert _emoji_prefix("") == ""
@@ -153,6 +180,18 @@ def describe_emoji_prefix():
 
     def it_captures_a_zwj_sequence_whole():
         assert _emoji_prefix(f"{_FAMILY} Family") == _FAMILY
+
+    def it_captures_exactly_one_regional_indicator_pair():
+        assert _emoji_prefix(f"{_FLAG_US} USA") == _FLAG_US
+
+    def it_rejects_a_lone_regional_indicator():
+        assert _emoji_prefix("\U0001f1fa X") == ""
+
+    def it_rejects_three_or_more_adjacent_regional_indicators():
+        assert _emoji_prefix(f"{_FLAG_US}{_FLAG_GB}") == ""
+
+    def it_drops_a_trailing_dangling_zwj():
+        assert _emoji_prefix(_DANGLING_ZWJ) == "🎬"
 
 
 # --- Validation (each ephemeral, nothing posted) ------------------------------
@@ -219,6 +258,13 @@ def describe_happy_path():
         ]
         assert poll["duration"] == 24
         assert poll["allow_multiselect"] is False
+        assert result["data"]["allowed_mentions"] == {"parse": []}
+
+    def it_suppresses_mentions_so_a_display_name_cannot_ping(linked_member):
+        member = linked_member(preferred_name="@everyone")
+        result = _run(member, question="Which?", answers="Alien; Clue")
+        assert "@everyone" in result["data"]["content"]  # the raw text is credited...
+        assert result["data"]["allowed_mentions"] == {"parse": []}  # ...but it can never ping
 
     def it_credits_the_asker_and_labels_the_duration_and_pick_mode(linked_member):
         member = linked_member(preferred_name="Nova")
@@ -256,6 +302,13 @@ def describe_reply_poll_kwarg():
 
     def it_omits_the_poll_key_by_default():
         assert "poll" not in di.reply("x")["data"]
+
+    def it_gates_mentions_on_the_poll_path():
+        data = di.reply("hi @everyone", ephemeral=False, poll={"question": {"text": "q"}})["data"]
+        assert data["allowed_mentions"] == {"parse": []}
+
+    def it_leaves_plain_replies_mention_behavior_untouched():
+        assert "allowed_mentions" not in di.reply("hi")["data"]
 
 
 # --- Guide + dispatch integration ---------------------------------------------


### PR DESCRIPTION
Fog Bot gets its own /poll so removing the sesh bot loses zero functionality. Posts a native Discord poll (live bars, counts, voter avatars) in the invoking channel: question, 2-10 answers split on semicolons, emoji answer icons (sesh-style), duration choices up to Discord's 32-day max, optional multi-select, styled attribution header. Five airtight ephemeral validation errors since polls cannot be edited after posting. reply() gains a poll= kwarg (non-deferred path only). No models, no migrations.

Spec: docs/superpowers/plans/2026-08-26-discord-poll-command.md (adversarially reviewed, 7 findings folded in pre-build)

Post-deploy: run register_discord_commands as a Render one-off.

https://claude.ai/code/session_01HXTzkHBXaNLM9nQ41Udtgu