### PR TITLE
fix(discord): modal responses via interaction callback (v1.9.3)

### DIFF
--- a/core/events/discord_commands.py
+++ b/core/events/discord_commands.py
@@ -20,7 +20,14 @@ from dataclasses import dataclass, field
 from importlib import import_module
 from typing import TYPE_CHECKING, Literal
 
-from core.events.discord_interactions import ack_deferred, error_reply, reply, send_followup, unlinked_reply
+from core.events.discord_interactions import (
+    ack_deferred,
+    error_reply,
+    reply,
+    send_followup,
+    send_modal_via_callback,
+    unlinked_reply,
+)
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
@@ -267,6 +274,23 @@ def _dispatch_deferred(cmd: SlashCommand, interaction: Interaction, member: Memb
     return {}
 
 
+def _route_modal(response: dict, interaction: Interaction) -> dict:
+    """Deliver a type-9 modal via the REST callback; anything else passes through.
+
+    Inline type-9 bodies are unreliable from an HTTP interactions endpoint (Discord
+    drops them and the member sees a timeout), so a modal response goes out over the
+    callback REST call — the same shape as the deferred path, which returns ``{}``
+    inline once the REST side has answered. A callback rejection surfaces as an
+    ephemeral reply carrying Discord's own error detail, never a silent timeout.
+    """
+    if response.get("type") != 9:
+        return response
+    detail = send_modal_via_callback(interaction["id"], interaction["token"], response)
+    if detail is None:
+        return {}
+    return reply(f"Discord would not open the form. It said: {detail}", ephemeral=True)
+
+
 def dispatch(interaction: Interaction, request: HttpRequest) -> dict:
     """Route an APPLICATION_COMMAND interaction to its handler and return a reply dict.
 
@@ -293,7 +317,7 @@ def dispatch(interaction: Interaction, request: HttpRequest) -> dict:
         return _dispatch_deferred(cmd, interaction, member)
 
     try:
-        return cmd.handler(interaction, member)
+        return _route_modal(cmd.handler(interaction, member), interaction)
     except Exception:
         logger.exception("Discord command %r handler failed", name)
         return error_reply()
@@ -326,7 +350,7 @@ def dispatch_component(interaction: Interaction, request: HttpRequest) -> dict:
         return unlinked_reply(_link_url(request))
 
     try:
-        return handler.handler(interaction, member)
+        return _route_modal(handler.handler(interaction, member), interaction)
     except Exception:
         logger.exception("Discord component %r handler failed", prefix)
         return error_reply()

--- a/core/events/discord_interactions.py
+++ b/core/events/discord_interactions.py
@@ -305,6 +305,34 @@ def error_reply() -> dict:
 # --- Deferred-response REST helpers (best-effort — log + falsy, never raise) ---
 
 
+def send_modal_via_callback(interaction_id: str, token: str, modal_response: dict) -> str | None:
+    """POST a type-9 modal response to the interaction callback endpoint.
+
+    Inline type-9 bodies from an HTTP interactions endpoint are silently discarded by
+    Discord in some paths (the member just sees "didn't respond in time"), while the
+    REST callback both opens the modal reliably and returns an explicit validation
+    error when the payload is malformed — so every modal goes out this way, mirroring
+    :func:`ack_deferred`'s shape. Returns ``None`` on success; on failure returns a
+    short human-readable detail (logged too) that the caller can surface ephemerally
+    instead of letting the interaction die as a timeout.
+    """
+    try:
+        response = httpx.post(
+            f"{API_BASE}/interactions/{interaction_id}/{token}/callback",
+            json=modal_response,
+            headers=_auth_headers(),
+            timeout=_DEFAULT_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("Discord modal callback failed (network error): %s", exc)
+        return "network error talking to Discord"
+    if response.is_success:
+        return None
+    detail = response.text[:300]
+    logger.warning("Discord modal callback rejected: %s %s", response.status_code, detail)
+    return f"{response.status_code} {detail}"
+
+
 def ack_deferred(interaction_id: str, token: str, *, ephemeral: bool = True) -> bool:
     """POST a type-5 deferred ack so Discord's 3-second clock is satisfied (§5.4).
 
@@ -436,6 +464,7 @@ __all__ = [
     "pong",
     "reply",
     "send_followup",
+    "send_modal_via_callback",
     "string_select",
     "text_display",
     "text_input",

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-VERSION = "1.9.2"
+VERSION = "1.9.3"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
     {
-        "version": "1.9.2",
+        "version": "1.9.3",
         "date": "2026-08-26",
         "title": "RSVP to events, plus friendlier /create and /poll forms",
         "changes": [

--- a/tests/core/events/discord_commands_spec.py
+++ b/tests/core/events/discord_commands_spec.py
@@ -6,6 +6,7 @@ never leak into other specs. All Discord REST (the deferred flow) is mocked with
 
 from __future__ import annotations
 
+import json
 import httpx
 import pytest
 import respx
@@ -450,3 +451,44 @@ def describe_deferred_dispatch():
 
         assert dispatch(interaction, rf.post("/")) == {}  # no raise; already acked
         assert "went wrong" in json.loads(followup.calls.last.request.content)["content"]
+
+
+def describe_modal_response_routing():
+    _CB = "https://discord.com/api/v10/interactions/intM/tokM/callback"
+
+    @pytest.fixture
+    def modal_command(monkeypatch):
+        from core.events import discord_commands as dc
+
+        cmd = dc.SlashCommand(
+            name="modaltest",
+            description="x",
+            handler=lambda interaction, member: {"type": 9, "data": {"custom_id": "t", "title": "T", "components": []}},
+            requires_link=False,
+            defer=False,
+        )
+        monkeypatch.setitem(dc._REGISTRY, "modaltest", cmd)
+        return cmd
+
+    @respx.mock
+    def it_routes_a_modal_through_the_callback_and_returns_empty(settings, rf, modal_command):
+        settings.DISCORD_BOT_TOKEN = "bot"
+        route = respx.post(_CB).mock(return_value=httpx.Response(204))
+        interaction = {"type": 2, "data": {"name": "modaltest", "options": []}, "id": "intM", "token": "tokM"}
+        result = dispatch(interaction, rf.post("/"))
+        assert result == {}
+        assert json.loads(route.calls.last.request.content)["type"] == 9
+
+    @respx.mock
+    def it_surfaces_a_callback_rejection_as_an_ephemeral_reply(settings, rf, modal_command):
+        settings.DISCORD_BOT_TOKEN = "bot"
+        respx.post(_CB).mock(return_value=httpx.Response(400, text='{"message": "Invalid Form Body"}'))
+        interaction = {"type": 2, "data": {"name": "modaltest", "options": []}, "id": "intM", "token": "tokM"}
+        result = dispatch(interaction, rf.post("/"))
+        assert result["type"] == 4
+        assert "would not open the form" in result["data"]["content"]
+        assert "Invalid Form Body" in result["data"]["content"]
+
+    def it_passes_non_modal_replies_through_untouched(rf):
+        interaction = {"type": 2, "data": {"name": "guide", "options": []}, "id": "i", "token": "t"}
+        assert dispatch(interaction, rf.post("/"))["type"] == 4

--- a/tests/core/events/discord_interactions_spec.py
+++ b/tests/core/events/discord_interactions_spec.py
@@ -326,3 +326,30 @@ def describe_parse_modal_values():
         # An unchecked checkbox Discord may echo with no values key at all.
         interaction = {"data": {"components": [{"type": 18, "component": {"custom_id": "c"}}]}}
         assert di.parse_modal_values(interaction) == {}
+
+
+def describe_send_modal_via_callback():
+    _MODAL = {"type": 9, "data": {"custom_id": "x", "title": "T", "components": []}}
+
+    @respx.mock
+    def it_returns_none_on_success_and_posts_the_modal(settings):
+        settings.DISCORD_BOT_TOKEN = "bot-token"
+        route = respx.post(_CALLBACK_URL).mock(return_value=httpx.Response(204))
+        assert di.send_modal_via_callback("int123", "tok456", _MODAL) is None
+        import json
+
+        assert json.loads(route.calls.last.request.content)["type"] == 9
+
+    @respx.mock
+    def it_returns_the_error_detail_on_a_rejection(settings):
+        settings.DISCORD_BOT_TOKEN = "bot-token"
+        respx.post(_CALLBACK_URL).mock(return_value=httpx.Response(400, text='{"message": "Invalid Form Body"}'))
+        detail = di.send_modal_via_callback("int123", "tok456", _MODAL)
+        assert detail is not None
+        assert "400" in detail and "Invalid Form Body" in detail
+
+    @respx.mock
+    def it_reports_a_network_error(settings):
+        settings.DISCORD_BOT_TOKEN = "bot-token"
+        respx.post(_CALLBACK_URL).mock(side_effect=httpx.ConnectError("no route"))
+        assert di.send_modal_via_callback("int123", "tok456", _MODAL) == "network error talking to Discord"


### PR DESCRIPTION
Hotfix: /poll and /create timed out for members after v1.9.2 because Discord drops inline type-9 (modal) bodies from HTTP interaction endpoints. Our server verified fast (~110-250ms, valid JSON, type-4 replies unaffected) — the body was discarded on Discord's side.

Fix: every modal response now goes out over POST /interactions/{id}/{token}/callback (the same proven shape as the deferred path, which returns {} inline after the REST call). If Discord rejects the modal payload, the member gets an ephemeral reply carrying Discord's own error detail instead of a dead timeout — so any residual schema issue becomes visible on the next attempt instead of invisible.

220 targeted tests green (new callback specs + dispatch routing specs + both command spec files). Changelog entry re-stamped to 1.9.3 (fix to a live announced feature).

https://claude.ai/code/session_01HXTzkHBXaNLM9nQ41Udtgu