### PR TITLE
My Classes filter on admin lists (1.16.0)

### DIFF
--- a/classes/models.py
+++ b/classes/models.py
@@ -205,6 +205,16 @@ class ClassOfferingQuerySet(models.QuerySet["ClassOffering"]):
     def for_instructor(self, instructor: "Member") -> "ClassOfferingQuerySet":
         return self.filter(instructor=instructor)
 
+    def hosted_by(self, member: "Member") -> "ClassOfferingQuerySet":
+        """Classes this member teaches or authored (instructor OR created_by).
+
+        Both are direct single-valued FK comparisons on the row, so no join can
+        multiply rows — no ``.distinct()`` needed. ``member`` must be a real
+        Member: callers guard ``None`` (passing ``None`` would match every class
+        with a NULL instructor/author, the opposite of intended).
+        """
+        return self.filter(Q(instructor=member) | Q(created_by=member))
+
     def editable_by(self, member: "Member") -> "ClassOfferingQuerySet":
         """Offerings this member may edit.
 

--- a/classes/spec/views/admin_classes_spec.py
+++ b/classes/spec/views/admin_classes_spec.py
@@ -481,6 +481,207 @@ def describe_edit_class():
         assert offering.slug == "original-2025-01-01"
 
 
+def describe_mine_filter():
+    def it_filters_to_classes_taught_by_me(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        me = admin_user.member
+        ClassOfferingFactory(title="Mine Taught", instructor=me, status=ClassOffering.Status.PUBLISHED)
+        ClassOfferingFactory(title="Not Mine Taught", status=ClassOffering.Status.PUBLISHED)
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1")
+        assert b"Mine Taught" in response.content
+        assert b"Not Mine Taught" not in response.content
+
+    def it_includes_classes_i_authored_but_do_not_teach(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        me = admin_user.member
+        # created_by=me, instructor is a different member (factory default) → still mine.
+        ClassOfferingFactory(title="I Authored This", created_by=me, status=ClassOffering.Status.PUBLISHED)
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1")
+        assert b"I Authored This" in response.content
+
+    def it_excludes_classes_where_i_am_neither(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        me = admin_user.member
+        ClassOfferingFactory(title="Keep Mine", instructor=me, status=ClassOffering.Status.PUBLISHED)
+        # NULL instructor AND NULL author — a memberful "mine" must not match these either.
+        ClassOfferingFactory(
+            title="Orphan Class", instructor=None, created_by=None, status=ClassOffering.Status.PUBLISHED
+        )
+        ClassOfferingFactory(title="Someone Elses", status=ClassOffering.Status.PUBLISHED)
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1")
+        assert b"Keep Mine" in response.content
+        assert b"Orphan Class" not in response.content
+        assert b"Someone Elses" not in response.content
+
+    def it_composes_with_status_and_search(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        me = admin_user.member
+        ClassOfferingFactory(title="Alpha Published", instructor=me, status=ClassOffering.Status.PUBLISHED)
+        ClassOfferingFactory(title="Alpha Draft", instructor=me, status=ClassOffering.Status.DRAFT)
+        ClassOfferingFactory(title="Zeta Published", instructor=me, status=ClassOffering.Status.PUBLISHED)
+        ClassOfferingFactory(title="Alpha NotMine", status=ClassOffering.Status.PUBLISHED)
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1&status=published&q=Alpha")
+        assert b"Alpha Published" in response.content
+        assert b"Alpha Draft" not in response.content  # wrong status
+        assert b"Zeta Published" not in response.content  # does not match q
+        assert b"Alpha NotMine" not in response.content  # not mine
+
+    def it_shows_the_pill_without_an_instructor_slug(admin_user, client, db):
+        # The admin_user's member has no instructor_slug — the exact condition that
+        # hid the old toggle. The pill must render anyway.
+        assert not admin_user.member.instructor_slug
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes"))
+        assert b"My Classes" in response.content
+
+    def it_returns_empty_for_a_user_with_no_member(client, db):
+        from classes.factories import ClassOfferingFactory, UserFactory
+        from classes.models import ClassOffering
+
+        # A superuser passes the admin gate even with no linked Member.
+        user = UserFactory(username="super-nomember@example.com", is_superuser=True, is_staff=True)
+        user.member.delete()
+        # A NULL-instructor/NULL-author class must NOT leak to a memberless "mine".
+        ClassOfferingFactory(
+            title="Orphan Leak", instructor=None, created_by=None, status=ClassOffering.Status.PUBLISHED
+        )
+        client.force_login(user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1")
+        assert response.status_code == 200
+        assert b"Orphan Leak" not in response.content
+        assert response.context["mine_count"] == 0
+
+    def it_ignores_bogus_mine_values(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        me = admin_user.member
+        ClassOfferingFactory(title="My One", instructor=me, status=ClassOffering.Status.PUBLISHED)
+        ClassOfferingFactory(title="Other One", status=ClassOffering.Status.PUBLISHED)
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=yes")
+        assert response.context["mine_active"] is False
+        assert b"My One" in response.content
+        assert b"Other One" in response.content
+
+    def it_counts_my_classes_across_all_statuses(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        me = admin_user.member
+        ClassOfferingFactory(instructor=me, status=ClassOffering.Status.PUBLISHED)
+        ClassOfferingFactory(instructor=me, status=ClassOffering.Status.DRAFT)
+        ClassOfferingFactory(instructor=me, status=ClassOffering.Status.ARCHIVED)
+        ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED)  # not mine
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?status=published")
+        # Count is global — all three of mine, not just the published one.
+        assert response.context["mine_count"] == 3
+
+    def it_counts_my_classes_ignoring_the_search_box(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        me = admin_user.member
+        ClassOfferingFactory(title="Findable Mine", instructor=me, status=ClassOffering.Status.PUBLISHED)
+        ClassOfferingFactory(title="Hidden By Search", instructor=me, status=ClassOffering.Status.PUBLISHED)
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?q=Findable")
+        assert response.context["mine_count"] == 2
+
+    def it_preserves_mine_in_status_pill_urls(admin_user, client, db):
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1&q=pottery")
+        for url, _label, _count, _selected in response.context["status_filters"]:
+            assert "mine=1" in url
+            assert "q=pottery" in url
+
+    def it_preserves_mine_in_base_params(admin_user, client, db):
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1")
+        assert "mine=1" in response.context["base_params"]
+
+    def it_preserves_mine_when_searching(admin_user, client, db):
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1&status=published&instructor=5")
+        html = response.content.decode()
+        # The search form carries the sibling filters as hidden inputs.
+        assert '<input type="hidden" name="mine" value="1">' in html
+        assert '<input type="hidden" name="status" value="published">' in html
+        assert '<input type="hidden" name="instructor" value="5">' in html
+        # Clearing the search drops only q, keeping mine and the rest.
+        clear = response.context["search_clear_url"]
+        assert "mine=1" in clear
+        assert "status=published" in clear
+        assert "q=" not in clear
+
+    def it_strips_bogus_mine_from_computed_urls(admin_user, client, db):
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=yes&status=published")
+        # No pill / clear URL echoes the bogus value or carries a mine at all (it is off).
+        for url, _label, _count, _selected in response.context["status_filters"]:
+            assert "mine" not in url
+        assert "mine" not in response.context["search_clear_url"]
+        assert "mine" not in response.context["mine_clear_url"]
+        assert "mine" not in response.context["instructor_clear_url"]
+        # The toggle is the turn-ON link → a clean mine=1, never mine=yes.
+        assert "mine=yes" not in response.context["mine_toggle_url"]
+        assert "mine=1" in response.context["mine_toggle_url"]
+
+    def it_renders_the_mine_empty_state_with_a_clear_link(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        # The admin owns no classes → mine=1 is empty.
+        ClassOfferingFactory(title="Someone Elses Only", status=ClassOffering.Status.PUBLISHED)
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_classes") + "?mine=1")
+        html = response.content.decode()
+        assert "not listed as instructor or author" in html
+        assert "Show all classes" in html
+        # The clear link drops only mine.
+        assert "mine" not in response.context["mine_clear_url"]
+
+    def it_uses_the_real_user_under_view_as_preview(admin_user, client, db):
+        from classes.factories import ClassOfferingFactory
+        from classes.models import ClassOffering
+
+        me = admin_user.member
+        ClassOfferingFactory(title="Real Mine", instructor=me, status=ClassOffering.Status.PUBLISHED)
+        ClassOfferingFactory(title="Not Real Mine", status=ClassOffering.Status.PUBLISHED)
+        client.force_login(admin_user)
+        session = client.session
+        session["view_as_role"] = "member"
+        session.save()
+        response = client.get(reverse("classes:admin_classes") + "?mine=1")
+        # Mine follows the real request.user.member, not the previewed role.
+        assert b"Real Mine" in response.content
+        assert b"Not Real Mine" not in response.content
+
+
+def describe_table_search_component():
+    def it_leaves_other_table_search_callers_unchanged():
+        from django.template.loader import render_to_string
+
+        # A caller that passes neither preserved_fields nor clear_url (e.g. the
+        # categories admin) gets no hidden inputs and the bare href="?" clear link.
+        html = render_to_string("components/table_search.html", {"q": "anything", "placeholder": "Search…"})
+        assert 'type="hidden"' not in html
+        assert 'href="?"' in html
+
+
 def describe_class_detail():
     def it_shows_the_detail_page(admin_user, client, db):
         from classes.factories import ClassOfferingFactory

--- a/classes/spec/views/admin_registrations_filters_spec.py
+++ b/classes/spec/views/admin_registrations_filters_spec.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import pytest
 from django.urls import reverse
 
-from classes.factories import ClassOfferingFactory, InstructorFactory, RegistrationFactory, UserFactory
+from classes.factories import (
+    CategoryFactory,
+    ClassOfferingFactory,
+    InstructorFactory,
+    RegistrationFactory,
+    UserFactory,
+)
 from classes.models import Registration
 
 pytestmark = pytest.mark.django_db
@@ -108,3 +114,123 @@ def describe_admin_registrations_export():
         body = b"".join(response.streaming_content).decode()
         assert "c-exp@example.com" in body
         assert "p-exp@example.com" not in body
+
+
+def describe_mine_filter():
+    def it_filters_to_registrations_for_classes_i_teach_or_authored(admin_user, client):
+        me = admin_user.member
+        taught = ClassOfferingFactory(slug="reg-mine-taught", instructor=me)
+        authored = ClassOfferingFactory(slug="reg-mine-authored", created_by=me)  # taught by someone else
+        other = ClassOfferingFactory(slug="reg-not-mine")
+        RegistrationFactory(class_offering=taught, email="taught@example.com")
+        RegistrationFactory(class_offering=authored, email="authored@example.com")
+        RegistrationFactory(class_offering=other, email="other@example.com")
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_registrations") + "?mine=1")
+        assert b"taught@example.com" in response.content
+        assert b"authored@example.com" in response.content
+        assert b"other@example.com" not in response.content
+
+    def it_composes_with_status_and_class_filters(admin_user, client):
+        me = admin_user.member
+        a = ClassOfferingFactory(slug="reg-mine-a", instructor=me)
+        b = ClassOfferingFactory(slug="reg-mine-b", instructor=me)
+        RegistrationFactory(class_offering=a, email="a-confirmed@example.com", status=Registration.Status.CONFIRMED)
+        RegistrationFactory(class_offering=a, email="a-pending@example.com", status=Registration.Status.PENDING)
+        RegistrationFactory(class_offering=b, email="b-confirmed@example.com", status=Registration.Status.CONFIRMED)
+        client.force_login(admin_user)
+        response = client.get(
+            reverse("classes:admin_registrations"),
+            {"mine": "1", "status": Registration.Status.CONFIRMED, "class": a.pk},
+        )
+        assert b"a-confirmed@example.com" in response.content
+        assert b"a-pending@example.com" not in response.content  # wrong status
+        assert b"b-confirmed@example.com" not in response.content  # wrong class
+
+    def it_keeps_plain_instructor_param_working(admin_user, client):
+        # instructor=<pk> stays the plain instructor filter — pre-change bookmarks work.
+        teacher = InstructorFactory(full_legal_name="Solo Teacher", instructor_slug="solo-teacher")
+        offering = ClassOfferingFactory(slug="reg-solo", instructor=teacher)
+        other = ClassOfferingFactory(slug="reg-solo-other")
+        RegistrationFactory(class_offering=offering, email="solo-reg@example.com")
+        RegistrationFactory(class_offering=other, email="other-reg@example.com")
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_registrations"), {"instructor": teacher.pk})
+        assert b"solo-reg@example.com" in response.content
+        assert b"other-reg@example.com" not in response.content
+
+    def it_shows_the_toggle_without_an_instructor_slug(admin_user, client):
+        assert not admin_user.member.instructor_slug
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_registrations"))
+        assert b"My Classes" in response.content
+
+    def it_shows_the_toggle_to_a_non_admin_instructor(client):
+        user, _ = _instructor_with_class(username="teach-toggle@example.com", slug="reg-tt")
+        client.force_login(user)
+        response = client.get(reverse("classes:admin_registrations"))
+        assert b"My Classes" in response.content
+
+    def it_narrows_a_guild_leads_scoped_view(client):
+        from tests.membership.factories import GuildFactory
+
+        user = UserFactory(username="guild-lead@example.com")
+        lead = InstructorFactory(user=user, full_legal_name="The Lead", instructor_slug="the-lead")
+        guild = GuildFactory(guild_lead=lead)
+        cat = CategoryFactory(guild=guild)
+        # In the lead's guild but taught by someone else — visible via scope, not mine.
+        others = ClassOfferingFactory(slug="gl-others", category=cat)
+        # The lead's own class — both scoped and mine.
+        own = ClassOfferingFactory(slug="gl-own", instructor=lead)
+        RegistrationFactory(class_offering=others, email="scoped-not-mine@example.com")
+        RegistrationFactory(class_offering=own, email="lead-own@example.com")
+        client.force_login(user)
+        # Without mine, the lead's scoped view shows both.
+        wide = client.get(reverse("classes:admin_registrations"))
+        assert b"scoped-not-mine@example.com" in wide.content
+        assert b"lead-own@example.com" in wide.content
+        # mine=1 narrows to strictly teach-or-authored.
+        narrow = client.get(reverse("classes:admin_registrations") + "?mine=1")
+        assert b"lead-own@example.com" in narrow.content
+        assert b"scoped-not-mine@example.com" not in narrow.content
+
+    def it_returns_empty_for_a_user_with_no_member(client):
+        # Superuser passes the admin gate with no linked Member; a NULL-instructor/
+        # NULL-author class's registrations must not leak to a memberless "mine".
+        user = UserFactory(username="reg-super-nomember@example.com", is_superuser=True, is_staff=True)
+        user.member.delete()
+        orphan = ClassOfferingFactory(slug="reg-orphan", instructor=None, created_by=None)
+        RegistrationFactory(class_offering=orphan, email="orphan-reg@example.com")
+        client.force_login(user)
+        response = client.get(reverse("classes:admin_registrations") + "?mine=1")
+        assert response.status_code == 200
+        assert b"orphan-reg@example.com" not in response.content
+
+    def it_ignores_bogus_mine_values(admin_user, client):
+        me = admin_user.member
+        mine = ClassOfferingFactory(slug="reg-bogus-mine", instructor=me)
+        other = ClassOfferingFactory(slug="reg-bogus-other")
+        RegistrationFactory(class_offering=mine, email="bogus-mine@example.com")
+        RegistrationFactory(class_offering=other, email="bogus-other@example.com")
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_registrations") + "?mine=yes")
+        assert response.context["mine_active"] is False
+        assert b"bogus-mine@example.com" in response.content
+        assert b"bogus-other@example.com" in response.content
+
+    def it_renders_a_hidden_mine_input_when_active(admin_user, client):
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_registrations") + "?mine=1")
+        assert b'<input type="hidden" name="mine" value="1">' in response.content
+
+    def it_renders_the_mine_empty_state_with_a_clear_link(admin_user, client):
+        # Admin owns no classes; one foreign registration exists so the list is not
+        # simply empty — mine=1 must show the mine-specific empty state.
+        other = ClassOfferingFactory(slug="reg-empty-other")
+        RegistrationFactory(class_offering=other, email="present@example.com")
+        client.force_login(admin_user)
+        response = client.get(reverse("classes:admin_registrations") + "?mine=1")
+        html = response.content.decode()
+        assert "None of these belong to a class where you are the instructor or author" in html
+        assert "Show all registrations" in html
+        assert "mine" not in response.context["mine_clear_url"]

--- a/classes/spec/views/registration_export_spec.py
+++ b/classes/spec/views/registration_export_spec.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pytest
 from django.urls import NoReverseMatch, reverse
 
-from classes.factories import ClassOfferingFactory, InstructorFactory, UserFactory
+from classes.factories import ClassOfferingFactory, InstructorFactory, RegistrationFactory, UserFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -59,3 +59,29 @@ def describe_teach_class_export_removed():
         resp = client.get(reverse("classes:teach_class_registrations", kwargs={"pk": mine.pk}))
         assert resp.status_code == 200
         assert b"Export Data" not in resp.content
+
+
+def describe_mine_filter_in_export():
+    def it_respects_the_mine_filter(admin_user, client):
+        me = admin_user.member
+        mine = ClassOfferingFactory(slug="exp-mine", instructor=me)
+        other = ClassOfferingFactory(slug="exp-not-mine")
+        RegistrationFactory(class_offering=mine, email="mine-export@example.com")
+        RegistrationFactory(class_offering=other, email="notmine-export@example.com")
+        client.force_login(admin_user)
+        resp = client.get(reverse("classes:admin_registrations_export") + "?mine=1")
+        body = b"".join(resp.streaming_content).decode()
+        assert "mine-export@example.com" in body
+        assert "notmine-export@example.com" not in body
+
+    def it_exports_nothing_for_a_memberless_user_with_mine(client):
+        # The None-guard asserted through the export path: a dropped guard would leak
+        # every registration of NULL-instructor/NULL-author classes into a download.
+        user = UserFactory(username="exp-super-nomember@example.com", is_superuser=True, is_staff=True)
+        user.member.delete()
+        orphan = ClassOfferingFactory(slug="exp-orphan", instructor=None, created_by=None)
+        RegistrationFactory(class_offering=orphan, email="orphan-export@example.com")
+        client.force_login(user)
+        resp = client.get(reverse("classes:admin_registrations_export") + "?mine=1")
+        body = b"".join(resp.streaming_content).decode()
+        assert "orphan-export@example.com" not in body

--- a/classes/spec/views/roster_actions_spec.py
+++ b/classes/spec/views/roster_actions_spec.py
@@ -544,26 +544,27 @@ def describe_admin_registrations_instructor_filter():
         content = client.get(reverse("classes:admin_registrations"), {"instructor": "bogus"}).content.decode()
         assert "anyone@example.com" in content
 
-    def it_renders_mine_only_for_an_admin_with_an_instructor_profile(admin_user, client):
+    def it_renders_my_classes_for_an_admin_with_an_instructor_profile(admin_user, client):
         member = admin_user.member
         member.instructor_slug = "admin-teaches"
         member.save(update_fields=["instructor_slug"])
         client.force_login(admin_user)
         content = client.get(reverse("classes:admin_registrations")).content.decode()
-        assert "Mine Only" in content
+        assert "My Classes" in content
 
-    def it_hides_mine_only_for_an_admin_with_no_instructor_profile(admin_user, client):
+    def it_still_shows_my_classes_for_an_admin_with_no_instructor_profile(admin_user, client):
+        # The old Mine Only toggle was gated on instructor_slug — that gate was the
+        # bug. My Classes is always visible now.
+        assert not admin_user.member.instructor_slug
         client.force_login(admin_user)
         content = client.get(reverse("classes:admin_registrations")).content.decode()
-        assert "Mine Only" not in content
+        assert "My Classes" in content
 
     def it_preserves_other_get_params_on_the_toggle(admin_user, client):
-        member = admin_user.member
-        member.instructor_slug = "admin-teaches2"
-        member.save(update_fields=["instructor_slug"])
         client.force_login(admin_user)
         content = client.get(reverse("classes:admin_registrations"), {"status": "confirmed"}).content.decode()
-        assert f"status=confirmed&amp;instructor={member.pk}" in content
+        # The My Classes toggle keeps the active status filter and turns mine on.
+        assert "status=confirmed&amp;mine=1" in content
 
     def it_applies_the_filter_to_the_csv_export(admin_user, client):
         client.force_login(admin_user)
@@ -581,6 +582,8 @@ def describe_admin_registrations_instructor_filter():
         RegistrationFactory(email="unscoped@example.com")
         content = client.get(reverse("classes:admin_registrations")).content.decode()
         assert 'name="instructor"' not in content
-        assert "Mine Only" not in content
+        # The instructor <select> stays admin-only, but My Classes is shown to
+        # everyone who reaches the page (the non-admin instructor can narrow too).
+        assert "My Classes" in content
         assert "scoped@example.com" in content
         assert "unscoped@example.com" not in content

--- a/classes/views.py
+++ b/classes/views.py
@@ -1078,11 +1078,12 @@ def _scoped_registrations(request: HttpRequest) -> QuerySet[Registration]:
 
 
 def _filter_registrations(request: HttpRequest, qs: QuerySet[Registration]) -> QuerySet[Registration]:
-    """Apply the optional ``status``, ``class``, and ``instructor`` GET filters to a registration queryset.
+    """Apply the optional ``status``, ``class``, ``instructor``, and ``mine`` GET filters.
 
     ``instructor`` mirrors the ``admin_classes`` pattern: validated as an int and
-    silently ignored when bogus. The CSV export reuses this, so every filter
-    applies there for free.
+    silently ignored when bogus. ``mine=1`` narrows to registrations of classes the
+    real logged-in user teaches or authored (via ``ClassOffering.hosted_by``). The
+    CSV export reuses this, so every filter — including ``mine`` — applies there for free.
     """
     status = request.GET.get("status", "")
     if status in Registration.Status.values:
@@ -1093,6 +1094,17 @@ def _filter_registrations(request: HttpRequest, qs: QuerySet[Registration]) -> Q
     raw_instructor = request.GET.get("instructor", "")
     if raw_instructor.isdigit():
         qs = qs.filter(class_offering__instructor_id=int(raw_instructor))
+    if request.GET.get("mine", "") == "1":
+        # "Mine" is defined once, on the queryset — reuse it via class_offering__in
+        # rather than inlining a second copy of the Q. A memberless viewer gets
+        # qs.none(): hosted_by(None) would match NULL-instructor/NULL-author classes
+        # and leak their registrations (including through the CSV export).
+        own_member = getattr(request.user, "member", None)
+        qs = (
+            qs.filter(class_offering__in=ClassOffering.objects.hosted_by(own_member))
+            if own_member is not None
+            else qs.none()
+        )
     return qs
 
 
@@ -2086,10 +2098,54 @@ def admin_classes(request: HttpRequest) -> HttpResponse:
     if instructor_filter:
         qs = qs.filter(instructor_id=instructor_filter)  # type: ignore[misc]  # Django coerces the str PK at query time
 
+    # "My Classes": classes I teach or authored. Always available; "me" is the real
+    # logged-in user's member even under a view-as preview. A bogus mine value is
+    # off (matching how the sibling filters ignore junk). The memberless guard is
+    # load-bearing: hosted_by(None) would match every NULL-instructor/NULL-author class.
+    mine_active = request.GET.get("mine", "") == "1"
+    own_member = getattr(request.user, "member", None)
+    if mine_active:
+        # hosted_by / none() return the base queryset type; qs carries annotate() aliases.
+        qs = qs.hosted_by(own_member) if own_member is not None else qs.none()  # type: ignore[assignment]
+
     status_counts = {row["status"]: row["count"] for row in base.values("status").annotate(count=Count("pk"))}
-    filters = [("", "All", base.count())] + [
-        (choice.value, choice.label, status_counts.get(choice.value, 0)) for choice in ClassOffering.Status
+    # mine_count is global — all statuses, ignoring q and the Instructor dropdown —
+    # to match how the status-pill counts ignore the search box and each other.
+    mine_count = base.hosted_by(own_member).count() if own_member is not None else 0
+
+    # Every view-computed URL starts from a normalized copy of the GET params: a
+    # bogus mine value (anything but "1") is stripped, not echoed, so cruft never
+    # rides along on subsequent links.
+    normalized = request.GET.copy()
+    if normalized.get("mine", "") != "1":
+        normalized.pop("mine", None)
+
+    def _url_without(*drop: str, **add: str) -> str:
+        params = normalized.copy()
+        for key in ("page", *drop):
+            params.pop(key, None)
+        for key, value in add.items():
+            params[key] = value
+        return params.urlencode()
+
+    mine_toggle_url = _url_without("mine") if mine_active else _url_without(mine="1")
+    status_filters = [
+        (
+            _url_without("status", **({"status": value} if value else {})),
+            label,
+            base.count() if not value else status_counts.get(value, 0),
+            status_filter == value,
+        )
+        for value, label in [("", "All"), *[(c.value, c.label) for c in ClassOffering.Status]]
     ]
+    search_clear_url = _url_without("q")
+    _search_preserved = normalized.copy()
+    for key in ("q", "page"):
+        _search_preserved.pop(key, None)
+    search_preserved_fields = list(_search_preserved.items())
+    mine_clear_url = _url_without("mine")
+    instructor_clear_url = _url_without("instructor")
+
     from membership.models import Member as MemberModel
 
     instructors = MemberModel.objects.filter(instructor_slug__gt="").order_by("full_legal_name")
@@ -2106,10 +2162,17 @@ def admin_classes(request: HttpRequest) -> HttpResponse:
         {
             "active_tab": "classes",
             "pending_count": ClassOffering.objects.pending_review().count(),
-            "status_filters": filters,
+            "status_filters": status_filters,
             "selected_status": status_filter,
             "instructors": instructors,
             "selected_instructor": instructor_filter,
+            "mine_active": mine_active,
+            "mine_count": mine_count,
+            "mine_toggle_url": mine_toggle_url,
+            "mine_clear_url": mine_clear_url,
+            "instructor_clear_url": instructor_clear_url,
+            "search_preserved_fields": search_preserved_fields,
+            "search_clear_url": search_clear_url,
             **table,
         },
     )
@@ -2838,23 +2901,36 @@ def admin_registrations(request: HttpRequest) -> HttpResponse:
 
     # The instructor filter UI is for actual admins only — non-admin visitors are
     # already scoped to their own classes, so a filter that can't widen anything
-    # would just confuse. "Mine Only" renders when the acting admin also teaches.
+    # would just confuse.
     view_as = getattr(request, "view_as", None)
     is_actual_admin = view_as is not None and view_as.has_actual("admin")
     instructors = None
-    mine_only_pk = ""
-    mine_only_params = ""
     if is_actual_admin:
         from membership.models import Member as MemberModel
 
         instructors = MemberModel.objects.filter(instructor_slug__gt="").order_by("full_legal_name")
-        own_member = getattr(request.user, "member", None)
-        if own_member is not None and own_member.instructor_slug:
-            mine_only_pk = str(own_member.pk)
-            preserved = request.GET.copy()
-            preserved.pop("instructor", None)
-            preserved.pop("page", None)
-            mine_only_params = preserved.urlencode()
+
+    # "My Classes": registrations for classes the real logged-in user teaches or
+    # authored. Always rendered — no instructor_slug gate (that gate was the bug that
+    # hid the old toggle) — and "me" is the real user even under a view-as preview.
+    # A bogus mine value is off and stripped from the computed URLs so cruft never
+    # rides along. The actual filtering (and its memberless guard) lives in
+    # _filter_registrations so the CSV export inherits it.
+    mine_active = request.GET.get("mine", "") == "1"
+    normalized = request.GET.copy()
+    if normalized.get("mine", "") != "1":
+        normalized.pop("mine", None)
+    toggle = normalized.copy()
+    toggle.pop("page", None)
+    if mine_active:
+        toggle.pop("mine", None)
+    else:
+        toggle["mine"] = "1"
+    mine_toggle_url = toggle.urlencode()
+    mine_clear = normalized.copy()
+    mine_clear.pop("mine", None)
+    mine_clear.pop("page", None)
+    mine_clear_url = mine_clear.urlencode()
     return render(
         request,
         "classes/admin/registrations.html",
@@ -2867,8 +2943,9 @@ def admin_registrations(request: HttpRequest) -> HttpResponse:
             "show_instructor_filter": is_actual_admin,
             "instructors": instructors,
             "instructor_filter": request.GET.get("instructor", ""),
-            "mine_only_pk": mine_only_pk,
-            "mine_only_params": mine_only_params,
+            "mine_active": mine_active,
+            "mine_toggle_url": mine_toggle_url,
+            "mine_clear_url": mine_clear_url,
             **table,
         },
     )

--- a/docs/superpowers/plans/2026-08-27-admin-mine-filters.md
+++ b/docs/superpowers/plans/2026-08-27-admin-mine-filters.md
@@ -1,0 +1,277 @@
+# "My Classes" Filter on the Admin Classes & Registrations Lists — Spec & Implementation Plan
+
+**Status:** Spec only — not yet approved to build.
+**Date:** 2026-08-27
+**Surface:** Classes admin — `/classes/admin/classes/` (`templates/classes/admin/classes_list.html`) and `/classes/admin/registrations/` (`templates/classes/admin/registrations.html`)
+**Related:** none
+
+---
+
+## 1. Summary
+
+An admin who also teaches (or authors) classes has no quick way to see *their own* slice of the two big admin lists. On the Classes tab there is no mine-style affordance at all — just the Instructor dropdown, which requires knowing to pick yourself. On the Registrations tab a "Mine Only" link exists but is invisible unless the acting admin happens to have an `instructor_slug` set, and it only matches classes where you are the listed *instructor*, missing classes you authored but someone else teaches. This adds an always-visible **My Classes** toggle to both lists: one click filters to classes where you are the instructor **or** the author, composing cleanly with every existing filter, search, sort, and the CSV export.
+
+### Locked decisions (from brainstorm Q&A)
+
+| Decision | Choice |
+|---|---|
+| Semantics of "mine" | `Q(instructor=me) \| Q(created_by=me)` — classes I teach or authored. **Not** `editable_by` (admins can edit everything, so it filters nothing). Stated in a `.pl-help` tooltip on the control. |
+| Visibility | Always visible to everyone who can reach these pages. Never gated on `instructor_slug` — that gate is exactly the bug that hid the old toggle. |
+| Who is "me" | The real logged-in user's member (`request.user.member`), even under view-as preview — matches the old Mine Only behavior. |
+| Composition | ANDs with everything already there: status pills, search, Instructor dropdown, Class/Status selects, sort, pagination, CSV export. |
+| Registrations back-compat | The old `instructor=<own pk>` trick is **not migrated** — `instructor=` keeps its unchanged meaning (plain instructor filter), so old bookmarks still work. The new toggle uses its own `mine=1` param. |
+| Empty state | Friendly message plus a one-click link that clears only the mine filter. Plain language, no dashes. |
+
+## 2. What already exists (reuse, don't reinvent)
+
+| Need | Existing thing | Location |
+|---|---|---|
+| Classes list view (status pills w/ counts, Instructor select, search, sort) | `admin_classes` | `classes/views.py:2046` |
+| Registrations list view | `admin_registrations` | `classes/views.py:2828` |
+| Shared GET-filter helper (status/class/instructor) that the **CSV export reuses** | `_filter_registrations` | `classes/views.py:1080` |
+| Role scoping (admins see all; instructors/guild leads see `editable_by`) | `_scoped_registrations` | `classes/views.py:1065` |
+| Search/sort/pagination + `base_params` that **carries any extra GET param** (so `mine=1` survives sort headers, pagination, and the export link with zero new plumbing) | `prepare_table` | `classes/table.py:12` |
+| Sort headers / pagination that consume `base_params` | `{% sort_header %}` / `table_pagination.html` | `classes/templatetags/`, `templates/components/` |
+| Pill styling with a muted count | Status pills | `templates/classes/admin/classes_list.html:9-14` |
+| Toggle-link pill pattern (`✓` + `hub-btn--primary` when active) | Old "Mine Only" link | `templates/classes/admin/registrations.html:30-36` |
+| Help tooltip | `.pl-help` bubble (CSS-only) | `static/css/hub.css`, FRONTEND.md §Help tooltip |
+| The two FKs behind "mine" | `ClassOffering.instructor` (`:404`, nullable), `ClassOffering.created_by` (`:492`, nullable, `SET_NULL`) | `classes/models.py` |
+| Queryset home for the new predicate | `ClassOfferingQuerySet` (`for_instructor`, `editable_by`) | `classes/models.py:205-221` |
+| Filter rows that already flex-wrap on mobile | `.admin-toolbar` / `.admin-filters` | `static/css/hub.css:3116-3134` |
+
+Gaps to close (all small):
+
+1. No `hosted_by` predicate on `ClassOfferingQuerySet`.
+2. `admin_classes` has no `mine` handling, and its status-pill hrefs are hardcoded `?status=X` / `.` — they currently drop `q` and `instructor` too, so a mine flag would not survive a status click. The pill URLs must be view-computed and param-preserving.
+3. **The shared search component drops every sibling param.** `components/table_search.html` is its own GET form submitting only `q`, and its clear link is a bare `href="?"` that nukes everything. Sequence today-plus-mine: click My Classes → type a search → mine (and status, and instructor) silently vanish. The component needs an opt-in way to carry sibling params. It is shared by five templates (`classes_list.html`, `categories.html`, `discount_codes.html`, `registration_questions.html`, `hub/help_search.html`), so the mechanism must be backward compatible — callers that pass nothing behave exactly as today.
+4. `_filter_registrations` has no `mine` handling.
+5. The registrations template's Mine Only block is gated and narrow; it gets replaced.
+
+## 3. Where the code lives
+
+```
+classes/models.py                                  # ClassOfferingQuerySet.hosted_by()
+classes/views.py                                   # admin_classes, _filter_registrations, admin_registrations
+templates/components/table_search.html             # opt-in preserved-params + clear-URL support (backward compatible)
+templates/classes/admin/classes_list.html          # My Classes pill, param-preserving status pills + search, empty state
+templates/classes/admin/registrations.html         # My Classes toggle (replaces Mine Only), empty state
+static/css/hub.css                                 # .pl-filter-divider (one tiny rule + mobile hide)
+classes/spec/views/admin_classes_spec.py           # extend
+classes/spec/views/admin_registrations_filters_spec.py  # extend
+classes/spec/views/registration_export_spec.py     # extend (export respects mine)
+```
+
+No new files, no migrations.
+
+## 4. Data model
+
+None. No schema changes; both FKs exist.
+
+## 5. Business logic (fat models)
+
+One queryset method on `ClassOfferingQuerySet` (next to `for_instructor` / `editable_by`):
+
+```python
+def hosted_by(self, member: "Member") -> "ClassOfferingQuerySet":
+    """Classes this member teaches or authored (instructor OR created_by)."""
+    return self.filter(Q(instructor=member) | Q(created_by=member))
+```
+
+- No `.distinct()` — both are direct single-valued FK comparisons on the row; no join can multiply rows.
+- `member` must be a real Member. **Callers guard `None`** (passing `None` would match every class with a NULL instructor/author — the opposite of intended). Views do `qs.none()` when the user has no linked member.
+
+### View changes
+
+**`admin_classes`** (`classes/views.py:2046`):
+
+- Parse `mine = request.GET.get("mine", "") == "1"` (any other value silently off, matching how the sibling filters ignore bogus values).
+- `own_member = getattr(request.user, "member", None)`.
+- After the existing status/instructor filtering: `if mine: qs = qs.hosted_by(own_member) if own_member else qs.none()`.
+- Pill count: `mine_count = base.hosted_by(own_member).count() if own_member else 0` (on `base`, i.e. all statuses **and ignoring `q` and the Instructor dropdown** — the same global convention as the status-pill counts, which ignore the search box and each other; a filter-aware count would disagree with its sibling pills).
+- Compute param-preserving URLs in the view (the same `QueryDict.copy()` / pop pattern the old `mine_only_params` used). All computed URLs start from a **normalized** copy of the GET params: a bogus `mine` value (anything other than `1`) is stripped, not echoed, so cruft never rides along on every subsequent link.
+  - `mine_toggle_url` — normalized GET minus `page`, with `mine=1` added (or removed, when already on).
+  - Status pill URLs — for each pill, normalized GET minus `page` and `status`, plus its own `status=<value>` (nothing extra for "All"). This is what makes mine (and, as a side benefit, `q` and `instructor` — dropped today) survive a status click. Pass the pills as `(url, label, count, is_selected)` tuples so the template stays dumb.
+  - `search_preserved_fields` — a list of `(name, value)` pairs for the search form's hidden inputs: normalized GET minus `q` and `page` (so `status`, `instructor`, `mine`, `sort`, `dir` all survive a search).
+  - `search_clear_url` — normalized GET minus `q` and `page` (the clear-search ✕ drops only the search, not the other filters).
+- Context additions: `mine_active`, `mine_count`, `mine_toggle_url`, `search_preserved_fields`, `search_clear_url`; `status_filters` becomes the tuple list above.
+
+**`_filter_registrations`** (`classes/views.py:1080`) — the mine filter lives here so the **CSV export inherits it for free**, exactly as the docstring promises for the other filters. The predicate is **defined once** — `hosted_by` is the single source of truth; this call site reuses it rather than hand-inlining a second copy of the `Q(...)`:
+
+```python
+if request.GET.get("mine", "") == "1":
+    own_member = getattr(request.user, "member", None)
+    qs = (
+        qs.filter(class_offering__in=ClassOffering.objects.hosted_by(own_member))
+        if own_member
+        else qs.none()
+    )
+```
+
+Same `None`-guard as the classes view: a memberless user under `mine=1` gets `qs.none()`, never a `hosted_by(None)` call (which would match NULL-instructor/NULL-author classes and leak their registrations — including through the export).
+
+**`admin_registrations`** (`classes/views.py:2828`):
+
+- Delete the `mine_only_pk` / `mine_only_params` machinery (and its instructor_slug gate).
+- Add `mine_active` plus a precomputed `mine_toggle_url` (current GET minus `page`, `mine` toggled).
+- The Instructor dropdown keeps its current admins-only visibility and unchanged `instructor=` semantics.
+- For non-admins the list is already scoped to `editable_by` (own classes + led guilds); mine **narrows further** to strictly teach-or-authored — genuinely useful for a guild lead who also teaches, so it renders for them too.
+
+### Querystring contract
+
+| Param | Values | Meaning |
+|---|---|---|
+| `mine` | `1` = on; absent/anything else = off | Filter to classes (or registrations of classes) where the real logged-in user's member is `instructor` or `created_by` |
+
+- Composes by AND with `status`, `instructor`, `class`, `q`, `sort`, `dir` on both pages.
+- Carried automatically by `prepare_table`'s `base_params` (any non-reserved, non-empty GET param is copied through), so sort headers, pagination links, and the Export CSV href all preserve it with no template surgery.
+- Toggle links always drop `page` (a filter change resets to page 1 — same convention as the old Mine Only link).
+- **Normalization:** a bogus `mine` value in the incoming URL is treated as off *and* stripped from every view-computed URL (pills, toggles, clear links, search hidden inputs) — `?mine=yes` degrades to a clean state instead of propagating forever.
+- Registrations `instructor=<pk>` is untouched: still the plain instructor filter, so pre-change bookmarks behave identically.
+
+## 6. UI / UX
+
+### Screen 1: Classes list (`templates/classes/admin/classes_list.html`)
+
+- **Layout:** the My Classes pill joins the existing `.admin-filters` status-pill row, after the last status pill, separated by a thin vertical divider so it reads as a different *kind* of filter (status pills are exclusive; this one is orthogonal). Divider is a new class in `hub.css`: `.pl-filter-divider { width:1px; height:1.25rem; background:var(--hub-border); }` — theme token, no inline style. Because `.admin-filters` flex-wraps, the divider can end up orphaned at a line start/end on narrow screens; hide it under the page's existing mobile breakpoint (`display:none` in the media query) — the wrap itself provides the visual separation there. The `{{ pending_count }} pending review` badge stays at the end of the row.
+- **The control, markup pattern (matches the status pills exactly):**
+
+  ```html
+  <span class="pl-filter-divider"></span>
+  <a class="hub-btn hub-btn--sm {% if mine_active %}hub-btn--primary{% else %}hub-btn--ghost{% endif %}"
+     href="?{{ mine_toggle_url }}">
+      My Classes <span style="opacity:0.6; font-weight:400;">{{ mine_count }}</span>
+  </a>
+  <span class="pl-help">
+    <span class="pl-help__icon" tabindex="0" role="img"
+          aria-label="My Classes: shows only classes where you are the instructor or the class author.">?</span>
+    <span class="pl-help__bubble">Shows only classes where you are the instructor or the class author.</span>
+  </span>
+  ```
+
+  (The count `<span>` copies the status pills' existing inline opacity style verbatim — consistency beats introducing a class for one attribute here.)
+- **Count on the pill: yes.** Every other pill in this row carries a count; a bare pill would read as broken. It costs one indexed `COUNT` on `base`, alongside the seven the row already runs. It is **global** (all statuses, ignoring the Instructor dropdown), matching how the status counts ignore each other.
+- **Status pills** switch from hardcoded `?status=X` hrefs to the view-computed URLs (§5), so clicking a status keeps mine (and search/instructor) applied. Their rendered look is unchanged.
+- **Search form** — the shared `components/table_search.html` gets two **optional, backward-compatible** parameters; callers that pass neither render byte-for-byte what they do today (so `categories.html`, `discount_codes.html`, `registration_questions.html`, and `hub/help_search.html` are untouched):
+  - `preserved_fields` — a list of `(name, value)` pairs rendered as hidden inputs inside the form, guarded so nothing renders when absent:
+
+    ```html
+    {% if preserved_fields %}{% for name, value in preserved_fields %}
+        <input type="hidden" name="{{ name }}" value="{{ value }}">
+    {% endfor %}{% endif %}
+    ```
+
+  - `clear_url` — the clear-✕ link becomes `href="?{{ clear_url }}"` when provided, falling back to today's bare `href="?"` via `{% if clear_url %}…{% else %}?{% endif %}` (or `|default:` on the querystring).
+
+  `classes_list.html` passes `preserved_fields=search_preserved_fields clear_url=search_clear_url` (§5). Net effect: searching keeps mine, status, instructor, and sort; clearing the search drops only `q`. This closes the worst leak — today the search form silently discards even the existing status and instructor filters.
+- **Instructor dropdown form** (`classes_list.html:23-32`) gains hidden inputs so submitting it stops discarding sibling state: `mine` (when active), `q` (when set), and `sort`/`dir` (when present) — the same four the registrations toolbar already carries; it already carries `status`. Its "✕ Clear" link becomes a view-computed URL preserving everything except `instructor` and `page`. Mine + Instructor=someone-else is a legal (if odd) intersection; it just returns the overlap — no special casing.
+- **States:**
+  - *Active:* pill renders `hub-btn--primary` (same as a selected status pill). No other on-state indicator needed.
+  - *Empty:* the existing empty `<td colspan="6">` row gets a `mine_active` branch, checked **first** (it is the most specific explanation):
+    > No classes match. You are not listed as instructor or author on any classes that match the current filters. <a href="?{{ mine_clear_url }}">Show all classes</a>
+    where `mine_clear_url` is current GET minus `mine` and `page` (one click clears *only* the mine filter; search/status stay). Link inherits the table's link styling; no dashes anywhere in the copy.
+  - *Loading/error:* full-page GET navigation, same as every other filter on this page — nothing new.
+- **Dark + light:** no new colors — `hub-btn` variants, `.pl-help`, and `--hub-border` are all existing themed pieces. Verify both themes on the rendered row (pill active/inactive, divider visibility, bubble). The Instructor `<select>`'s pre-existing inline `background`/`color` (a Rule 13 violation) is not touched here — noted in §10.
+- **Mobile:** `.admin-filters` already `flex-wrap`s; the pill, divider, and `?` icon wrap as units in the same flow. The pill is a real `hub-btn--sm` tap target; the `.pl-help` bubble auto-pins to viewport gutters on phones per the component. No new fixed widths.
+
+### Screen 2: Registrations list (`templates/classes/admin/registrations.html`)
+
+- **Layout:** the new toggle **replaces the old Mine Only block** (`registrations.html:30-36`) in the same spot — inside the GET toolbar form, after the Apply button, before Export CSV. The toolbar already wraps (`flex-wrap` inline on the form).
+- **The control, markup pattern (upgraded old Mine Only, same pill style):**
+
+  ```html
+  {% if mine_active %}
+      <input type="hidden" name="mine" value="1">
+      <a href="?{{ mine_toggle_url }}" class="hub-btn hub-btn--sm hub-btn--primary">My Classes ✓</a>
+  {% else %}
+      <a href="?{{ mine_toggle_url }}" class="hub-btn hub-btn--sm">My Classes</a>
+  {% endif %}
+  <span class="pl-help">
+    <span class="pl-help__icon" tabindex="0" role="img"
+          aria-label="My Classes: shows only registrations for classes where you are the instructor or the class author.">?</span>
+    <span class="pl-help__bubble">Shows only registrations for classes where you are the instructor or the class author.</span>
+  </span>
+  ```
+
+  - The toggle is a **link** (instant, no Apply needed — same as before). The hidden `mine` input is what keeps the filter alive when the user changes a `<select>` and hits **Apply** (the form already preserves `sort`/`dir` the same way).
+  - Renamed from "Mine Only" to **My Classes** so both pages use one name for one concept.
+  - Always rendered — no `instructor_slug` gate, no admin gate. Non-admins (already scoped) can still narrow to strictly their own.
+- **Count on the pill: no.** This toolbar shows counts nowhere (selects and buttons only); a lone counted pill would be inconsistent, and it would add a `COUNT` over the largest table in the CMS on every load for little value. The result count is immediately visible in the table itself.
+- **Export CSV** link already uses `base_params`, and the filter lives in `_filter_registrations` — so the export honors mine with zero changes. Say so in the PR; test it (§9).
+- **States:**
+  - *Active:* `hub-btn--primary` + `✓`, exactly the old visual language.
+  - *Empty:* the empty `<td colspan="7">` row gets a `mine_active` branch, checked before the `q` branch:
+    > No registrations match. None of these belong to a class where you are the instructor or author. <a href="?{{ mine_clear_url }}">Show all registrations</a>
+    (`mine_clear_url` = current GET minus `mine`/`page`; other filters survive. For a non-admin, "all" means their scoped view — the copy stays honest since it just says "show all registrations".)
+  - *Loading/error:* full-page GET, unchanged.
+- **Dark + light:** all existing themed components; verify both themes (active pill, bubble). The toolbar's pre-existing inline-styled search input is untouched (§10).
+- **Mobile:** the toolbar form already wraps; pill + `?` icon flow with it. Real tap target, no new widths.
+
+### User-lens pass (both screens)
+
+- Primary action obvious: one clearly labeled pill per page, in the filter row where filters live.
+- Whole task completable: click pill → see mine → sort/paginate/search/export without losing it → click again (or the empty-state link) to clear. No dead ends.
+- Nothing half-built: the toggle turns on, off, composes, exports, and explains itself (`?` bubble covers the one non-obvious thing: instructor OR author).
+- Labels a non-technical admin understands: "My Classes", not "hosted_by" or "created_by".
+
+## 7. Notifications / emails / activity
+
+None — a read-only filter sends nothing.
+
+## 8. Build order (phased; each phase ships green)
+
+1. **Queryset + views:** `hosted_by` on `ClassOfferingQuerySet`; `mine` handling + normalized URL precomputation (incl. `search_preserved_fields`/`search_clear_url`) in `admin_classes`; `mine` via `hosted_by` in `_filter_registrations`; context rewiring (and old Mine Only context removal) in `admin_registrations`. Specs for all of it (§9). Suite + `ruff` + `mypy` + `manage.py check` green.
+2. **Templates + CSS:** the opt-in `preserved_fields`/`clear_url` extension to `components/table_search.html` (other callers byte-identical), both admin templates per §6, `.pl-filter-divider` in `hub.css` (with the mobile hide), empty-state branches, hidden inputs, view-computed status-pill hrefs. Template/response-content specs incl. the component regression. Verify both themes and mobile wrap on the rendered pages. Suite green.
+
+> Spec only — do not build until approved. No VERSION bump or changelog work in this plan (handled at release time, outside this spec).
+
+## 9. Testing
+
+BDD `*_spec.py`, `describe_*`/`it_*`, factory-boy, extending the existing files.
+
+**`classes/spec/views/admin_classes_spec.py` — `describe_mine_filter`:**
+
+- `it_filters_to_classes_taught_by_me` — instructor=me kept, others dropped.
+- `it_includes_classes_i_authored_but_do_not_teach` — created_by=me, instructor=someone else → kept.
+- `it_excludes_classes_where_i_am_neither` — including a class with NULL instructor and NULL author (the `None`-guard regression: a memberless "mine" must never match NULL FKs).
+- `it_composes_with_status_and_search` — mine + status + q AND together.
+- `it_shows_the_pill_without_an_instructor_slug` — admin with no `instructor_slug` still gets the control (the original bug).
+- `it_returns_empty_for_a_user_with_no_member` — `qs.none()`, count 0, page renders.
+- `it_ignores_bogus_mine_values` — `mine=yes` → filter off.
+- `it_counts_my_classes_across_all_statuses` — `mine_count` ignores the active status pill.
+- `it_counts_my_classes_ignoring_the_search_box` — `mine_count` unaffected by `q`.
+- `it_preserves_mine_in_status_pill_urls` — pill URLs contain `mine=1` (and keep `q`).
+- `it_preserves_mine_in_base_params` — sort/pagination links carry it.
+- `it_preserves_mine_when_searching` — the search form's markup contains hidden inputs for `mine` (and `status`/`instructor` when set), and its clear-✕ href keeps those params while dropping `q`.
+- `it_strips_bogus_mine_from_computed_urls` — `?mine=yes` in → no `mine` in any pill/toggle/clear URL out.
+- `it_renders_the_mine_empty_state_with_a_clear_link` — message text + link that drops only `mine`.
+- `it_uses_the_real_user_under_view_as_preview` — mine follows `request.user.member`, not the previewed role.
+
+**Component regression (same file or a small template spec):**
+
+- `it_leaves_other_table_search_callers_unchanged` — a page passing no `preserved_fields`/`clear_url` (e.g. the categories admin) renders no hidden inputs and keeps the bare `href="?"` clear link.
+
+**`classes/spec/views/admin_registrations_filters_spec.py` — `describe_mine_filter`:**
+
+- `it_filters_to_registrations_for_classes_i_teach_or_authored`.
+- `it_composes_with_status_and_class_filters`.
+- `it_keeps_plain_instructor_param_working` — `instructor=<pk>` unchanged (back-compat).
+- `it_shows_the_toggle_without_an_instructor_slug` / `it_shows_the_toggle_to_a_non_admin_instructor`.
+- `it_narrows_a_guild_leads_scoped_view` — lead of a guild with others' classes + one own class → mine shows only the own class's registrations.
+- `it_returns_empty_for_a_user_with_no_member` — memberless admin + `mine=1` → zero rows, even when NULL-instructor/NULL-author classes have registrations (the `None`-guard leak regression).
+- `it_ignores_bogus_mine_values` — `mine=yes` → filter off.
+- `it_renders_a_hidden_mine_input_when_active` — Apply keeps the filter.
+- `it_renders_the_mine_empty_state_with_a_clear_link`.
+
+**`classes/spec/views/registration_export_spec.py`:**
+
+- `it_respects_the_mine_filter` — CSV rows limited the same way the list is.
+- `it_exports_nothing_for_a_memberless_user_with_mine` — the `None`-guard asserted through the export path too: a dropped guard here would leak every registration of NULL-instructor/NULL-author classes into a downloadable file.
+
+Also run `tests/template_comment_lint_spec.py` after the template edits (house rule).
+
+## 10. Open / deferred
+
+- **Grouped-class edge:** the classes list shows one representative row (lowest pk) per `grouping_key` group. If a multi-date group somehow mixed instructors and the representative row is not mine, my date stays hidden under mine. Grouping is same-title-same-category, so mixed instructors within a group are not an expected state; accepted, not handled.
+- **Pre-existing Rule 13 violations** (inline `background`/`color` on the Instructor `<select>` and the registrations search input) — out of scope; note for a styling sweep.
+- **Teach portal:** instructors' own portal already scopes to their classes; no mine toggle needed there.
+- **Persisting the toggle as a preference** (sticky mine across visits) — YAGNI until someone asks; the querystring is bookmarkable.

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "1.15.0"
+VERSION = "1.16.0"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.16.0",
+        "date": "2026-08-27",
+        "title": "See just the classes you teach or run",
+        "changes": [
+            "The admin class list and the registrations list now have a My Classes filter, so if "
+            "you teach or run classes you can jump straight to only yours instead of scrolling the "
+            "whole makerspace. It stays put as you search, sort, and page through the results.",
+        ],
+    },
     {
         "version": "1.15.0",
         "date": "2026-08-27",

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -3133,6 +3133,21 @@ a:hover { color: var(--hub-link-hover); }
     margin-bottom: 0.75rem;
 }
 
+/* Thin vertical rule separating the exclusive status pills from the orthogonal
+   "My Classes" toggle. Hidden on phones (below) where the flex-wrap already
+   provides visual separation and the divider can orphan at a line edge. */
+.pl-filter-divider {
+    width: 1px;
+    height: 1.25rem;
+    background: var(--hub-border);
+}
+
+@media (max-width: 640px) {
+    .pl-filter-divider {
+        display: none;
+    }
+}
+
 .admin-table-wrap {
     border: 1px solid var(--hub-border);
     border-radius: 8px;

--- a/templates/classes/admin/classes_list.html
+++ b/templates/classes/admin/classes_list.html
@@ -2,16 +2,26 @@
 {% load classes_tags %}
 {% block tab_content %}
 <div class="admin-toolbar">
-    {% include "components/table_search.html" with q=q placeholder="Search classes…" %}
+    {% include "components/table_search.html" with q=q placeholder="Search classes…" preserved_fields=search_preserved_fields clear_url=search_clear_url %}
     <a class="hub-btn hub-btn--primary hub-btn--sm" href="{% url 'classes:admin_class_create' %}">+ New Class</a>
 </div>
 <div class="admin-filters">
-    {% for value, label, count in status_filters %}
-        <a class="hub-btn hub-btn--sm {% if selected_status == value %}hub-btn--primary{% else %}hub-btn--ghost{% endif %}"
-           href="{% if value %}?status={{ value }}{% else %}.{% endif %}">
+    {% for url, label, count, is_selected in status_filters %}
+        <a class="hub-btn hub-btn--sm {% if is_selected %}hub-btn--primary{% else %}hub-btn--ghost{% endif %}"
+           href="?{{ url }}">
             {{ label }} <span style="opacity:0.6; font-weight:400;">{{ count }}</span>
         </a>
     {% endfor %}
+    <span class="pl-filter-divider"></span>
+    <a class="hub-btn hub-btn--sm {% if mine_active %}hub-btn--primary{% else %}hub-btn--ghost{% endif %}"
+       href="?{{ mine_toggle_url }}">
+        My Classes <span style="opacity:0.6; font-weight:400;">{{ mine_count }}</span>
+    </a>
+    <span class="pl-help">
+      <span class="pl-help__icon" tabindex="0" role="img"
+            aria-label="My Classes: shows only classes where you are the instructor or the class author.">?</span>
+      <span class="pl-help__bubble">Shows only classes where you are the instructor or the class author.</span>
+    </span>
     {% if pending_count %}
         <span style="margin-left:0.5rem; display:inline-block; background:var(--color-tuscan-yellow,#EEB44B); color:#000; font-size:0.75rem; font-weight:600; padding:0.15rem 0.55rem; border-radius:9999px;">
             {{ pending_count }} pending review
@@ -22,13 +32,17 @@
 <div class="admin-filters" style="margin-top:0.5rem;">
     <form method="get" style="display:flex;align-items:center;gap:0.5rem;">
         {% if selected_status %}<input type="hidden" name="status" value="{{ selected_status }}">{% endif %}
+        {% if mine_active %}<input type="hidden" name="mine" value="1">{% endif %}
+        {% if q %}<input type="hidden" name="q" value="{{ q }}">{% endif %}
+        {% if sort %}<input type="hidden" name="sort" value="{{ sort }}">{% endif %}
+        {% if sort_dir %}<input type="hidden" name="dir" value="{{ sort_dir }}">{% endif %}
         <select name="instructor" onchange="this.form.submit()" style="font-size:0.875rem;padding:0.25rem 0.5rem;background:var(--hub-card-bg,#0c2236);color:var(--hub-text,#f4efdd);border:1px solid var(--hub-border);border-radius:4px;">
             <option value="">All instructors</option>
             {% for inst in instructors %}
             <option value="{{ inst.pk }}"{% if selected_instructor == inst.pk|stringformat:"s" %} selected{% endif %}>{{ inst.display_name }}</option>
             {% endfor %}
         </select>
-        {% if selected_instructor %}<a href="?{% if selected_status %}status={{ selected_status }}&{% endif %}" class="hub-btn hub-btn--sm hub-btn--ghost">✕ Clear</a>{% endif %}
+        {% if selected_instructor %}<a href="?{{ instructor_clear_url }}" class="hub-btn hub-btn--sm hub-btn--ghost">✕ Clear</a>{% endif %}
     </form>
 </div>
 {% endif %}
@@ -63,7 +77,7 @@
     {% empty %}
         <tr>
             <td colspan="6" style="padding:1.5rem 0.75rem; color:var(--hub-text-muted);">
-                {% if q %}No classes matching "{{ q }}".{% elif selected_status %}No {{ selected_status }} classes.{% else %}No classes yet.{% endif %}
+                {% if mine_active %}No classes match. You are not listed as instructor or author on any classes that match the current filters. <a href="?{{ mine_clear_url }}">Show all classes</a>{% elif q %}No classes matching "{{ q }}".{% elif selected_status %}No {{ selected_status }} classes.{% else %}No classes yet.{% endif %}
             </td>
         </tr>
     {% endfor %}

--- a/templates/classes/admin/registrations.html
+++ b/templates/classes/admin/registrations.html
@@ -27,13 +27,17 @@
     {% if sort %}<input type="hidden" name="sort" value="{{ sort }}">{% endif %}
     {% if sort_dir %}<input type="hidden" name="dir" value="{{ sort_dir }}">{% endif %}
     <button type="submit" class="hub-btn hub-btn--sm hub-btn--primary">Apply</button>
-    {% if mine_only_pk %}
-        {% if instructor_filter == mine_only_pk %}
-        <a href="?{{ mine_only_params }}" class="hub-btn hub-btn--sm hub-btn--primary">Mine Only ✓</a>
-        {% else %}
-        <a href="?{% if mine_only_params %}{{ mine_only_params }}&amp;{% endif %}instructor={{ mine_only_pk }}" class="hub-btn hub-btn--sm">Mine Only</a>
-        {% endif %}
+    {% if mine_active %}
+        <input type="hidden" name="mine" value="1">
+        <a href="?{{ mine_toggle_url }}" class="hub-btn hub-btn--sm hub-btn--primary">My Classes ✓</a>
+    {% else %}
+        <a href="?{{ mine_toggle_url }}" class="hub-btn hub-btn--sm">My Classes</a>
     {% endif %}
+    <span class="pl-help">
+      <span class="pl-help__icon" tabindex="0" role="img"
+            aria-label="My Classes: shows only registrations for classes where you are the instructor or the class author.">?</span>
+      <span class="pl-help__bubble">Shows only registrations for classes where you are the instructor or the class author.</span>
+    </span>
     <a href="{% url 'classes:admin_registrations_export' %}{% if base_params %}?{{ base_params }}{% endif %}" class="hub-btn hub-btn--sm hub-btn--ghost">Export CSV</a>
 </form>
 <div class="admin-table-wrap">
@@ -63,7 +67,7 @@
     {% empty %}
         <tr>
             <td colspan="7" style="padding:1.5rem 0.75rem; color:var(--hub-text-muted);">
-                {% if q %}No registrations matching "{{ q }}".{% else %}No registrations yet.{% endif %}
+                {% if mine_active %}No registrations match. None of these belong to a class where you are the instructor or author. <a href="?{{ mine_clear_url }}">Show all registrations</a>{% elif q %}No registrations matching "{{ q }}".{% else %}No registrations yet.{% endif %}
             </td>
         </tr>
     {% endfor %}

--- a/templates/components/table_search.html
+++ b/templates/components/table_search.html
@@ -1,6 +1,6 @@
-<form method="get"{% if action %} action="{{ action }}"{% endif %} style="display:flex; gap:0.5rem; align-items:center; flex:1; max-width:340px;">
+<form method="get"{% if action %} action="{{ action }}"{% endif %} style="display:flex; gap:0.5rem; align-items:center; flex:1; max-width:340px;">{% if preserved_fields %}{% for name, value in preserved_fields %}<input type="hidden" name="{{ name }}" value="{{ value }}">{% endfor %}{% endif %}
     <input type="search" name="q" value="{{ q }}" placeholder="{{ placeholder|default:'Search…' }}"
            style="flex:1; padding:0.45rem 0.75rem; border:1px solid var(--hub-border); border-radius:6px; background:rgba(0,0,0,0.1); color:inherit; font-size:0.875rem;">
     <button type="submit" class="hub-btn hub-btn--sm hub-btn--ghost">Search</button>
-    {% if q %}<a href="?" class="hub-btn hub-btn--sm hub-btn--ghost" title="Clear search">&#10005;</a>{% endif %}
+    {% if q %}<a href="?{% if clear_url %}{{ clear_url }}{% endif %}" class="hub-btn hub-btn--sm hub-btn--ghost" title="Clear search">&#10005;</a>{% endif %}
 </form>


### PR DESCRIPTION
## What ships

An always visible **My Classes** filter (instructor OR author) on `/classes/admin/classes/` and `/classes/admin/registrations/`, so staff can narrow to only the classes they teach or authored.

- New `ClassOfferingQuerySet.hosted_by(member)` = `Q(instructor=member) | Q(created_by=member)`, backing both lists and the registrations CSV export via `class_offering__in` (one definition of "mine").
- **None-guard**: a viewer with no member record matches nothing (a dropped guard would leak every NULL-instructor/NULL-author class).
- The shared search box (`components/table_search.html`) gains opt-in `preserved_fields` + `clear_url` so search and clear no longer drop the active filters. The four other callers render byte-identically (no params passed).
- Status pills and the instructor form now preserve `mine`/`q`/`sort`/`dir`; bogus `mine` values are normalized out of computed URLs.
- Pill is always visible (not gated on `instructor_slug`, which was the original bug that hid it). `.pl-help` tooltip states the instructor-or-author semantic. `mine_count` ignores search and instructor, matching the sibling status counts. Mine-first empty states with a clears-only-mine link.

## Spec

`docs/superpowers/plans/2026-08-27-admin-mine-filters.md` (fogstorm + adversarial UX review; the review caught the shared-search-box blocker that would have silently dropped the filter, now fixed via the opt-in preserved-params mechanism).

## Test evidence

`.venv/bin/pytest classes/spec/views/ classes/spec/models/ tests/template_comment_lint_spec.py -q` → 1050+ passed (admin_classes_spec, admin_registrations_filters_spec, registration_export_spec new suites incl. the memberless-leak and search-preservation tests). `ruff check`, `manage.py check`, and pre-push mypy all clean.

https://claude.ai/code/session_01NF4MEeH2icSRQ9U4RuGTmA