### PR TITLE
fix(brand): remove the Do It Together tagline sitewide (1.9.1)

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-VERSION = "1.9.0"
+VERSION = "1.9.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.9.1",
+        "date": "2026-08-26",
+        "title": "Rebrand cleanup",
+        "changes": [
+            "We retired the old Do It Together tagline from the member portal and our emails. "
+            "We are Past Lives Makerspace everywhere now.",
+        ],
+    },
     {
         "version": "1.9.0",
         "date": "2026-08-26",

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -284,16 +284,6 @@ p:last-child {
     padding: var(--spacing-2xl) var(--spacing-sm) var(--spacing-xl);
 }
 
-.hero__tagline {
-    font-family: var(--font-body);
-    font-size: 0.8rem;
-    font-weight: 700;
-    letter-spacing: 0.25em;
-    text-transform: uppercase;
-    color: var(--color-accent);
-    margin-bottom: var(--spacing-md);
-}
-
 .hero__title {
     font-size: 4rem;
     color: var(--color-text);
@@ -782,14 +772,6 @@ p:last-child {
     width: 100%;
 }
 
-.site-footer__tagline {
-    font-family: var(--font-heading);
-    font-style: italic;
-    font-size: 0.95rem;
-    color: var(--color-accent);
-    margin-bottom: var(--spacing-xs);
-}
-
 .site-footer__copy {
     color: var(--color-text-muted);
 }
@@ -844,10 +826,6 @@ p:last-child {
 
     .hero {
         padding: var(--spacing-xl) var(--spacing-xs) var(--spacing-lg);
-    }
-
-    .hero__tagline {
-        font-size: 0.7rem;
     }
 
     .hero__subtitle {

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <meta name="description" content="Past Lives Member Portal - Portland's community workshop for creators, builders, and makers. Do It Together.">
+    <meta name="description" content="Past Lives Member Portal - Portland's community workshop for creators, builders, and makers.">
     <meta name="theme-color" content="#092E4C">
     <link rel="manifest" href="/static/manifest.json">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -40,7 +40,6 @@
         {% block content %}{% endblock %}
     </main>
     <footer class="site-footer">
-        <p class="site-footer__tagline">Do It Together</p>
         <p class="site-footer__copy">&copy; 2026 Past Lives Member Portal</p>
     </footer>
     {% include "includes/changelog_modal.html" %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,7 +4,6 @@
 
 {% block content %}
 <section class="hero">
-    <p class="hero__tagline">Do It Together</p>
     <h1 class="hero__title">Past Lives</h1>
     <p class="hero__subtitle">Member Portal</p>
     <p class="hero__description">

--- a/templates/membership/emails/notification_shell.html
+++ b/templates/membership/emails/notification_shell.html
@@ -1,8 +1,7 @@
 {% comment %}
 Branded notification shell (EventType.email_shell == "dark", and shared by the
 "light" shell via include). Wraps EVERY notification/announcement email: a navy
-lantern hero with the wordmark and the "Do It Together" tagline in brand gold, a
-gold brand rule, then a bordered white content card carrying the copy fragment, and
+lantern hero with the wordmark, a gold brand rule, then a bordered white content card carrying the copy fragment, and
 the reused _footer below on the pale page background.
 
 Standalone document (does NOT extend _base.html — that grey-card chrome is kept for
@@ -33,7 +32,6 @@ Context: body_html (safe fragment).
             <img src="{% member_base_url %}{% static 'img/favicon.png' %}" width="58" height="58" alt="Past Lives Makerspace" style="display: block; margin: 0 auto 12px; border: 0; outline: none;">
             <div style="font-size: 22px; font-weight: 700; color: #F4EFDD; letter-spacing: 0.02em; line-height: 1.2;">Past Lives Makerspace</div>
         </a>
-        <div style="margin: 11px 0 0; font-size: 11px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase; color: #EEB44B;">Do It Together</div>
     </td>
     </tr>
     <!-- Gold brand rule -->

--- a/templates/membership/emails/notification_shell.html
+++ b/templates/membership/emails/notification_shell.html
@@ -25,7 +25,7 @@ Context: body_html (safe fragment).
 <tr>
 <td align="center">
 <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; width: 100%;">
-    <!-- Hero band: lantern logo, wordmark, gold tagline -->
+    <!-- Hero band: lantern logo, wordmark -->
     <tr>
     <td style="background-color: #092E4C; border-radius: 14px 14px 0 0; padding: 34px 28px 28px; text-align: center;">
         <a href="{% member_base_url %}" style="text-decoration: none;">


### PR DESCRIPTION
## Summary

The Makerspace rebrand removed "Federation of Guilds" everywhere, but the old "Do It Together" tagline survived in four member facing spots. This PR finishes the sweep:

* `templates/home.html`: hero tagline on the login page
* `templates/base.html`: meta description and site footer tagline
* `templates/membership/emails/notification_shell.html`: gold tagline in the branded email header (and its doc comment)
* `static/css/style.css`: now unused `.hero__tagline` and `.site-footer__tagline` rules

A repo wide grep confirms zero remaining occurrences outside historical planning docs.

## Version

`VERSION` bumped to 1.9.1 with a short member facing changelog entry (1.9.0 is claimed by the pending poll modal branch).

## Testing

* `tests/core/home_spec.py`, `tests/hub/home_spec.py`, `tests/hub/release_announcement_spec.py`, `tests/core/context_processors_spec.py`, `tests/core/release_email_spec.py`, `tests/template_comment_lint_spec.py`: 129 passed
* `ruff format --check` and `ruff check` clean on the touched Python file
* Coverage/mutation gates run in CI

https://claude.ai/code/session_017TYZYJSp3SsbsmBBijKD8V