### PR TITLE
Member settings page restructure (1.18.0)

### DIFF
--- a/core/events/settings_matrix.py
+++ b/core/events/settings_matrix.py
@@ -57,25 +57,30 @@ CHANNEL_LABELS: dict[Channel, str] = {
 # Shown on a disabled DISCORD_DM toggle when the member hasn't linked Discord yet.
 _DISCORD_LINK_HINT = "Connect your Discord account first to receive DMs."
 
-# Stable category display order; any category not listed falls to the end, alpha.
-# STAFF_SECTION is always forced dead-last by _ordered_categories, so it is not
-# listed here.
+# Stable category display order; any category not listed falls to the end, alpha
+# (before STAFF_SECTION). STAFF_SECTION is always forced dead-last by
+# _ordered_categories, so it is not listed here.
 CATEGORY_ORDER: tuple[str, ...] = (
+    "Orientations",
+    "Guilds",
+    "Events",
     "Classes",
     "Teaching",
     "Voting",
-    "Guilds",
     "Billing",
     "Membership",
     "Spaces",
     "Announcements",
     "Security",
+    "Meetings",
 )
 
 # The single display section that collects every staff / leadership / admin event
 # (approval requests + admin-only alerts) instead of scattering them through the
-# member-facing categories. Rendered first and shown ONLY to eligible viewers
-# (see _is_staff_or_leadership); a plain member never sees it.
+# member-facing categories. Rendered dead-last and shown ONLY to eligible viewers
+# (see _is_staff_or_leadership); a plain member never sees it. When an admin/officer
+# previews the page as a Member or Guest, the section is omitted entirely
+# (include_staff_section=False).
 STAFF_SECTION = "Staff & leadership"
 
 # Recipients that target staff, leadership, or admins rather than an individual
@@ -236,7 +241,7 @@ def _eligible_for(recipient: Recipients, profile: _StaffProfile) -> bool:
     return checks[recipient]
 
 
-def _visible_events(user: User) -> list[EventType]:
+def _visible_events(user: User, *, include_staff_section: bool = True) -> list[EventType]:
     """Events whose preference row should be shown to ``user``.
 
     Every registered *member-facing* event that declares a user channel is shown — the page
@@ -248,23 +253,36 @@ def _visible_events(user: User) -> list[EventType]:
     actually eligible to receive it — a holder of its capability or a member of its role
     (:func:`_eligible_for`). A plain member sees none of them; an admin sees only the duties
     they hold plus the admin/leadership alerts.
+
+    When ``include_staff_section`` is ``False`` (an admin/officer previewing the page as a
+    Member or Guest), every staff/leadership/admin event is dropped up front — before the
+    eligibility check — so the Staff & Leadership section is omitted entirely.
     """
     profile = _staff_profile(user)
     out: list[EventType] = []
     for event in all_events():
         if not any(event.has_channel(channel) for channel in USER_CHANNELS):
             continue
-        if event.recipient in STAFF_RECIPIENTS and not _eligible_for(event.recipient, profile):
-            continue
+        if event.recipient in STAFF_RECIPIENTS:
+            if not include_staff_section:
+                continue
+            if not _eligible_for(event.recipient, profile):
+                continue
         out.append(event)
     return out
 
 
 def _ordered_categories(categories: set[str]) -> list[str]:
-    head = [STAFF_SECTION] if STAFF_SECTION in categories else []
+    """Order the rendered sections: CATEGORY_ORDER first, unknown extras alpha, staff last.
+
+    STAFF_SECTION is forced dead-last (its comment finally becomes true): a member-facing
+    category always sorts ahead of the Staff & Leadership section, even a brand-new one not
+    yet listed in CATEGORY_ORDER.
+    """
+    tail = [STAFF_SECTION] if STAFF_SECTION in categories else []
     ranked = [c for c in CATEGORY_ORDER if c in categories]
     rest = sorted(c for c in categories if c not in CATEGORY_ORDER and c != STAFF_SECTION)
-    return head + ranked + rest
+    return ranked + rest + tail
 
 
 def _member_discord_linked(user: User) -> bool:
@@ -292,15 +310,18 @@ def channel_availability(user: User, channel: Channel, *, discord_linked: bool) 
     return True, ""
 
 
-def visible_channels(user: User) -> list[Channel]:
+def visible_channels(user: User, *, include_staff_section: bool = True) -> list[Channel]:
     """The user channels at least one visible event actually offers, in display order.
 
     A channel no event declares (today: the unbuilt Scheduled-email and Digest shells)
     would render as an entire column of empty '—' cells — dead, confusing UI. We drop
     such columns until something uses them; the column reappears automatically the day
     an event starts declaring that channel.
+
+    ``include_staff_section`` is forwarded to :func:`_visible_events` so a member-view
+    preview doesn't render a dead column for a channel only staff events offer.
     """
-    events = _visible_events(user)
+    events = _visible_events(user, include_staff_section=include_staff_section)
     return [channel for channel in USER_CHANNELS if any(event.channel(channel) is not None for event in events)]
 
 
@@ -340,18 +361,21 @@ def _capability_badges(user: User, events: list[EventType]) -> dict[str, str]:
     return badges
 
 
-def build_matrix(user: User) -> list[tuple[str, list[Row]]]:
+def build_matrix(user: User, *, include_staff_section: bool = True) -> list[tuple[str, list[Row]]]:
     """Assemble the matrix for ``user`` — a list of ``(category, [Row, ...])``.
 
     For each visible event, one :class:`Row` with a :class:`Cell` per user channel:
     forced cells locked-on, opt-out-able cells reflecting the saved preference (or the
     event's channel default). A row the user receives via an admin capability carries a
     badge. Sections are returned in :data:`CATEGORY_ORDER`, with every staff/leadership
-    event collected into a single :data:`STAFF_SECTION` rendered first (and only for
+    event collected into a single :data:`STAFF_SECTION` rendered **last** (and only for
     eligible viewers — see :func:`_visible_events`).
+
+    When ``include_staff_section`` is ``False`` (an admin/officer previewing as Member or
+    Guest), the Staff & Leadership section and any staff-only channel columns are omitted.
     """
-    events = _visible_events(user)
-    channels = visible_channels(user)
+    events = _visible_events(user, include_staff_section=include_staff_section)
+    channels = visible_channels(user, include_staff_section=include_staff_section)
     # Compute per-channel availability once (the Discord-linked lookup is a single
     # query) rather than re-deriving it for every cell.
     discord_linked = _member_discord_linked(user)
@@ -392,7 +416,7 @@ def build_matrix(user: User) -> list[tuple[str, list[Row]]]:
     return [(category, by_category[category]) for category in _ordered_categories(set(by_category))]
 
 
-def save_matrix(user: User, posted: dict[str, str]) -> None:
+def save_matrix(user: User, posted: dict[str, str], *, include_staff_section: bool = True) -> None:
     """Persist the matrix POST for ``user``.
 
     For each visible (event, opt-out-able channel) cell, upsert a
@@ -404,12 +428,19 @@ def save_matrix(user: User, posted: dict[str, str]) -> None:
     before they link Discord) is skipped — its box renders disabled, so the browser
     omits it, and writing ``enabled=False`` would silently wipe a preference they set
     while linked. Skipping preserves their choice across an unlink/relink.
+
+    ``include_staff_section`` **must** match the flag the GET render used. When it is
+    ``False`` (an admin/officer saving while previewing as Member/Guest), the staff-event
+    rows were never rendered, so their checkboxes are absent from the POST — iterating them
+    here would write ``enabled=False`` and silently wipe the admin's own staff prefs. The
+    flag drops those events from the iteration entirely, the same protective pattern as the
+    Discord-unlinked channel skip below.
     """
     discord_linked = _member_discord_linked(user)
     availability = {
         channel: channel_availability(user, channel, discord_linked=discord_linked) for channel in USER_CHANNELS
     }
-    for event in _visible_events(user):
+    for event in _visible_events(user, include_staff_section=include_staff_section):
         for channel in USER_CHANNELS:
             spec = event.channel(channel)
             if spec is None or spec.is_forced or channel is Channel.IN_APP:

--- a/core/triggers.py
+++ b/core/triggers.py
@@ -100,13 +100,13 @@ TRIGGERS: list[Trigger] = [
         "orientation_requested",
         "Orientation requested",
         "Someone requested an orientation for a guild you lead.",
-        "Guilds",
+        "Orientations",
     ),
     Trigger(
         "orientation_update",
         "Orientation updates",
         "Your orientation request was confirmed, declined, or cancelled.",
-        "Guilds",
+        "Orientations",
     ),
     Trigger(
         "guild_joined",

--- a/docs/superpowers/plans/2026-08-27-settings-restructure.md
+++ b/docs/superpowers/plans/2026-08-27-settings-restructure.md
@@ -1,0 +1,569 @@
+# Settings Restructure — Spec & Implementation Plan
+
+**Status:** Spec only — not yet approved to build.
+**Date:** 2026-08-27
+**Surface:** FOG hub `pastlives.test` — the User Settings page (`/settings/`) and its four tabs; touches the shared notification matrix partial (also rendered on admin member-edit and the token email-prefs page) and the shared confirm modal component.
+**Related:** `2026-08-26-guild-subscriptions.md` (the Guilds tab + `?tab=guilds` answered-stamp this spec now makes the *default* landing), the notification spine (`core/events/`), `2026-08-24-meetings-qol.md` (the `/meetings/` page the new Meetings subtitle links to).
+
+---
+
+## 1. Summary
+
+Six related cleanups that make `/settings/` behave like one coherent page instead of five bolted-on tabs. Members land on the things they touch most (Guilds, then Notifications); the Notifications tab gets a sensible section order (Orientations → Guilds → Events → the rest), jump-to-section chips, and a floating back-to-top button; the redundant Emails tab folds into Account; the Danger Zone stops looking like a prototype; two notification sections gain the same "manage it here →" subtitle the Staff section already has; an admin previewing the page as a Member no longer sees the Staff & Leadership section; and unsaved toggle changes now prompt before the user navigates away.
+
+### Locked decisions (from brainstorm Q&A)
+
+| Decision | Choice |
+|---|---|
+| (a) View-as and the Staff section | `build_matrix` gains an `include_staff_section` flag; when an admin/officer is previewing as Member (or Guest), the view passes `False` and the Staff & Leadership section is omitted entirely. `settings_matrix` stays framework-agnostic — the view derives the flag from `request.view_as`, the matrix never imports the request. **`save_matrix` gets the same flag** (see §5.2 — without it, saving while previewing would silently wipe staff prefs). |
+| (b) Section order | New `CATEGORY_ORDER`: Orientations, Guilds, Events first; the rest keep their current relative order; **Staff & Leadership moves dead-last** (the code's own comment already claims it is — the code just never did it). Jump chips at the top of the Notifications pane, one per rendered section, plain anchor scroll (reduced motion respected). Floating back-to-top after ~400px scroll, bottom-right, hub tokens, with mobile clearance for the Save button. |
+| (c) Emails tab | Removed. The whole "Manage Email Addresses" card moves into the Account tab **above** the danger zone. `?tab=emails` resolves to `account` (old links keep working); allauth's `HubEmailView` redirect target updated. Danger Zone gets a dedicated `.pl-danger-zone` card treatment (red-tinted border + background in both themes, warning icon, tightened copy, right-aligned button in a card footer). The typed-DELETE confirm stays exactly as is. |
+| (d) Section subtitles | Guilds section: "Manage which guilds send you updates →" switching to the Guilds tab in-page (Alpine, no reload — the `_my_guilds.html:43` pattern). Meetings section: "View upcoming meetings →" linking to `hub_meetings` (`/meetings/`). Both use the existing `.pl-notif-section-note` pattern, shown only on the member's own settings page. Plain language, no dashes; the `→` matches the existing Staff note. |
+| (e) Tab order | Guilds, Notifications, Profile, Account. **Default tab becomes `guilds`** — which means every bare `/settings/` visit fires `mark_guild_updates_answered()`. Deliberate and accepted: viewing your guild toggles *is* answering the prompt (it is idempotent, one-way, no-op after the first hit). Profile sub-tabs (Member / Instructor) untouched. |
+| (f) Unsaved-changes guard | Scoped to the three batch-save forms only (notification matrix, Guided Tours, Profile). Alpine dirty flags per form; tab switches route through a guard that opens a two-option confirm ("Stay" / "Discard Changes" — reusing `confirm_modal.html` in its JS mode, plus a tiny backward-compatible `confirm_cancel_text` param); `beforeunload` for hard navigations; **`htmx:confirm` interception for hx-boost'd links** (htmx 2.0.4 supports async `issueRequest` resume — verified in the bundled `htmx.min.js`). Guild autosave toggles never trip it; bulk All on/off buttons do; Profile's Alpine-only controls arm it via explicit `data-arm-dirty` markers, and a Profile discard is a pane **reload** (its Alpine-fed hidden inputs make `form.reset()` unsafe — §6.6). Auto-save-on-leave is out of scope; Back-button history restoration is an accepted gap (§10). |
+
+## 2. What already exists (reuse, don't reinvent)
+
+All verified in the codebase on 2026-08-27:
+
+| Need | Existing thing | Location |
+|---|---|---|
+| The settings page + tab state | Pure Alpine `x-data="{ tab: … }"`, `vote-tab` buttons, `x-show` panes all rendered in initial HTML | `templates/hub/user_settings.html:7-39` |
+| Tab whitelist + guilds answered-stamp | `_resolve_settings_tab` — whitelist `{profile,emails,notifications,guilds,account}`, `?tab=guilds` fires `member.mark_guild_updates_answered()` | `hub/views.py:2194-2209` |
+| The view + `form_id` POST dispatch | `user_settings` (`profile` / `notifications` / `tours` form_ids; emails POST to allauth) | `hub/views.py:2071-2191` |
+| The matrix builder / saver | `build_matrix(user)` / `save_matrix(user, posted)` — raw user, no view-as awareness (bug (a)) | `core/events/settings_matrix.py:343,395` |
+| Section ordering | `CATEGORY_ORDER` (:63-73) + `_ordered_categories` (:263-267) — staff section rendered FIRST despite the ":61-62" comment claiming "always forced dead-last" | `core/events/settings_matrix.py` |
+| Category grouping per event | `_section_for` — staff-routed events collapse into `STAFF_SECTION` regardless of their `category`; everything else keys off `event.category` | `core/events/settings_matrix.py:150-158` |
+| Preference storage is **event-keyed** | `NotificationPreference(user, event_key, channel, enabled)`, unique on `(user, event_key, channel)`; category is never stored. `save_matrix` upserts by `event_key` (`:419-424`) | `core/models.py:1117-1146` |
+| View-as roles | `request.view_as` (`ViewAs`), `view_as_role`, `actual_is_admin`, `actual_is_guild_officer`; attached by `ViewAsMiddleware` | `hub/view_as.py:109-202,305-317` |
+| The matrix template + Staff note pattern | `.pl-notif-section-note` under `Staff & leadership` with trailing link "Manage your admin duties →" | `templates/hub/partials/_notification_matrix.html:36-42`; CSS `static/css/components.css:417-420` |
+| Bulk on/off | `plNotifBulk(scope, on)` — flips non-disabled checkboxes, **fires no `change` events** (matters for (f)) | `_notification_matrix.html:92-103` |
+| In-page tab-switch link pattern | `<a href="?tab=notifications" @click.prevent="tab = 'notifications'">` | `templates/hub/partials/_my_guilds.html:43` |
+| Guilds tab autosave (no Save button) | per-toggle `hx-post` + error-revert toast — must NOT trip the dirty guard | `templates/hub/partials/_my_guilds.html:24-37` |
+| Emails card to relocate | "Manage Email Addresses" — allauth radio list + actions + Add form | `templates/hub/user_settings.html:579-643` |
+| allauth redirect into the Emails tab | `HubEmailView` — `success_url = "/settings/?tab=emails"` + GET redirect | `plfog/urls.py:52-65` |
+| Current danger zone | bare `hub-card` + `<h3>Danger Zone</h3>` + `pl-btn--danger` + typed-DELETE `confirm_modal` | `templates/hub/user_settings.html:658-669` |
+| Confirm modal (incl. JS mode) | `confirm_js` runs inline JS + closes — exactly the discard-confirm shape; Cancel label currently hardcoded | `templates/components/confirm_modal.html:39-42,80-84,109` |
+| Back-to-top precedent (public CMS) | Alpine `show: scrollY > 400`, fixed 44px circle bottom-right | `templates/classes/public/list.html:146-155`; CSS `static/css/cms-public.css:436-437` |
+| Smooth scroll + reduced motion | `html { scroll-behavior: smooth }` with `prefers-reduced-motion` reset | `static/css/hub.css:182-190` |
+| Sticky topbar (anchor offset needed) | `.pl-topbar` sticky, `top:0`, height `var(--topbar-height) + safe-area` | `static/css/hub.css:801-809` |
+| hx-boost topology | `<body hx-boost="true">`; the sidebar nav opts OUT (`hx-boost="false"` — real navigations, so `beforeunload` fires there) | `templates/hub/base.html:72,89` |
+| htmx async confirm | htmx **2.0.4** bundled; `htmx:confirm` event + `evt.detail.issueRequest(true)` both present | `static/js/htmx.min.js` |
+| Meetings page | `hub_meetings` → `/meetings/` | `hub/urls.py:8` |
+| Other matrix consumers (untouched, default flag) | token prefs flow (`hub/views.py:1964-2001`), admin member-edit Permissions tab (`hub/views.py:5293-5331`) | as listed |
+
+### Genuine gaps to close
+
+1. `include_staff_section` flag on `build_matrix`/`save_matrix` + the view-as plumbing.
+2. Two category re-tags in `core/triggers.py` + the new `CATEGORY_ORDER` + staff-last ordering.
+3. Jump chips, back-to-top, danger-zone card, and the dirty-guard JS — all new, all small.
+4. `confirm_cancel_text` param plus open-focus/focus-restore on `confirm_modal.html` — backward compatible.
+5. POST re-renders must derive the active tab from `form_id` (the failed-profile-save blocker, §5.3), and Profile discard must be a pane reload, not `form.reset()` (§6.6).
+
+## 3. Where the code lives
+
+```
+core/
+  triggers.py                    # orientation_requested + orientation_update: category "Guilds" → "Orientations"
+  events/settings_matrix.py      # include_staff_section flag on build_matrix/save_matrix/_visible_events/
+                                 #   visible_channels; new CATEGORY_ORDER; _ordered_categories: staff → tail
+hub/
+  views.py                       # user_settings: derive include_staff flag from request.view_as, pass to
+                                 #   build + save; _resolve_settings_tab: default "guilds", drop "emails",
+                                 #   alias emails→account
+plfog/
+  urls.py                        # HubEmailView: success_url + GET redirect → /settings/?tab=account
+templates/
+  hub/user_settings.html         # tab reorder + default; Emails pane removed, card moved into Account;
+                                 #   danger-zone markup; back-to-top button; dirty-guard x-data + discard
+                                 #   confirm include; go() tab guard
+  hub/_notifications_settings.html   # jump-chips nav above the matrix
+  hub/partials/_notification_matrix.html  # section anchor ids; Guilds + Meetings subtitles; plNotifBulk
+                                 #   change-event dispatch
+  hub/partials/_profile_field_with_visibility.html  # + data-arm-dirty on the vis pill (dirty-guard arming)
+  components/confirm_modal.html  # + confirm_cancel_text param; focus Cancel on open + restore opener on
+                                 #   close (a11y)
+static/css/
+  components.css                 # .pl-notif-jump chips; .pl-danger-zone; .pl-notif-section scroll-margin
+  hub.css                        # .pl-scroll-top (hub-tokenized back-to-top); mobile Save clearance
+tests/
+  core/notification_matrix_ordering_spec.py   (new — ordering, re-tag, staff flag)
+  hub/notification_settings_spec.py           (extend — view-as omission, save skip)
+  hub/user_settings_tabs_spec.py              (new — tab fallback, emails alias, default landing stamp)
+  hub/account_tab_spec.py                     (new or fold into account_delete_spec — moved card, danger zone)
+```
+
+Home apps: `core` (matrix/registry), `hub` (view + templates). No new app, no new models — everything inside the existing coverage/mypy scope.
+
+## 4. Data model
+
+**None.** No new models, no migrations. The one data-shaped change is re-tagging two trigger categories (§5.3), and that is safe because preferences are stored per `(user, event_key, channel)` — the category never touches the database.
+
+**Evidence, as required:** `core/models.py:1132-1135` — `NotificationPreference` fields are `user`, `event_key`, `channel`, `enabled`; the unique constraint (`:1138-1143`) is on `(user, event_key, channel)`. `save_matrix` upserts with `event_key=event.key` (`core/events/settings_matrix.py:419-424`). `orientation_requested` and `orientation_update` keep their keys; only `Trigger.category` (a display string) changes, so every stored preference row keeps matching.
+
+**One knock-on effect to state out loud:** `event.category` also rides outgoing email as the `X-Category` header (`core/events/channels.py:147`, `core/email.py:53`). After the re-tag, orientation-request/update emails carry `X-Category: Orientations` instead of `Guilds`. That header is ESP analytics grouping only — arguably more correct now — but the reviewer should see it was noticed.
+
+## 5. Business logic (fat models / service layer)
+
+### 5.1 The event re-categorization inventory
+
+The explorer's claim that "there is no Orientations or Events category" was **wrong** — both exist in the registry, along with **Meetings**; they are merely absent from `CATEGORY_ORDER`, so today all three alpha-sort to the bottom as "extras" (`_ordered_categories:266`). The re-categorization is therefore mostly an *ordering* change plus **two re-tags**. Full inventory (every registered event, its declared category, and where it renders after this change; "Staff" = collapses into Staff & Leadership via `STAFF_RECIPIENTS` regardless of category):
+
+| Section (new order) | Member-facing rows | Staff-collapsed rows from this category |
+|---|---|---|
+| **1. Orientations** | `orientation_update` (**re-tagged** from Guilds), `orientation.completed` | `orientation_requested` (**re-tagged** from Guilds; recipient `GUILD_ORIENTERS` → renders in Staff anyway — re-tagged for `X-Category` coherence) |
+| **2. Guilds** | `guild_announcement`, `guild_announcement.approved`, `guild_announcement.changes_requested`, `guild_announcement.declined`, `discord_guilds_imported` | `guild_announcement.submitted`, `guild_joined` (→ `GUILD_LEAD`) |
+| **3. Events** | `event.guild_published`, `event.community_published`, `event.approved`, `event.changes_requested`, `event.declined`, `event.reminder`, `event.happening_now` | `event.submitted`, `event.lead_meeting_published` (→ `ALL_GUILD_LEADS`) |
+| 4. Classes | `class_published`, `class_reminder`, `registration_confirmed`, `class_cancelled` (forced), `waitlist_spot_available`, `waitlist_confirmed`, `refund_issued` (forced), `waitlist_promoted`, `waitlist_promoted_pay`, `registration_removed`, `class_announcement` | — |
+| 5. Teaching | `instructor_class_approved`, `instructor_changes_requested`, `instructor_new_registration` | `class_review_requested`, `class_validation_requested`, `discount_code.requested` |
+| 6. Voting | `voting.closing_soon`, `voting.vote_soon`, `voting.results_published` | `voting.officers_closing_soon`, `voting.results_ready`. (`voting.discord_reminder` / `voting.results_discord` declare only the broadcast `DISCORD` channel — no user channel — so `_visible_events` already drops them; verified `registry.py:853-873`.) |
+| 7. Billing | `tab_charged`, `tab_charge_failed`, `tab_entry_added` (forced), `tab_approaching_limit` (forced) | `refund_failed`, `billing.charge_failed_admin` |
+| 8. Membership | `member.invited`, `member.login_invite`, `invite_accepted` | `new_member_joined` (→ `FOG_ADMINS`) |
+| 9. Spaces | `lease_expiring` (forced), `space.request_approved`, `space.request_declined` | `space.lease_requested`, `space.cubby_requested` |
+| 10. Announcements | `site_announcement`, `release.published` | — |
+| 11. Security | *(no registered events — category never renders; kept in the tuple for the day one returns)* | — |
+| 12. Meetings | `meeting.item_decided`, `meeting.minutes_approved` | `meeting.item_proposed`, `meeting.council_minutes_approved` |
+| **13. Staff & Leadership** (moved last) | *(eligible viewers only — all the staff-collapsed rows above)* | |
+
+**Meetings finding (asked explicitly):** a `Meetings` category **does exist** and plain members **do** see it — `meeting.item_decided` and `meeting.minutes_approved` are member-facing. The "View upcoming meetings →" subtitle goes on this category's header (§6.5); no fallback placement needed.
+
+**Code changes:**
+
+- `core/triggers.py`: `orientation_requested` (:100-104) and `orientation_update` (:105-110) — `"Guilds"` → `"Orientations"`. Their keys, labels, descriptions, and audiences are untouched.
+- `core/events/settings_matrix.py` `CATEGORY_ORDER` (:63-73) becomes:
+
+  ```python
+  CATEGORY_ORDER: tuple[str, ...] = (
+      "Orientations",
+      "Guilds",
+      "Events",
+      "Classes",
+      "Teaching",
+      "Voting",
+      "Billing",
+      "Membership",
+      "Spaces",
+      "Announcements",
+      "Security",
+      "Meetings",
+  )
+  ```
+
+  ("The rest in their current relative order" — today's *rendered* order for the tail is Classes, Teaching, Voting, Billing, Membership, Spaces, Announcements, then the alpha extra Meetings; Security keeps its slot though it currently renders nothing.)
+- `_ordered_categories` (:263-267): staff moves from `head` to `tail` — `return ranked + rest + tail`. The comment at `:61-62` ("STAFF_SECTION is always forced dead-last") finally becomes true; update the docstring on `build_matrix` (:349-351, "rendered first") to match.
+
+### 5.2 `include_staff_section` (feature (a))
+
+`settings_matrix` stays framework-agnostic: a keyword-only bool, no request objects.
+
+```python
+def build_matrix(user: User, *, include_staff_section: bool = True) -> list[tuple[str, list[Row]]]: ...
+def save_matrix(user: User, posted: dict[str, str], *, include_staff_section: bool = True) -> None: ...
+```
+
+- `_visible_events(user, include_staff_section)`: when `False`, skip every event whose `recipient in STAFF_RECIPIENTS` *before* the eligibility check — the staff section is omitted entirely.
+- `visible_channels` takes and forwards the flag too — a channel offered only by staff events must not render as a dead column for a member-view preview.
+- **Why `save_matrix` needs the flag (the trap):** `save_matrix` treats an absent checkbox as `enabled=False` and iterates `_visible_events(user)` with the raw user. If the GET hid the staff section but the POST saved without the flag, every staff checkbox would be absent → an admin clicking Save while previewing as Member would **silently wipe all their staff notification prefs**. The view computes the flag once per request (the view-as choice is session-backed, so GET and the subsequent POST agree) and passes it to both calls. When `False`, `save_matrix` never touches staff-event rows — same protective pattern as the existing Discord-unlinked skip (`:416-418`).
+
+**View plumbing** (`hub/views.py user_settings`):
+
+```python
+va = request.view_as
+include_staff = not (
+    va.view_as_role in (view_as.ROLE_MEMBER, view_as.ROLE_GUEST)
+    and (va.actual_is_admin or va.actual_is_guild_officer)
+)
+```
+
+Rationale for this exact condition: `ViewAs.is_member` is `True` for everyone holding the member role (admins included), so it cannot be the test. The flag must flip only when a *higher-role holder is previewing down* — an actual plain member (including a guild lead whose `fog_role` is member) always gets `True`, so leads keep the staff rows their `led_guilds` eligibility grants today (`settings_matrix.py:222-227`); a plain member's staff section stays absent via the existing eligibility filter either way. Guest preview also hides it (an admin previewing Guest sees even less than a member). The other two call sites — the token flow (`hub/views.py:1984,1995`) and admin member-edit (`:5296,5329`) — keep the default `True`: no view-as concept applies to a token-authorized member or to an admin editing someone else's prefs.
+
+### 5.3 Tab resolution (features (c) + (e))
+
+`_resolve_settings_tab` (`hub/views.py:2194-2209`):
+
+```python
+tab_param = request.GET.get("tab", "guilds")
+if tab_param == "emails":          # legacy deep links (old emails tab) land on its new home
+    tab_param = "account"
+active_tab = tab_param if tab_param in {"profile", "notifications", "guilds", "account"} else "guilds"
+```
+
+- Default and unknown-value fallback both become `guilds` (the new first tab). The XSS-whitelist rationale in the docstring stays word-for-word — the value still flows into an Alpine `x-data` expression.
+- **Failed-POST re-render must land on the tab that failed (reviewer blocker).** The profile form posts to the current URL with no `?tab` param; on a validation failure the view re-renders instead of redirecting. With `guilds` as default, that re-render would resolve `active_tab="guilds"` — the pane holding the errors hidden, the user believing Save worked — and, as a bonus wrong-write, that render would stamp `mark_guild_updates_answered()` on a landing the user never chose. Fix in `user_settings`: on POST, derive the tab from the submitted `form_id` and consult `_resolve_settings_tab` on GET only:
+
+  ```python
+  if request.method == "POST":
+      active_tab = {"profile": "profile", "tours": "notifications", "notifications": "notifications"}.get(
+          request.POST.get("form_id", ""), "guilds"
+      )
+  else:
+      active_tab = _resolve_settings_tab(request, member)
+  ```
+
+  The notifications and tours handlers redirect on success and have no failing-validation path today, so `profile` is the only live re-render — but the mapping covers all three so any future validating handler inherits the right tab for free. The guilds stamp now fires on GET resolution only. Pinned by a spec: "failed profile POST re-renders with `active_tab == 'profile'` and does not stamp `guild_updates_prompt_answered_at`" (§9).
+- **Stated deliberately for the reviewer:** with `guilds` as default, `mark_guild_updates_answered()` now fires on **every** bare `/settings/` GET (`:2207-2208`), not just `?tab=guilds` deep links. Accepted: landing on your guild toggles *is* seeing and answering the guild-updates prompt; the method is login-gated, one-way, idempotent, and a no-op after the first hit (`2026-08-26-guild-subscriptions.md` §5 established the write-on-GET pattern; this widens when, not what).
+- `HubEmailView` (`plfog/urls.py:62,65`): both `success_url` and the GET redirect become `"/settings/?tab=account"` (allauth's add/primary/resend/remove flows land the user back beside the email card).
+
+## 6. UI / UX
+
+The page keeps its architecture: one Alpine root, `vote-tab` buttons, all panes in the initial HTML behind `x-show`. Every subsection below ends with its states / themes / mobile notes.
+
+### 6.1 Tab bar — new order + default (e)
+
+- **Screen:** `templates/hub/user_settings.html:8-39`.
+- Reorder the four buttons: **Guilds, Notifications, Profile, Account** (Emails button deleted). Each `@click="tab = '…'"` becomes `@click="go('…')"` — the dirty-guard router (§6.6). Alpine root default: `x-data="{ tab: '{{ active_tab|default:"guilds" }}', … }"` (the view always supplies `active_tab`; the template default changes for belt-and-braces).
+- Profile pane internals (Member/Instructor sub-tabs, `ptab`) untouched.
+- **States:** unlinked account (`member is None`) — Guilds pane already renders its "not linked to a membership" message (`_my_guilds.html:49`), so the new default landing still shows something sensible, plus the existing info message (`hub/views.py:2144-2145`). No other state change.
+- **Mobile / themes:** existing `pl-tabs` styling; nothing new.
+
+### 6.2 Emails → Account (c): the moved card
+
+- **Screen:** Account pane, `user_settings.html` (current `:658-669`, growing).
+- The entire "Manage Email Addresses" card (`:582-642`) moves verbatim into the Account pane, **above** the danger zone. Two copy edits inside it:
+  - The footer cross-link "Choose which emails you receive in the **Notifications** tab" keeps its in-page tab switch but routes through the guard: `@click="go('notifications')"`.
+  - Profile tab email hint (`:147`) "Manage your emails in the Emails tab." → "Manage your emails in the Account tab."
+- The Emails pane (`:579-643`) and its tab button are deleted. Old links: `?tab=emails` aliases to `account` (§5.3); the allauth redirect is updated (§5.3). No other template references `tab=emails` (verified by grep — only `plfog/urls.py`).
+- The pane loses its stray "Delete Your Account" `<h2>` page heading — each card carries its own heading (Title Case, per FRONTEND rule 22): "Manage Email Addresses", "Add an Email Address", "Danger Zone".
+- **The controls, named:** unchanged from today — radio list per address with Verified/Unverified/Primary pills; **Make Primary** / **Re-send Verification** (shown only for an unverified selection, existing Alpine `selectedVerified`) / **Remove** (native confirm, as today) buttons submitting to `account_email`; the **Add Email** form (`form_field.html` fields + primary button). All POSTs land back on `?tab=account`.
+- **States:** zero addresses → existing "No email addresses on file yet." empty state; allauth validation errors re-render via `form_field.html` as today. Success feedback: full-page POST + Django messages (existing pattern, correct for non-HTMX forms).
+- **Themes / mobile:** the card is existing, already token-clean; the button row already wraps (`flex-wrap`). Verify both themes after the move (no CSS change expected).
+
+### 6.3 Danger Zone polish (c)
+
+- **Screen:** Account pane, below the email card, `margin-top: 1.5rem` (buttons never touch an adjacent section — FRONTEND rule 18 applies between the cards too).
+- **Markup (exact):**
+
+  ```html
+  <div class="hub-card pl-danger-zone">
+      <div class="pl-danger-zone__head">
+          <svg class="pl-danger-zone__icon" width="18" height="18" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+               aria-hidden="true">
+              <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+              <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+          </svg>
+          <h2 class="pl-danger-zone__title">Danger Zone</h2>
+      </div>
+      <p class="pl-danger-zone__text">
+          Deleting your account permanently removes your personal info (name, photo, contact details, bio)
+          from Past Lives and signs you out everywhere. It does not cancel any paid subscription managed
+          outside this site.
+      </p>
+      <p class="pl-danger-zone__text">
+          <strong>This can't be undone from here.</strong> To use Past Lives again, a guild lead or admin
+          will need to send you a new invite.
+      </p>
+      <div class="pl-danger-zone__footer">
+          <button type="button" class="pl-btn pl-btn--danger pl-btn--sm"
+                  @click="$dispatch('open-confirm', 'delete-account')">Delete My Account</button>
+      </div>
+  </div>
+  ```
+
+  The `confirm_modal` include with `confirm_typed_value="DELETE"` (`:667`) is kept **byte-for-byte** — the typed-DELETE flow is locked. Note the trigger button also drops to `pl-btn--sm` per the destructive-action checklist (§3 of the UX rubric: danger buttons are small, the modal is the guard).
+- **CSS (`static/css/components.css`, new — it is a reusable card treatment):**
+
+  ```css
+  .pl-danger-zone { border: 1px solid rgba(220, 38, 38, 0.45); background: rgba(220, 38, 38, 0.07); }
+  .pl-danger-zone__head { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+  .pl-danger-zone__icon { color: #f0a0a0; flex-shrink: 0; }
+  .pl-danger-zone__title { font-size: 1rem; font-weight: 700; margin: 0; color: #f0a0a0; }
+  .pl-danger-zone__text { margin: 0 0 0.75rem; font-size: 0.9rem; }
+  .pl-danger-zone__footer { display: flex; justify-content: flex-end; margin-top: 1.25rem;
+                            padding-top: 1rem; border-top: 1px solid rgba(220, 38, 38, 0.25); }
+  [data-theme="light"] .pl-danger-zone { border-color: rgba(220, 38, 38, 0.35); background: rgba(220, 38, 38, 0.05); }
+  [data-theme="light"] .pl-danger-zone__icon,
+  [data-theme="light"] .pl-danger-zone__title { color: #b03030; }
+  ```
+
+  The `#f0a0a0` / `#b03030` pair is the established danger-text precedent (`hub.css:442,574`); rgba tints over the theme's card background work in both themes without inventing a token. **Verify both themes.**
+- **States:** none beyond the modal (existing). **Mobile:** card reflows naturally; the footer button stays right-aligned (a full-width danger button would over-invite the tap).
+
+### 6.4 Notifications — section order, jump chips, back-to-top (b)
+
+- **Screens:** `templates/hub/_notifications_settings.html` (chips), `templates/hub/partials/_notification_matrix.html` (anchors), `user_settings.html` (back-to-top).
+- **Section order** is entirely server-side (§5.1/5.3) — the template renders `notif_matrix` in order received.
+- **Jump chips** — in `_notifications_settings.html`, between the intro paragraph and the Discord CTA (only this wrapper gets them; the admin member-edit and token pages include the matrix partial directly and stay chip-free):
+
+  ```html
+  <nav class="pl-notif-jump" aria-label="Jump to a notification section">
+      {% for category, rows in notif_matrix %}
+          <a class="pl-notif-jump__chip" href="#notif-{{ category|slugify }}">{{ category }}</a>
+      {% endfor %}
+  </nav>
+  ```
+
+  In `_notification_matrix.html:27`, each section gains its anchor: `<div class="pl-notif-section" id="notif-{{ category|slugify }}">`. `slugify` handles "Staff & leadership" → `staff-leadership`; ids are unique per page (one matrix per page on every consumer). Plain hash anchors: `hx-boost` ignores local `#` links, so no htmx involvement, and `html { scroll-behavior: smooth }` + the existing `prefers-reduced-motion` reset (`hub.css:182-190`) give smooth-or-instant scrolling for free — **no JS**.
+- **Anchor offset** for the sticky topbar: `.pl-notif-section { scroll-margin-top: calc(var(--topbar-height) + 1rem); }` (components.css, next to the existing `.pl-notif-section` rules at `:412`).
+- **Chips CSS** (components.css, `pl-notif-*` family):
+
+  ```css
+  .pl-notif-jump { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0 0 1.25rem; }
+  .pl-notif-jump__chip { padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.8rem;
+                         background: var(--hub-surface); color: var(--hub-text-muted);
+                         border: 1px solid transparent; text-decoration: none; }
+  .pl-notif-jump__chip:hover,
+  .pl-notif-jump__chip:focus-visible { color: var(--hub-text); border-color: var(--color-tuscan-yellow);
+                                       text-decoration: none; }
+  ```
+
+  Theme tokens only; both themes covered by the tokens themselves.
+- **Back-to-top** — in `user_settings.html`, after the tab panes (page-scoped: every tab here is long, and the button is harmless when the page is short because it only shows past 400px):
+
+  ```html
+  <button type="button" class="pl-scroll-top"
+          x-data="{ show: false }" x-show="show" x-cloak
+          x-init="window.addEventListener('scroll', () => { show = window.scrollY > 400 }, { passive: true })"
+          @click="window.scrollTo({ top: 0, behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth' })"
+          aria-label="Back to top">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+           stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 15l-6-6-6 6"/></svg>
+  </button>
+  ```
+
+  This is the public-CMS pattern (`classes/public/list.html:146-155`) with two upgrades: hub tokens, and an explicit reduced-motion check (CSS `scroll-behavior` does **not** govern a JS `scrollTo` with an explicit `behavior`, so the `matchMedia` guard is required, not decoration).
+- **CSS (`static/css/hub.css`, hub-tokenized — deliberately NOT the cms `#scroll-top-btn` styles):**
+
+  ```css
+  .pl-scroll-top { position: fixed; bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px)); right: 1.25rem;
+                   z-index: 90; width: 44px; height: 44px; border-radius: 50%; border: 1px solid var(--hub-border);
+                   cursor: pointer; background: var(--hub-elevated); color: var(--color-tuscan-yellow);
+                   display: flex; align-items: center; justify-content: center;
+                   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25); }
+  .pl-scroll-top:hover { transform: translateY(-2px); }
+  @media (max-width: 768px) {
+      #pl-settings-root { padding-bottom: 4.5rem; }
+  }
+  ```
+
+  (`--hub-border` is a real token — defined for both themes at `hub.css:68` and `:139`.) **z-index: 90, pinned** — above page content and the sticky topbar (50; irrelevant anyway, the button lives at the bottom edge) and below the modal layer (`.pl-modal-backdrop`, 500), so the discard confirm always covers the button.
+- **Mobile clearance (the locked requirement, corrected per review):** padding the Save rows sideways guards the wrong elements — the real bottom-right colliders on a phone are the **Guilds tab's right-edge toggle switches** (the new default landing), the **danger-zone footer button** on Account, and the **Tours card Save** sitting below `.pl-notif-actions`. One rule covers every tab: `padding-bottom: 4.5rem` on the settings root (`#pl-settings-root`) at ≤768px, so the page's last row of controls always scrolls clear of the fixed 44px button — the FAB floats over the padded strip, never over a control. State in the PR that this was checked at phone width on the Guilds, Notifications, and Account tabs.
+- **States:** chips render one per *rendered* section — a member with no staff section gets no dead "Staff & Leadership" chip, and an empty category never renders a section at all (categories derive from actual rows, `build_matrix:392`), so no chip can point at nothing. Back-to-top hidden until 400px (its `x-cloak` prevents a flash). **Reduced motion:** anchors instant via the existing CSS reset; button instant via the `matchMedia` guard.
+- **A11y:** chips are real anchors inside a labeled `<nav>` (keyboard + screen-reader native); back-to-top keeps the `aria-label` and is a real `<button>` with a 44px tap target.
+
+### 6.5 Section subtitles (d)
+
+- **Screen:** `_notification_matrix.html`, immediately after the category heading row — extending the existing Staff-note conditional block (`:36-42`), same `.pl-notif-section-note` class, no new CSS.
+
+  ```html
+  {% if category == 'Guilds' and matrix_self and not prefs_token %}
+      <p class="hub-text-muted pl-notif-section-note">
+          <a href="?tab=guilds" @click.prevent="go('guilds')">Manage which guilds send you updates →</a>
+      </p>
+  {% endif %}
+  {% if category == 'Meetings' and matrix_self and not prefs_token %}
+      <p class="hub-text-muted pl-notif-section-note">
+          <a href="{% url 'hub_meetings' %}">View upcoming meetings →</a>
+      </p>
+  {% endif %}
+  ```
+
+- The Guilds link is the `_my_guilds.html:43` in-page pattern — `href` as a real fallback, `@click.prevent="go(…)"` so it switches the Alpine tab without a reload (and routes through the dirty guard, which is exactly what we want: jumping from unsaved matrix edits to the Guilds tab should prompt).
+- The Meetings link is a normal (boosted) navigation to `/meetings/` (`hub_meetings`, `hub/urls.py:8`) — when the matrix is dirty, the htmx-confirm guard (§6.6) intercepts it; that is correct behavior, not an accident.
+- **`matrix_self and not prefs_token` guard, reasoned:** `matrix_self` excludes the admin member-edit render (an admin editing *your* prefs has no "your guilds" tab in scope); `not prefs_token` excludes the token email-prefs page, where there is no Alpine `tab`/`go()` and `?tab=guilds` would bounce a logged-out visitor to login. On those surfaces the sections simply render without a subtitle — same behavior as today.
+- **Copy check:** plain language, no dashes, `→` matches the existing Staff note ("Manage your admin duties →", `:38`).
+
+### 6.6 Unsaved-changes guard (f)
+
+**Scope.** Exactly the three batch-save forms: the notification matrix form (`_notification_matrix.html:16`), the Guided Tours form (`_tour_settings.html:10`), and the Profile form (`user_settings.html:53`). The Guilds tab autosave toggles, the Skills HTMX controls, and the Account tab's email forms are explicitly out — they save immediately or on their own short-form Save.
+
+**Dirty tracking (Alpine, page root).** The settings root `x-data` grows:
+
+```js
+{
+  tab: '{{ active_tab|default:"guilds" }}',
+  dirty: { notifications: false, tours: false, profile: false },
+  pending: null,   // { type: 'tab', tab } | { type: 'nav', proceed }
+  isDirty() { return this.dirty.notifications || this.dirty.tours || this.dirty.profile },
+  go(next) {
+    this.pending = null;   // drop any stale held navigation before deciding (never resume an old one)
+    if (this.tab === next) return;
+    if (this.isDirty()) { this.pending = { type: 'tab', tab: next };
+                          this.$dispatch('open-confirm', 'discard-settings-changes'); }
+    else { this.tab = next; }
+  },
+  discard() {
+    const p = this.pending; this.pending = null;
+    if (p && p.type === 'nav') {
+      // The page is about to unload — nothing to reset.
+      this.dirty = { notifications: false, tours: false, profile: false };
+      p.proceed();
+      return;
+    }
+    if (this.dirty.profile) {
+      // Profile edits live partly in Alpine state — a full re-render is the only honest reset (see below).
+      // Clear the flags BEFORE navigating: assign() fires beforeunload, and with dirty still set the
+      // browser would stack a native "Leave site?" prompt on top of the discard the user just confirmed
+      // (cancelling that would strand a half-state). Mirrors the nav branch.
+      this.dirty = { notifications: false, tours: false, profile: false };
+      window.location.assign('?tab=' + ((p && p.tab) || this.tab));
+      return;
+    }
+    // Reset ONLY the forms whose flag was actually set. A blanket reset of every data-dirty-key form
+    // would include a CLEAN profile form — and by this spec's own analysis, reset() forces the
+    // x-model master checkbox unchecked while Alpine's `listed` stays true, so the member's NEXT
+    // profile Save would silently delist them. Reachable with profile never dirty (e.g. discarding
+    // matrix edits on a tab switch), so profile is structurally excluded here: its discard is always
+    // the reload branch above.
+    ['notifications', 'tours'].filter((k) => this.dirty[k]).forEach((k) => {
+      document.querySelector('form[data-dirty-key="' + k + '"]')?.reset();
+    });
+    this.dirty = { notifications: false, tours: false, profile: false };
+    if (p && p.type === 'tab') this.tab = p.tab;
+  },
+}
+```
+
+The root element gets `id="pl-settings-root"` and `@pl-settings-discard.window="discard()"` (the modal is teleported to `<body>`, outside Alpine scope inheritance — a window event is the documented bridge, same as the toast contract).
+
+Each tracked form gets three attributes: `data-dirty-key="notifications"` (resp. `tours`, `profile`), `@input="dirty.notifications = true" @change="dirty.notifications = true"` (both — `change` alone fires only on blur for text inputs), and `@submit="dirty.notifications = false"` (clears the flag **before** the full-page POST navigates, so `beforeunload` never nags on a legitimate Save; this is the locked "clear before navigation" requirement). Alpine scope inheritance makes `dirty` reachable from the nested profile `x-data` — no plumbing needed.
+
+**Profile's Alpine-only controls must arm the guard explicitly (reviewer blocker, part one).** The directory master seg buttons, the per-field visibility pills, and the Hidden/Public buttons are `@click` buttons that mutate Alpine state feeding hidden `:value` inputs — they fire no `input` or `change`, so the form-level listeners alone would never arm the guard and navigating away would drop exactly those edits with no prompt. Same for the contact-row "+ Add" and clone-"Remove" buttons. Fix: each of these controls gains a `data-arm-dirty` attribute — the two `.pl-profile-master__seg-btn` buttons (`user_settings.html:100,110`), every `.pl-vis-toggle` (the shared `hub/partials/_profile_field_with_visibility.html` pill plus the two inline email/photo pills at `:134,155`), the three contact "+ Add" buttons, and the Remove button inside each contact `<template>` — and the profile form gets one delegated listener: `@click="if ($event.target.closest('[data-arm-dirty]')) dirty.profile = true"`. Explicit opt-in markers rather than a broad "any button" selector, so the Discord connect CTA and the photo-delete modal trigger (both inside the form, both acting elsewhere) can never arm a false prompt before their own navigations.
+
+**Bulk buttons set dirty.** `plNotifBulk` flips `.checked` programmatically, which fires **no** `change` event — add one line at the end (`_notification_matrix.html:97-102`):
+
+```js
+const form = scope.closest ? (scope.closest('form') || scope) : scope;
+form.dispatchEvent(new Event('change', { bubbles: true }));
+```
+
+(`scope` is either the `<form>` itself or a `.pl-notif-section` inside it.) On the admin member-edit and token pages the dispatched event finds no Alpine listener and is inert — safe to share.
+
+**The confirm dialog.** Reuse `components/confirm_modal.html` in JS mode, included once in `user_settings.html`:
+
+```html
+{% include "components/confirm_modal.html" with confirm_id="discard-settings-changes" confirm_title="Discard unsaved changes?" confirm_message="You have unsaved changes on this page. If you leave now they will be lost." confirm_button_text="Discard Changes" confirm_cancel_text="Stay" confirm_js="window.dispatchEvent(new CustomEvent('pl-settings-discard'))" %}
+```
+
+Two-option, as locked: **Stay** (also Escape / click-outside / ×, all existing modal behavior) and **Discard Changes**. This needs one tiny backward-compatible component change: `confirm_modal.html:109` becomes `>{{ confirm_cancel_text|default:"Cancel" }}<` — every existing include is untouched.
+
+**Discard really discards — two mechanisms, because Profile is special (reviewer blocker, part two).** Because tab panes are `x-show` (DOM persists), merely switching tabs would keep the edits lurking, so a discard must genuinely revert. The matrix and Tours forms are plain server-rendered controls whose defaults live in HTML attributes — `form.reset()` restores the rendered `checked` states and is a faithful discard, so a pure matrix/tours discard resets in place and switches tabs client-side. The Profile pane is **not** resettable that way: its Alpine state (`listed`, `vis`, `fields`) feeds hidden `:value` inputs that `reset()` cannot touch, and reset actively *corrupts* it — the master directory checkbox is `x-model="listed"` with **no `checked` attribute** (`user_settings.html:94-99`), so `reset()` forces it unchecked while `listed` stays `true`, Alpine never re-asserts, and the *next* Save would submit `show_in_directory` absent, **silently delisting the member from the directory**. Cloned contact rows would also survive a reset as empty rows. So when `dirty.profile` is set, `discard()` performs a **pane re-render** instead: `window.location.assign('?tab=<target>')` — a full reload restores server truth for every input, every piece of Alpine state, and the live preview, and drops cloned rows; the reload's `_resolve_settings_tab` lands on the target tab. A mixed-dirty discard (profile + matrix) takes the reload path, which resets everything at once. A `type: 'nav'` discard needs no reset at all — the page is about to unload.
+
+**Hard navigation** (sidebar links — `hx-boost="false"`, `base.html:89` — address bar, tab close):
+
+```js
+window.addEventListener('beforeunload', (e) => {
+  const root = window.Alpine && Alpine.$data(document.getElementById('pl-settings-root'));
+  if (root && root.isDirty()) { e.preventDefault(); e.returnValue = ''; }
+});
+```
+
+Browser-native prompt; no custom UI possible there, by design. Its remaining role is **true hard navigations only** — sidebar links (`hx-boost="false"`), address bar, refresh, tab close. Untracked *boosted* form submits never reach it: the `htmx:confirm` hold below intercepts them first (and the once-cited Add Email-while-matrix-dirty case cannot occur at all — dirty arises only on the pane being edited, and reaching the Account tab passes the tab guard).
+
+**Boosted-link navigation** (the body-level `hx-boost="true"`, `base.html:72`, where `beforeunload` does NOT fire): htmx 2.0.4's cancelable **`htmx:confirm`** event with async resume — this is the precisely-researched mechanism (both `htmx:confirm` and `issueRequest` verified present in the bundled `static/js/htmx.min.js`, version 2.0.4):
+
+```js
+document.body.addEventListener('htmx:confirm', (evt) => {
+  const rootEl = document.getElementById('pl-settings-root');
+  const root = rootEl && window.Alpine && Alpine.$data(rootEl);
+  if (!root || !root.isDirty()) return;
+  const elt = evt.detail.elt;
+  const boostedLink = elt instanceof HTMLAnchorElement;
+  const hasHxVerb = ['hx-get', 'hx-post', 'hx-put', 'hx-patch', 'hx-delete']
+      .some((a) => elt.hasAttribute(a));           // any explicit verb, not just get/post (future-proof)
+  const boostedForm = elt instanceof HTMLFormElement
+      && !elt.hasAttribute('data-dirty-key') && !hasHxVerb;
+  const crossFormSave = elt instanceof HTMLFormElement && elt.dataset.dirtyKey
+      && Object.entries(root.dirty).some(([k, v]) => v && k !== elt.dataset.dirtyKey);
+  if (!boostedLink && !boostedForm && !crossFormSave) return;
+  root.pending = null;                       // drop any stale held navigation before holding a new one
+  evt.preventDefault();                      // hold the request
+  // Re-arm the held form's OWN flag: its Alpine @submit already cleared it in this same submit
+  // dispatch, but the hold cancelled the POST — without this, a Stay would leave that pane's
+  // never-saved edits unguarded AND invisible to a later Discard's flag-filtered reset.
+  // No-op for the link and boosted-form branches (no data-dirty-key).
+  if (elt instanceof HTMLFormElement && elt.dataset.dirtyKey) root.dirty[elt.dataset.dirtyKey] = true;
+  root.pending = { type: 'nav', proceed: () => evt.detail.issueRequest(true) };
+  window.dispatchEvent(new CustomEvent('open-confirm', { detail: 'discard-settings-changes' }));
+});
+```
+
+Why this filter, precisely: `htmx:confirm` fires for *every* htmx request, and `hx-boost` boosts **forms as well as anchors** (`base.html:72`) — so an anchor-only filter would let boosted POSTs navigate the whole page with no `beforeunload` and no hold. Three branches:
+
+- **Boosted links** — every in-hub navigation link.
+- **Boosted forms** (no `data-dirty-key`, no explicit hx verb) — the **reachable** beneficiaries are the *same-pane* plain-POST confirm-modal forms: **photo-delete while the Profile is dirty** and **Discord-disconnect while the matrix is dirty** (both are plain `method="post"` forms inside `confirm_modal.html`, boosted by the body). Yes, that means two dialogs in sequence — action confirm, then the discard hold — accepted: rare, and each answers a different question. The cross-*pane* scenario the earlier draft cited (Add Email while the matrix is dirty) is actually **unreachable**: dirty only arises on the pane being edited, and every route to the Account tab passes the tab guard first — so it justifies nothing, but the branch still correctly covers any future boosted form. Exemptions: forms with an explicit hx verb (`hx-get/post/put/patch/delete` — partial-swap forms like Skills don't navigate, nothing is lost) and forms carrying `data-dirty-key` — for their own key (their `@submit` clears it, and gating a form on its own flag would race the Alpine submit listener).
+- **Cross-form saves** (reviewer should-fix): a tracked form's Save must still be held when a *different* pane is dirty — otherwise editing matrix toggles and clicking the Tours card's Save would clear only `dirty.tours`, sail through the exemption, and navigate away with the matrix edits silently gone. The `k !== elt.dataset.dirtyKey` condition checks only *other* keys, so the own-key `@submit` race is irrelevant here. On Discard the held Save proceeds (`issueRequest(true)`) and the other pane's edits are knowingly dropped; on Stay nothing is submitted.
+
+The guild autosave toggles are `<input>` elements → no branch → **still exempt** (locked requirement). Hash-only jump chips never reach htmx at all (boost ignores local `#` links). "Discard Changes" resumes the held request via `issueRequest(true)` (the `true` skips htmx re-asking); "Stay" simply drops it — the click is consumed, the user stays put. Both `go()` and this handler null `pending` up front, so a dropped ("Stay") navigation closure can never be resumed later by an unrelated discard.
+
+**A11y / focus management (checklist item + reviewer should-fix):** `confirm_modal.html`'s root `x-data` grows `opener: null`. On open it records `document.activeElement` and moves focus to the Cancel/Stay button (`x-effect="if (open) { opener = document.activeElement; $nextTick(() => $el.querySelector('.pl-btn--secondary')?.focus()) }"`); **every close path** (Stay/Cancel, Escape, ×, click-outside) restores focus to `opener` — without the restore, "Stay" would strand keyboard focus on a hidden element. A full focus **trap** stays explicitly deferred (§10): the page has no trap utility, and Escape-to-close plus focus restore covers the keyboard flow. **Named behavior change:** every existing confirm modal now opens focused on its Cancel button — including the typed-DELETE account modal, which previously left focus wherever the trigger was; the user tabs or clicks into the typed field. A deliberate safe default for destructive confirms, called out in §9 so existing confirm-modal specs get eyeballed. One more deliberate exemption worth naming: the email card's footer cross-link to Notifications is a **button**, not an anchor (`user_settings.html:638`) — it stays a button, which conveniently keeps it out of the `htmx:confirm` anchor branch; it routes through `go()` like every tab switch.
+
+**States walk (f):** clean forms → tabs switch instantly, links navigate, no prompts. Dirty + tab click → modal; Stay keeps edits and tab; Discard resets in place and switches (matrix/tours) or reloads onto the target tab (profile or mixed). Dirty + boosted link, same-pane confirm-modal POST (photo-delete, Discord-disconnect), or a *different* tracked form's Save (cross-form) → modal; Discard resumes the held navigation/submit. Dirty + sidebar/close/refresh → native browser prompt. Save on any tracked form → flag cleared pre-submit, normal redirect + Django success message, no prompt. Guild toggle flips → no flags, no prompts, existing toast/error-revert behavior. **Accepted limitation, stated rather than implied away (reviewer should-fix):** the browser Back/Forward buttons through htmx's history restoration bypass *both* guards — restoration replays a cached snapshot with no unload event and no htmx request, and `popstate` is not cancelable. Dirty edits are lost without a prompt on Back. Accepted for this round (§10); the guard covers clicks, submits, tab switches, refresh, and tab-close.
+
+### 6.7 View-as walk (a) — what each viewer sees
+
+| Viewer | Staff & Leadership section | Save while in this state |
+|---|---|---|
+| Plain member (incl. guild lead by `led_guilds`) | Eligibility-filtered as today (leads see their rows) | Unchanged |
+| Admin / officer, viewing as self | Rendered — now **last** | Full save incl. staff rows |
+| Admin / officer, **viewing as Member or Guest** | **Omitted entirely** (flag `False`) | Staff-event rows untouched (§5.2) |
+| Admin viewing as Guild Officer | Rendered (previewing a staff role) | Full save |
+| Token email-prefs page / admin member-edit | Unchanged (default `True`) | Unchanged |
+
+Also omitted with the section: its jump chip (chips derive from rendered sections) and the `capabilities_url` note inside it. The `capabilities_url` context computation (`hub/views.py:2160-2164`) can stay as is — the template only renders it inside the staff section.
+
+## 7. Notifications / emails / activity
+
+None sent or changed by this feature. The only spine-adjacent effect is the `X-Category` header shift for the two re-tagged orientation events (§4). No new `SiteActivity` kinds.
+
+## 8. Build order (phased; each phase ships green)
+
+1. **Matrix layer** — `include_staff_section` flag through `_visible_events` / `visible_channels` / `build_matrix` / `save_matrix`; new `CATEGORY_ORDER`; staff-last `_ordered_categories` (+ docstring/comment truth-up); `core/triggers.py` re-tags. Specs for all of it (§9). Run `manage.py check` (registry-adjacent change).
+2. **View + tab plumbing** — view-as flag in `user_settings` (GET + POST paths); `_resolve_settings_tab` default/alias/whitelist + the POST `form_id` tab derivation (§5.3 blocker fix); `HubEmailView` redirect; tab-bar reorder in the template (still plain `@click` at this phase). Specs for tab resolution (incl. the failed-profile-POST pin) + view-as rendering. Update the §9 existing-test inventory in the same phase.
+3. **Account tab** — move the email card, delete the Emails pane/button, danger-zone markup + CSS, copy fixes. Template-render specs.
+4. **Notifications pane** — jump chips + anchors + `scroll-margin-top`, subtitles (d), back-to-top button + CSS + mobile clearance.
+5. **Dirty guard** — page `x-data` growth, `go()` rewiring of every tab-switch point (4 tab buttons, `_my_guilds.html:43`, the relocated email-card footer button, the new Guilds subtitle), form attributes + `data-arm-dirty` markers, the Profile reload-discard path, `plNotifBulk` change-dispatch, `beforeunload` + `htmx:confirm` (links **and** boosted forms) listeners, discard modal include, `confirm_modal` `confirm_cancel_text` + open-focus/restore. Run `tests/template_comment_lint_spec.py` with the template phases.
+
+> Spec only — do not build until approved. Versioning/changelog is handled by the release pipeline and is explicitly not part of this spec.
+
+## 9. Testing
+
+BDD `*_spec.py`, `describe_*`/`it_*` (never `context_*` — it silently collects nothing), factory-boy, existing fixtures from `tests/hub/notification_settings_spec.py` and `tests/hub/my_guilds_spec.py`.
+
+**Matrix ordering + re-tag** (`tests/core/notification_matrix_ordering_spec.py`, new):
+- Section order for a plain member starts `Orientations, Guilds, Events` and never contains `Staff & leadership`.
+- For an eligible admin, `Staff & leadership` is the **last** section.
+- `orientation_update` renders under Orientations (not Guilds); `orientation_requested` lands in the staff section for an orienter.
+- Re-tag safety: a saved `NotificationPreference` row for `orientation_update` still round-trips through `build_matrix` → checked cell → `save_matrix` unchanged (the event-key evidence, executable).
+- An unknown/extra category still falls to the end, alpha, before staff.
+
+**View-as omission + save skip** (extend `tests/hub/notification_settings_spec.py`):
+- `build_matrix(user, include_staff_section=False)` yields no staff section and no staff-only channel columns.
+- Admin with session `view_as_role = "member"`: GET `/settings/` response context matrix has no staff section; **POST the notifications form in that state and assert the admin's pre-existing staff-event `NotificationPreference` rows are untouched** (the §5.2 wipe trap, pinned).
+- Officer previewing member: hidden. Guild lead (fog_role member, `led_guilds`): still shown. Admin viewing as officer: shown.
+- Token flow and admin member-edit still render/save staff rows (default flag).
+
+**Tab resolution** (`tests/hub/user_settings_tabs_spec.py`, new):
+- No `?tab` → `active_tab == "guilds"`; garbage `?tab=<script>` → `"guilds"`; `?tab=emails` → `"account"`; each surviving value passes through.
+- Bare `/settings/` GET stamps `guild_updates_prompt_answered_at` (the deliberate side effect, pinned as intended); second GET is a no-op.
+- **Failed profile POST re-renders with `active_tab == "profile"` and does NOT stamp `guild_updates_prompt_answered_at`** (the reviewer-blocker pin — errors visible, no wrong-write).
+- allauth `account_email` GET redirects to `/settings/?tab=account`.
+
+**Templates** (render assertions in the same spec files):
+- Emails pane gone; email card renders inside the Account pane above `.pl-danger-zone`; danger card contains the typed-DELETE confirm include unchanged.
+- Chips: one `pl-notif-jump__chip` per section with matching `#notif-<slug>` anchor ids; no staff chip for a plain member.
+- Subtitles: Guilds + Meetings notes present when `matrix_self` and no token; absent on the token page and admin member-edit render.
+- `confirm_modal` with `confirm_cancel_text="Stay"` renders "Stay"; without the param still renders "Cancel" (backward-compat pin). Existing confirm-modal specs re-run to catch the `x-effect` focus addition.
+- Guard markup pins: `data-dirty-key` on exactly three forms; `data-arm-dirty` present on the seg buttons, the vis pills (shared partial + the two inline ones), and the contact add/remove controls; the discard modal include and the `plNotifBulk` change-dispatch line present in the rendered page.
+- `tests/template_comment_lint_spec.py` (multi-line `{# #}` guard) — run after every template phase.
+
+**Existing tests to update (verified breakages — reviewer inventory):**
+- `tests/core/events/settings_matrix_spec.py:127` `it_sees_the_section_for_admin_alerts_rendered_first` — pins staff FIRST; inverted by this spec. Rename/re-assert to *rendered last*.
+- `tests/hub/views_spec.py:317-323` `it_defaults_to_profile_tab` → defaults to `guilds`.
+- `tests/hub/views_spec.py:331` `it_honors_tab_query_param` — asserts `emails` survives the whitelist; now asserts the `emails → account` alias.
+- `tests/hub/views_spec.py:334-342` `it_falls_back_to_profile_when_tab_param_is_not_whitelisted` → falls back to `guilds`.
+- `tests/hub/views_spec.py:687,702` — allauth redirect assertions `== "/settings/?tab=emails"` → `?tab=account`.
+- `tests/hub/my_guilds_spec.py:261` — asserts `active_tab == "profile"` → `guilds`.
+
+**Not server-testable, stated honestly:** the dirty-guard runtime behavior (Alpine flags, `beforeunload`, `htmx:confirm` interception, the reset/reload discard, back-to-top scroll listener) is browser JS. Server-side we pin what we can: the guard *markup* (`data-dirty-key` on exactly three forms, `@submit` clears, the discard modal include, `plNotifBulk`'s dispatch line present in the rendered page). The rest is a manual QA checklist in the PR: dirty→tab-switch modal both outcomes, profile discard reloads onto the target tab (and the master directory toggle survives a discard round-trip un-corrupted), Alpine-only controls (seg buttons, vis pills, contact add/remove) arm the guard, dirty→sidebar native prompt, dirty→boosted link held + resumable, photo-delete confirm while Profile is dirty and Discord-disconnect confirm while the matrix is dirty both held, Tours Save while the matrix is dirty held (cross-form), cross-form hold → Stay → tab-switch Discard resets BOTH panes (the re-armed own flag), guild toggle immunity, bulk-button dirtiness, Save-no-prompt, focus lands on Stay and returns to the opener on close, both themes, phone-width FAB clearance on Guilds/Notifications/Account, reduced-motion instant scrolling.
+
+## 10. Open / deferred / out of scope
+
+- **Auto-save-on-leave** (third option in the discard dialog) — explicitly out; two-option guard is locked.
+- **Back/Forward through htmx history restoration** — not guardable (`popstate` isn't cancelable, restoration makes no request); dirty edits are lost without a prompt on Back. Accepted limitation, stated in §6.6's states walk.
+- **Focus trap in the confirm modal** — deferred; open-focus + focus-restore ship (§6.6), a full trap needs a utility the codebase doesn't have and Escape-to-close covers the exit.
+- **Profile tab redesign** — untouched beyond the guard attributes and one hint-copy fix.
+- **Email management forms in the dirty guard** — out; they save immediately per action, and no reachable state submits them while another pane is dirty (dirty arises only on the pane being edited; every route to Account passes the tab guard). The same-pane confirm-modal POSTs that *are* reachable while dirty — photo-delete, Discord-disconnect — are covered by the boosted-form hold (§6.6).
+- **Renaming `?tab=` values or URLs** — the `emails→account` alias is the only routing change; nothing else moves.
+- **Security category** — kept in `CATEGORY_ORDER` though no event currently declares it; costs nothing, self-heals when one appears.
+- **hub/CLAUDE.md staleness** — it still lists `hub_profile_settings` / `hub_email_preferences` URLs that no longer exist in `hub/urls.py`; a one-line doc tidy can ride along with the build PR but is not part of this feature.

--- a/hub/views.py
+++ b/hub/views.py
@@ -32,7 +32,7 @@ from billing.exceptions import NoPaymentMethodError, TabLimitExceededError, TabL
 from billing.models import BillingSettings, Tab, TabCharge
 from classes.models import Category, ClassOffering
 from core.models import HeroCropMixin, SiteConfiguration
-from hub.view_as import ALL_ROLES, SESSION_ROLE_KEY, fog_admin_required
+from hub.view_as import ALL_ROLES, ROLE_GUEST, ROLE_MEMBER, SESSION_ROLE_KEY, fog_admin_required
 from hub.forms import (
     BetaFeedbackForm,
     CalendarFeedFormSet,
@@ -2069,14 +2069,15 @@ def guild_updates_prompt(request: HttpRequest) -> HttpResponse:
 
 
 def user_settings(request: HttpRequest) -> HttpResponse:
-    """Tabbed user settings page — Profile + Emails + Notifications.
+    """Tabbed user settings page — Guilds, Notifications, Profile, Account.
 
     Three concerns POST to this endpoint, disambiguated by the ``form_id`` hidden
-    field: ``profile`` (member info) and ``notifications`` (the event × channel
-    preference matrix). Email address management (add, primary, verify, remove) POSTs
-    to allauth's ``account_email`` URL, which is overridden in ``plfog.urls`` to
-    redirect back here after each action. The Notifications tab is the unified
-    preferences matrix (design §2.7) sourced from the event registry.
+    field: ``profile`` (member info), ``notifications`` (the event × channel preference
+    matrix), and ``tours``. Email address management (add, primary, verify, remove) lives
+    on the Account tab and POSTs to allauth's ``account_email`` URL, which is overridden
+    in ``plfog.urls`` to redirect back here (``?tab=account``) after each action. The
+    Notifications tab is the unified preferences matrix (design §2.7) sourced from the
+    event registry.
     """
     if not request.user.is_authenticated:
         # Logged-out visitors are bounced to login, except the email "manage preferences"
@@ -2123,10 +2124,11 @@ def user_settings(request: HttpRequest) -> HttpResponse:
         contact_formset = None
 
     user: User = request.user  # type: ignore[assignment]  # @login_required guarantees User
+    include_staff = _settings_include_staff(request)
     if request.method == "POST" and request.POST.get("form_id") == "notifications":
         from core.events import settings_matrix
 
-        settings_matrix.save_matrix(user, request.POST)
+        settings_matrix.save_matrix(user, request.POST, include_staff_section=include_staff)
         messages.success(request, "Notification preferences updated.")
         return redirect(f"{request.path}?tab=notifications")
 
@@ -2139,7 +2141,7 @@ def user_settings(request: HttpRequest) -> HttpResponse:
     primary_email = next((ea for ea in email_addresses if ea.primary), None)
     primary_verified_json = "true" if primary_email is None or primary_email.verified else "false"
 
-    active_tab = _resolve_settings_tab(request, member)
+    active_tab = _settings_active_tab(request, member)
 
     if member is None and request.method == "GET" and not request.GET.get("tab"):
         messages.info(request, "Your account is not linked to a membership.")
@@ -2147,9 +2149,10 @@ def user_settings(request: HttpRequest) -> HttpResponse:
     from core.events import settings_matrix
     from hub.guild_membership import build_my_guilds_rows
 
-    notif_matrix = settings_matrix.build_matrix(user)
+    notif_matrix = settings_matrix.build_matrix(user, include_staff_section=include_staff)
     notif_channels = [
-        (channel, settings_matrix.CHANNEL_LABELS[channel]) for channel in settings_matrix.visible_channels(user)
+        (channel, settings_matrix.CHANNEL_LABELS[channel])
+        for channel in settings_matrix.visible_channels(user, include_staff_section=include_staff)
     ]
     # Channel labels keyed by channel value, so each matrix cell can build its own
     # screen-reader name (event × channel) via the get_item template filter.
@@ -2191,19 +2194,59 @@ def user_settings(request: HttpRequest) -> HttpResponse:
     )
 
 
+def _settings_include_staff(request: HttpRequest) -> bool:
+    """Whether the Staff & Leadership notification section should render (and save).
+
+    An admin/officer previewing the page as a Member or Guest must not see — or, on save,
+    wipe — the section. The flag flips only when a higher-role holder is previewing down; an
+    actual plain member (incl. a guild lead whose ``fog_role`` is member) always keeps their
+    staff rows. GET and the subsequent POST share the session-backed view-as choice, so build
+    and save agree (§5.2 — the save-without-flag wipe trap).
+    """
+    va = getattr(request, "view_as", None)
+    if va is None:
+        return True
+    previewing_down = va.view_as_role in (ROLE_MEMBER, ROLE_GUEST)
+    higher_role_holder = va.actual_is_admin or va.actual_is_guild_officer
+    return not (previewing_down and higher_role_holder)
+
+
+def _settings_active_tab(request: HttpRequest, member: Member | None) -> str:
+    """Resolve the active settings tab for a request.
+
+    On POST, derive the tab from the submitted ``form_id`` so a failed save re-renders on the
+    tab that failed (not the guilds default) and never stamps the guild-updates answer on a
+    landing the user didn't navigate to. The mapping covers all three save forms so any future
+    validating handler inherits the right tab for free. On GET, defer to
+    :func:`_resolve_settings_tab` (which whitelists the param and stamps a Guilds landing). (§5.3)
+    """
+    if request.method == "POST":
+        return {"profile": "profile", "tours": "notifications", "notifications": "notifications"}.get(
+            request.POST.get("form_id", ""), "guilds"
+        )
+    return _resolve_settings_tab(request, member)
+
+
 def _resolve_settings_tab(request: HttpRequest, member: Member | None) -> str:
     """Whitelist the settings ``tab`` param and record a Guilds-tab landing.
 
     The whitelist matters because the tab flows into an Alpine x-data JS expression —
     HTML escaping alone isn't enough to stop a payload like ``?tab='+alert(1)+'``.
 
-    Landing on the Guilds tab via its ``?tab=guilds`` deep link counts as having seen
-    and chosen your guild updates — the checklist step, the prompt's Skip fallback, and
-    every cross-link arrive this way. A deliberate idempotent write-on-GET (login-gated,
-    one-way, no-op after the first hit); see ``Member.mark_guild_updates_answered``.
+    Guilds is now the default (and unknown-value fallback) tab. The legacy ``?tab=emails``
+    deep link resolves to ``account`` — its Manage Email Addresses card moved there — so old
+    links keep working.
+
+    Landing on the Guilds tab counts as having seen and chosen your guild updates — the
+    checklist step, the prompt's Skip fallback, and every cross-link arrive this way. With
+    guilds as the default, this now fires on every bare ``/settings/`` GET, not just the
+    ``?tab=guilds`` deep link. A deliberate idempotent write-on-GET (login-gated, one-way,
+    no-op after the first hit); see ``Member.mark_guild_updates_answered``.
     """
-    tab_param = request.GET.get("tab", "profile")
-    active_tab = tab_param if tab_param in {"profile", "emails", "notifications", "guilds", "account"} else "profile"
+    tab_param = request.GET.get("tab", "guilds")
+    if tab_param == "emails":  # legacy deep links land on the email card's new home
+        tab_param = "account"
+    active_tab = tab_param if tab_param in {"profile", "notifications", "guilds", "account"} else "guilds"
     if active_tab == "guilds" and member is not None:
         member.mark_guild_updates_answered()
     return active_tab

--- a/plfog/urls.py
+++ b/plfog/urls.py
@@ -54,15 +54,17 @@ class HubEmailView(EmailView):
 
     POSTs (add, make primary, re-send, remove) still run through allauth's
     EmailView logic; only the success_url and GET rendering change so the user
-    always lands on /settings/?tab=emails instead of the legacy themed page.
+    always lands on /settings/?tab=account (the Manage Email Addresses card's home
+    after the Emails tab folded into Account) instead of the legacy themed page.
     """
 
-    # Always land back on the Emails tab after add/primary/resend/remove so the
-    # user's context is preserved instead of bouncing them to Profile.
-    success_url = "/settings/?tab=emails"
+    # Always land back on the Account tab (beside the email card) after
+    # add/primary/resend/remove so the user's context is preserved instead of
+    # bouncing them to Profile.
+    success_url = "/settings/?tab=account"
 
     def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
-        return redirect("/settings/?tab=emails")
+        return redirect("/settings/?tab=account")
 
 
 class SeededRequestLoginCodeView(RequestLoginCodeView):

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
-VERSION = "1.17.0"
+VERSION = "1.18.0"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.18.0",
+        "date": "2026-08-27",
+        "title": "A friendlier Settings page",
+        "changes": [
+            "Settings is easier to get around now. Guilds is the first tab, and the notifications "
+            "list is reordered with orientations, guilds, and events up top plus quick links to "
+            "jump between sections and a back to top button. Your email addresses now live with "
+            "your account details, and if you change a bunch of notification toggles we ask before "
+            "you leave so you do not lose them.",
+        ],
+    },
     {
         "version": "1.17.0",
         "date": "2026-08-27",

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -419,6 +419,76 @@
     font-size: 0.85rem;
 }
 
+/* Anchor offset so a jumped-to section clears the sticky topbar. */
+.pl-notif-section {
+    scroll-margin-top: calc(var(--topbar-height) + 1rem);
+}
+
+/* Jump-to-section chips above the notification matrix. */
+.pl-notif-jump {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0 0 1.25rem;
+}
+.pl-notif-jump__chip {
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    background: var(--hub-surface);
+    color: var(--hub-text-muted);
+    border: 1px solid transparent;
+    text-decoration: none;
+}
+.pl-notif-jump__chip:hover,
+.pl-notif-jump__chip:focus-visible {
+    color: var(--hub-text);
+    border-color: var(--color-tuscan-yellow);
+    text-decoration: none;
+}
+
+/* Danger-zone card treatment: red-tinted border + background in both themes, warning
+   icon, right-aligned footer button. Reusable, so it lives with the components. */
+.pl-danger-zone {
+    border: 1px solid rgba(220, 38, 38, 0.45);
+    background: rgba(220, 38, 38, 0.07);
+}
+.pl-danger-zone__head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+.pl-danger-zone__icon {
+    color: #f0a0a0;
+    flex-shrink: 0;
+}
+.pl-danger-zone__title {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0;
+    color: #f0a0a0;
+}
+.pl-danger-zone__text {
+    margin: 0 0 0.75rem;
+    font-size: 0.9rem;
+}
+.pl-danger-zone__footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(220, 38, 38, 0.25);
+}
+[data-theme="light"] .pl-danger-zone {
+    border-color: rgba(220, 38, 38, 0.35);
+    background: rgba(220, 38, 38, 0.05);
+}
+[data-theme="light"] .pl-danger-zone__icon,
+[data-theme="light"] .pl-danger-zone__title {
+    color: #b03030;
+}
+
 /* Bulk on/off controls (the top "Everything" row and each section's). */
 .pl-notif-bulk {
     display: inline-flex;

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -7109,3 +7109,35 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
     flex-wrap: wrap;
     margin: 0 0 0.5rem;
 }
+
+/* Floating back-to-top button on the User Settings page (hub-tokenized; deliberately
+   NOT the public-CMS #scroll-top-btn styles). z-index sits above page content and the
+   sticky topbar but below the modal backdrop (500), so the discard confirm covers it. */
+.pl-scroll-top {
+    position: fixed;
+    bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+    right: 1.25rem;
+    z-index: 90;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 1px solid var(--hub-border);
+    cursor: pointer;
+    background: var(--hub-elevated);
+    color: var(--color-tuscan-yellow);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+}
+.pl-scroll-top:hover {
+    transform: translateY(-2px);
+}
+
+/* Phone clearance: the fixed back-to-top FAB floats over a padded strip, never over the
+   page's last row of controls (Guilds toggles, danger-zone footer, Tours Save). */
+@media (max-width: 768px) {
+    #pl-settings-root {
+        padding-bottom: 4.5rem;
+    }
+}

--- a/templates/components/confirm_modal.html
+++ b/templates/components/confirm_modal.html
@@ -8,6 +8,10 @@ Parameters (pass via {% include ... with %}):
   confirm_action_url   — required (plain-POST mode), form POST target
   confirm_button_text  — optional, button label (default: "Confirm")
   confirm_button_style — optional, "danger" (default) or "primary"
+  confirm_cancel_text  — optional, label for the dismiss button (default: "Cancel")
+
+  On open the modal records the triggering element and moves focus to the Cancel/dismiss
+  button; every close path (Cancel, Escape, ×, click-outside) restores focus to the opener.
   confirm_field_name   — optional (plain-POST mode), name of one hidden field to carry with
   confirm_field_value    the POST (e.g. run_job=bill_tabs), so the teleported form — which posts
                          OUTSIDE its trigger's form — can still reach a named handler.
@@ -42,8 +46,9 @@ Parameters (pass via {% include ... with %}):
   confirm_js — inline JS the Confirm button runs.
 {% endcomment %}
 <template x-teleport="body">
-<div x-data="{ open: false, typed: '', note: '' }"
+<div x-data="{ open: false, typed: '', note: '', opener: null }"
      x-show="open"
+     x-init="$watch('open', (value) => { if (value) { opener = document.activeElement; $nextTick(() => $el.querySelector('.pl-btn--secondary')?.focus()); } else if (opener) { opener.focus(); opener = null; } })"
      x-transition:enter="modal-enter"
      x-transition:leave="modal-leave"
      @open-confirm.window="if ($event.detail === '{{ confirm_id }}') open = true"
@@ -106,7 +111,7 @@ Parameters (pass via {% include ... with %}):
                     </button>
                 </form>
                 {% endif %}
-                <button type="button" @click="open = false" class="pl-btn pl-btn--secondary" style="flex:1;">Cancel</button>
+                <button type="button" @click="open = false" class="pl-btn pl-btn--secondary" style="flex:1;">{{ confirm_cancel_text|default:"Cancel" }}</button>
             </div>
         </div>
     </div>

--- a/templates/hub/_notifications_settings.html
+++ b/templates/hub/_notifications_settings.html
@@ -6,6 +6,13 @@
     operational notices (receipts, security, booking and orientation updates) are always on and
     can't be turned off.
   </p>
+  {% if not prefs_token %}
+  <nav class="pl-notif-jump" aria-label="Jump to a notification section">
+    {% for category, rows in notif_matrix %}
+      <a class="pl-notif-jump__chip" href="#notif-{{ category|slugify }}">{{ category }}</a>
+    {% endfor %}
+  </nav>
+  {% endif %}
   {% if member %}
     {% comment %}
       Shared Discord CTA. It (and the confirm modal) sit OUTSIDE the notifications

--- a/templates/hub/_tour_settings.html
+++ b/templates/hub/_tour_settings.html
@@ -7,7 +7,11 @@ page's "Show me around" button or the Help page still work (the description says
 {% if tours_form %}
 <div class="hub-card" style="margin-top:1.5rem;">
     <h2 class="pl-notif-title">Guided Tours</h2>
-    <form method="post" class="hub-form">
+    <form method="post" class="hub-form"
+          data-dirty-key="tours"
+          @input="dirty.tours = true"
+          @change="dirty.tours = true"
+          @submit="dirty.tours = false">
         {% csrf_token %}
         <input type="hidden" name="form_id" value="tours">
         {% include "components/toggle.html" with field=tours_form.guided_tours_enabled toggle_label="Offer guided tours" toggle_description="Suggest a quick tour the first time you visit a new area. You can always start one yourself from a page's Show me around button or the Help page." %}

--- a/templates/hub/partials/_my_guilds.html
+++ b/templates/hub/partials/_my_guilds.html
@@ -40,7 +40,7 @@
       </div>
       <p class="hub-text-muted" style="margin-top:1rem; font-size:0.85rem;">
         How updates reach you (email, in app, Discord) is set on the
-        <a href="?tab=notifications" @click.prevent="tab = 'notifications'">Notifications tab</a>.
+        <a href="?tab=notifications" @click.prevent="go('notifications')">Notifications tab</a>.
       </p>
     {% else %}
       <p class="hub-text-muted">No guilds have been set up yet. Check back soon.</p>

--- a/templates/hub/partials/_notification_matrix.html
+++ b/templates/hub/partials/_notification_matrix.html
@@ -13,7 +13,7 @@ Context:
                      Staff & leadership note (only shown on one's own page).
   prefs_token    — optional no-login token carried through on the email-link flow.
 {% endcomment %}
-<form method="post" class="hub-form">
+<form method="post" class="hub-form"{% if matrix_self and not prefs_token %} data-dirty-key="notifications" @input="dirty.notifications = true" @change="dirty.notifications = true" @submit="dirty.notifications = false"{% endif %}>
   {% csrf_token %}
   <input type="hidden" name="form_id" value="notifications">
   {% if prefs_token %}<input type="hidden" name="t" value="{{ prefs_token }}">{% endif %}
@@ -24,7 +24,7 @@ Context:
     <button type="button" class="pl-notif-bulk__btn" onclick="plNotifBulk(this.closest('form'), false)">All off</button>
   </div>
   {% for category, rows in notif_matrix %}
-    <div class="pl-notif-section">
+    <div class="pl-notif-section" id="notif-{{ category|slugify }}">
     <div class="pl-notif-category-head">
       <h3 class="hub-detail-label pl-notif-category">{{ category }}</h3>
       <div class="pl-notif-bulk pl-notif-bulk--section">
@@ -39,6 +39,16 @@ Context:
       {% else %}
         <p class="hub-text-muted pl-notif-section-note">This member sees a row here only for a duty they hold or a role they have. The five capability alerts follow their admin capabilities on the Permissions tab.</p>
       {% endif %}
+    {% endif %}
+    {% if category == 'Guilds' and matrix_self and not prefs_token %}
+      <p class="hub-text-muted pl-notif-section-note">
+        <a href="?tab=guilds" @click.prevent="go('guilds')">Manage which guilds send you updates →</a>
+      </p>
+    {% endif %}
+    {% if category == 'Meetings' and matrix_self and not prefs_token %}
+      <p class="hub-text-muted pl-notif-section-note">
+        <a href="{% url 'hub_meetings' %}">View upcoming meetings →</a>
+      </p>
     {% endif %}
     <div class="pl-notif-matrix__scroll">
       <div class="pl-notif-matrix" role="table" aria-label="{{ category }} notification preferences"
@@ -99,5 +109,10 @@ Context:
     scope.querySelectorAll('input[type="checkbox"]:not(:disabled)').forEach(function (cb) {
       cb.checked = on;
     });
+    // Flipping .checked fires no change event, so the dirty guard would miss a bulk flip.
+    // Dispatch one bubbling change on the owning form. Inert where no Alpine listener exists
+    // (the admin member-edit and token pages), safe to share.
+    var form = scope.closest ? (scope.closest('form') || scope) : scope;
+    form.dispatchEvent(new Event('change', { bubbles: true }));
   }
 </script>

--- a/templates/hub/partials/_profile_field_with_visibility.html
+++ b/templates/hub/partials/_profile_field_with_visibility.html
@@ -3,6 +3,7 @@
         <label for="{{ field.id_for_label }}" class="pl-profile-row__label">{{ label }}</label>
         <button type="button"
                 class="pl-vis-toggle"
+                data-arm-dirty
                 :class="{ 'pl-vis-toggle--on': vis.{{ key }}, 'pl-vis-toggle--off': !vis.{{ key }}, 'pl-vis-toggle--disabled': !listed }"
                 :disabled="!listed"
                 @click="vis.{{ key }} = !vis.{{ key }}"

--- a/templates/hub/user_settings.html
+++ b/templates/hub/user_settings.html
@@ -4,34 +4,30 @@
 {% block content %}
 <h1 class="hub-page-title">User Settings</h1>
 
-<div x-data="{ tab: '{{ active_tab|default:"profile" }}' }">
+<div id="pl-settings-root"
+     x-data="plSettingsRoot('{{ active_tab|default:"guilds" }}')"
+     @pl-settings-discard.window="discard()">
     <div class="pl-tabs">
         <button type="button"
-                @click="tab = 'profile'"
-                :class="{ 'vote-tab--active': tab === 'profile' }"
-                class="vote-tab">
-            Profile
-        </button>
-        <button type="button"
-                @click="tab = 'emails'"
-                :class="{ 'vote-tab--active': tab === 'emails' }"
-                class="vote-tab">
-            Emails
-        </button>
-        <button type="button"
-                @click="tab = 'notifications'"
-                :class="{ 'vote-tab--active': tab === 'notifications' }"
-                class="vote-tab">
-            Notifications
-        </button>
-        <button type="button"
-                @click="tab = 'guilds'"
+                @click="go('guilds')"
                 :class="{ 'vote-tab--active': tab === 'guilds' }"
                 class="vote-tab">
             Guilds
         </button>
         <button type="button"
-                @click="tab = 'account'"
+                @click="go('notifications')"
+                :class="{ 'vote-tab--active': tab === 'notifications' }"
+                class="vote-tab">
+            Notifications
+        </button>
+        <button type="button"
+                @click="go('profile')"
+                :class="{ 'vote-tab--active': tab === 'profile' }"
+                class="vote-tab">
+            Profile
+        </button>
+        <button type="button"
+                @click="go('account')"
                 :class="{ 'vote-tab--active': tab === 'account' }"
                 class="vote-tab">
             Account
@@ -51,6 +47,11 @@
         </div>
         {% endif %}
         <form method="post" enctype="multipart/form-data" class="hub-form pl-profile-edit"
+              data-dirty-key="profile"
+              @input="dirty.profile = true"
+              @change="dirty.profile = true"
+              @submit="dirty.profile = false"
+              @click="if ($event.target.closest('[data-arm-dirty]')) dirty.profile = true"
               x-data="{
                 listed: {% if profile_form.show_in_directory.value %}true{% else %}false{% endif %},
                 vis: {
@@ -99,6 +100,7 @@
                            class="pl-profile-master__seg-input">
                     <button type="button"
                             class="pl-profile-master__seg-btn"
+                            data-arm-dirty
                             :class="{ 'pl-profile-master__seg-btn--active': !listed }"
                             :disabled="forceListed"
                             @click="if (!forceListed) listed = false"
@@ -109,6 +111,7 @@
                     </button>
                     <button type="button"
                             class="pl-profile-master__seg-btn"
+                            data-arm-dirty
                             :class="{ 'pl-profile-master__seg-btn--active': listed }"
                             @click="listed = true"
                             role="radio"
@@ -133,6 +136,7 @@
                             <label for="email" class="pl-profile-row__label">Email</label>
                             <button type="button"
                                     class="pl-vis-toggle"
+                                    data-arm-dirty
                                     :class="{ 'pl-vis-toggle--on': vis.email, 'pl-vis-toggle--off': !vis.email, 'pl-vis-toggle--disabled': !listed }"
                                     :disabled="!listed"
                                     @click="vis.email = !vis.email"
@@ -144,7 +148,7 @@
                             <input type="hidden" name="show_email" :value="vis.email ? 'on' : ''">
                         </div>
                         <input type="email" id="email" value="{{ user.email }}" disabled>
-                        <span class="hub-field-hint">Manage your emails in the Emails tab.</span>
+                        <span class="hub-field-hint">Manage your emails in the Account tab.</span>
                     </div>
 
                     {# Profile photo #}
@@ -154,6 +158,7 @@
                             <span class="pl-profile-row__label">Profile photo</span>
                             <button type="button"
                                     class="pl-vis-toggle"
+                                    data-arm-dirty
                                     :class="{ 'pl-vis-toggle--on': vis.profile_photo, 'pl-vis-toggle--off': !vis.profile_photo, 'pl-vis-toggle--disabled': !listed }"
                                     :disabled="!listed"
                                     @click="vis.profile_photo = !vis.profile_photo">
@@ -327,12 +332,12 @@
                         {{ ef.id }}
                         {{ ef.sort_order }}
                         {{ ef.kind }}
-                        <button type="button" class="pl-btn pl-btn--danger pl-btn--sm" style="margin-top:0.75rem;" onclick="this.closest('.hub-card').remove();">Remove</button>
+                        <button type="button" class="pl-btn pl-btn--danger pl-btn--sm" data-arm-dirty style="margin-top:0.75rem;" onclick="this.closest('.hub-card').remove();">Remove</button>
                         {% endwith %}
                     </div>
                 </template>
 
-                <button type="button" class="hub-btn hub-btn--sm" style="margin-top:1rem;"
+                <button type="button" class="hub-btn hub-btn--sm" data-arm-dirty style="margin-top:1rem;"
                         onclick="
                           const tpl = document.getElementById('contact-empty-template-website');
                           const total = document.getElementById('id_contacts-TOTAL_FORMS');
@@ -399,12 +404,12 @@
                         {{ ef.id }}
                         {{ ef.sort_order }}
                         {{ ef.kind }}
-                        <button type="button" class="pl-btn pl-btn--danger pl-btn--sm" style="margin-top:0.75rem;" onclick="this.closest('.hub-card').remove();">Remove</button>
+                        <button type="button" class="pl-btn pl-btn--danger pl-btn--sm" data-arm-dirty style="margin-top:0.75rem;" onclick="this.closest('.hub-card').remove();">Remove</button>
                         {% endwith %}
                     </div>
                 </template>
 
-                <button type="button" class="hub-btn hub-btn--sm" style="margin-top:1rem;"
+                <button type="button" class="hub-btn hub-btn--sm" data-arm-dirty style="margin-top:1rem;"
                         onclick="
                           const tpl = document.getElementById('contact-empty-template-social');
                           const total = document.getElementById('id_contacts-TOTAL_FORMS');
@@ -471,12 +476,12 @@
                         {{ ef.id }}
                         {{ ef.sort_order }}
                         {{ ef.kind }}
-                        <button type="button" class="pl-btn pl-btn--danger pl-btn--sm" style="margin-top:0.75rem;" onclick="this.closest('.hub-card').remove();">Remove</button>
+                        <button type="button" class="pl-btn pl-btn--danger pl-btn--sm" data-arm-dirty style="margin-top:0.75rem;" onclick="this.closest('.hub-card').remove();">Remove</button>
                         {% endwith %}
                     </div>
                 </template>
 
-                <button type="button" class="hub-btn hub-btn--sm" style="margin-top:1rem;"
+                <button type="button" class="hub-btn hub-btn--sm" data-arm-dirty style="margin-top:1rem;"
                         onclick="
                           const tpl = document.getElementById('contact-empty-template-other');
                           const total = document.getElementById('id_contacts-TOTAL_FORMS');
@@ -576,9 +581,22 @@
         {% endif %}
     </div>
 
-    {# -------- Emails tab -------- #}
-    <div x-show="tab === 'emails'" x-cloak>
-        {# --- Manage Email Addresses card --- #}
+    {# -------- Notifications tab -------- #}
+    <div x-show="tab === 'notifications'" x-cloak data-help-key="settings.notifications">
+        {% include "hub/_notifications_settings.html" %}
+        {% include "hub/_tour_settings.html" %}
+    </div>
+
+    {# -------- Guilds tab -------- #}
+    {% comment %}Sits outside every <form>: its per-row toggles carry their own hx-post, so a
+       wrapping <form> would orphan them (the nested-form/submit bug). No page Save.{% endcomment %}
+    <div x-show="tab === 'guilds'" x-cloak data-help-key="settings.your-guilds">
+        {% include "hub/partials/_my_guilds.html" %}
+    </div>
+
+    {# -------- Account tab -------- #}
+    <div x-show="tab === 'account'" x-cloak>
+        {# --- Manage Email Addresses card (moved here from the former Emails tab) --- #}
         <div class="hub-card" style="margin-bottom: 1.5rem;" data-help-key="settings.email-addresses"
              x-data='{ selectedVerified: {{ primary_verified_json|default:"true" }} }'>
             <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem;">Manage Email Addresses</h2>
@@ -635,37 +653,145 @@
             </form>
             <p class="hub-text-muted" style="margin-top:1.25rem;font-size:0.8rem;">
                 Choose which emails you receive in the
-                <button type="button" @click="tab = 'notifications'"
+                <button type="button" @click="go('notifications')"
                         style="background:none;border:0;padding:0;color:var(--color-tuscan-yellow);cursor:pointer;font:inherit;text-decoration:underline;">Notifications</button>
                 tab.
             </p>
         </div>
-    </div>
 
-    {# -------- Notifications tab -------- #}
-    <div x-show="tab === 'notifications'" x-cloak data-help-key="settings.notifications">
-        {% include "hub/_notifications_settings.html" %}
-        {% include "hub/_tour_settings.html" %}
-    </div>
-
-    {# -------- Guilds tab -------- #}
-    {% comment %}Sits outside every <form>: its per-row toggles carry their own hx-post, so a
-       wrapping <form> would orphan them (the nested-form/submit bug). No page Save.{% endcomment %}
-    <div x-show="tab === 'guilds'" x-cloak data-help-key="settings.your-guilds">
-        {% include "hub/partials/_my_guilds.html" %}
-    </div>
-
-    {# -------- Account tab -------- #}
-    <div x-show="tab === 'account'" x-cloak>
-        <h2 class="pl-profile-heading">Delete Your Account</h2>
-        <div class="hub-card">
-            <h3>Danger Zone</h3>
-            <p>Deleting your account removes your personal info (name, photo, contact details, bio) from Past Lives for good and signs you out everywhere. It does not cancel any paid subscription managed outside this site.</p>
-            <p><strong>This can't be undone from here.</strong> To use Past Lives again, a guild lead or admin will need to send you a new invite.</p>
+        {# --- Danger Zone --- #}
+        <div class="hub-card pl-danger-zone">
+            <div class="pl-danger-zone__head">
+                <svg class="pl-danger-zone__icon" width="18" height="18" viewBox="0 0 24 24" fill="none"
+                     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                     aria-hidden="true">
+                    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                    <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+                </svg>
+                <h2 class="pl-danger-zone__title">Danger Zone</h2>
+            </div>
+            <p class="pl-danger-zone__text">
+                Deleting your account permanently removes your personal info (name, photo, contact details, bio)
+                from Past Lives and signs you out everywhere. It does not cancel any paid subscription managed
+                outside this site.
+            </p>
+            <p class="pl-danger-zone__text">
+                <strong>This can't be undone from here.</strong> To use Past Lives again, a guild lead or admin
+                will need to send you a new invite.
+            </p>
+            <div class="pl-danger-zone__footer">
+                <button type="button" class="pl-btn pl-btn--danger pl-btn--sm"
+                        @click="$dispatch('open-confirm', 'delete-account')">Delete My Account</button>
+            </div>
             {% url 'hub_account_delete' as account_delete_url %}
-            <button type="button" class="pl-btn pl-btn--danger" @click="$dispatch('open-confirm', 'delete-account')">Delete My Account</button>
             {% include "components/confirm_modal.html" with confirm_id="delete-account" confirm_title="Delete your account?" confirm_message="This permanently removes your personal info from Past Lives and signs you out. This can't be undone from here." confirm_action_url=account_delete_url confirm_button_text="Delete My Account" confirm_typed_value="DELETE" confirm_typed_placeholder="Type DELETE" confirm_typed_field_name="confirm_text" %}
         </div>
     </div>
+
+    {# Discard-unsaved-changes confirm (dirty guard §6.6) — teleports to body; the confirm_js #}
+    {# dispatches a window event the root's @pl-settings-discard listener turns into discard(). #}
+    {% include "components/confirm_modal.html" with confirm_id="discard-settings-changes" confirm_title="Discard unsaved changes?" confirm_message="You have unsaved changes on this page. If you leave now they will be lost." confirm_button_text="Discard Changes" confirm_cancel_text="Stay" confirm_js="window.dispatchEvent(new CustomEvent('pl-settings-discard'))" %}
+
+    {# Floating back-to-top — page-scoped, shows past ~400px; below the modal layer (§6.4). #}
+    <button type="button" class="pl-scroll-top"
+            x-data="{ show: false }" x-show="show" x-cloak
+            x-init="window.addEventListener('scroll', () => { show = window.scrollY > 400 }, { passive: true })"
+            @click="window.scrollTo({ top: 0, behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth' })"
+            aria-label="Back to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 15l-6-6-6 6"/></svg>
+    </button>
 </div>
+
+{# Dirty-guard runtime (§6.6): the Alpine root component + the beforeunload / htmx:confirm #}
+{# holds for hard and boosted navigations. Defined before Alpine (deferred) initializes the #}
+{# x-data; the listeners read Alpine.$data at event time, so they need no load ordering. #}
+<script>
+    function plSettingsRoot(activeTab) {
+        return {
+            tab: activeTab,
+            dirty: { notifications: false, tours: false, profile: false },
+            pending: null,   // { type: 'tab', tab } | { type: 'nav', proceed }
+            isDirty() { return this.dirty.notifications || this.dirty.tours || this.dirty.profile; },
+            go(next) {
+                this.pending = null;   // drop any stale held navigation before deciding
+                if (this.tab === next) return;
+                if (this.isDirty()) {
+                    this.pending = { type: 'tab', tab: next };
+                    this.$dispatch('open-confirm', 'discard-settings-changes');
+                } else {
+                    this.tab = next;
+                }
+            },
+            discard() {
+                const p = this.pending; this.pending = null;
+                if (p && p.type === 'nav') {
+                    // The page is about to unload — nothing to reset.
+                    this.dirty = { notifications: false, tours: false, profile: false };
+                    p.proceed();
+                    return;
+                }
+                if (this.dirty.profile) {
+                    // Profile edits live partly in Alpine state — a full re-render is the only honest
+                    // reset. Clear the flags BEFORE navigating so beforeunload doesn't stack a native
+                    // "Leave site?" prompt on top of the discard the user just confirmed.
+                    this.dirty = { notifications: false, tours: false, profile: false };
+                    window.location.assign('?tab=' + ((p && p.tab) || this.tab));
+                    return;
+                }
+                // Reset ONLY the forms whose flag was actually set. A blanket reset would include a
+                // clean profile form, whose reset() corrupts the x-model directory checkbox and would
+                // silently delist the member on their next Save — so profile is structurally excluded
+                // here (its discard is always the reload branch above).
+                ['notifications', 'tours'].filter((k) => this.dirty[k]).forEach((k) => {
+                    document.querySelector('form[data-dirty-key="' + k + '"]')?.reset();
+                });
+                this.dirty = { notifications: false, tours: false, profile: false };
+                if (p && p.type === 'tab') this.tab = p.tab;
+            },
+        };
+    }
+
+    // hx-boost re-executes this inline script every time the page is (re)swapped in, and the
+    // window/body listeners below outlive a boosted swap — so bind them exactly once to avoid
+    // stacking duplicate handlers across a settings -> other -> settings round-trip. Guard on
+    // pl-settings-root existence keeps them inert on every non-settings page.
+    if (!window.__plSettingsGuardBound) {
+        window.__plSettingsGuardBound = true;
+
+    // Hard navigations (sidebar links hx-boost="false", address bar, refresh, tab close):
+    // the browser-native prompt is the only guard available there.
+    window.addEventListener('beforeunload', (e) => {
+        const root = window.Alpine && Alpine.$data(document.getElementById('pl-settings-root'));
+        if (root && root.isDirty()) { e.preventDefault(); e.returnValue = ''; }
+    });
+
+    // Boosted navigations (body hx-boost="true", where beforeunload does NOT fire): htmx 2.0.4's
+    // cancelable htmx:confirm with async issueRequest resume.
+    document.body.addEventListener('htmx:confirm', (evt) => {
+        const rootEl = document.getElementById('pl-settings-root');
+        const root = rootEl && window.Alpine && Alpine.$data(rootEl);
+        if (!root || !root.isDirty()) return;
+        const elt = evt.detail.elt;
+        const boostedLink = elt instanceof HTMLAnchorElement;
+        const hasHxVerb = ['hx-get', 'hx-post', 'hx-put', 'hx-patch', 'hx-delete']
+            .some((a) => elt.hasAttribute(a));
+        const boostedForm = elt instanceof HTMLFormElement
+            && !elt.hasAttribute('data-dirty-key') && !hasHxVerb;
+        const crossFormSave = elt instanceof HTMLFormElement && elt.dataset.dirtyKey
+            && Object.entries(root.dirty).some(([k, v]) => v && k !== elt.dataset.dirtyKey);
+        if (!boostedLink && !boostedForm && !crossFormSave) return;
+        root.pending = null;                       // drop any stale held navigation before holding a new one
+        evt.preventDefault();                      // hold the request
+        // Re-arm the held form's OWN flag: its @submit already cleared it in this submit dispatch,
+        // but the hold cancelled the POST — without this a Stay would leave that pane's never-saved
+        // edits unguarded and invisible to a later Discard's flag-filtered reset. No-op for the link
+        // and boosted-form branches (no data-dirty-key).
+        if (elt instanceof HTMLFormElement && elt.dataset.dirtyKey) root.dirty[elt.dataset.dirtyKey] = true;
+        root.pending = { type: 'nav', proceed: () => evt.detail.issueRequest(true) };
+        window.dispatchEvent(new CustomEvent('open-confirm', { detail: 'discard-settings-changes' }));
+    });
+
+    }
+</script>
 {% endblock %}

--- a/tests/core/events/settings_matrix_spec.py
+++ b/tests/core/events/settings_matrix_spec.py
@@ -124,10 +124,10 @@ def describe_staff_section():
             assert settings_matrix.STAFF_SECTION not in _sections(user)
 
     def describe_a_fog_admin_without_capabilities():
-        def it_sees_the_section_for_admin_alerts_rendered_first(db):
+        def it_sees_the_section_for_admin_alerts_rendered_last(db):
             user = _member_user("admin1", fog_role=Member.FogRole.ADMIN)
             sections = _sections(user)
-            assert sections[0] == settings_matrix.STAFF_SECTION
+            assert sections[-1] == settings_matrix.STAFF_SECTION
             assert _section_of(user, ADMIN_ALERT_EVENT) == settings_matrix.STAFF_SECTION
 
         def it_does_not_see_a_capability_it_does_not_hold(db):

--- a/tests/core/notification_matrix_ordering_spec.py
+++ b/tests/core/notification_matrix_ordering_spec.py
@@ -1,0 +1,101 @@
+"""Section ordering + orientation re-tag for the settings notification matrix.
+
+Covers the settings-restructure changes: the new CATEGORY_ORDER (Orientations, Guilds,
+Events first; Staff & Leadership dead-last), the two orientation trigger re-tags, and the
+event-key round-trip that proves the re-tag never touches stored preferences.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from core.events import settings_matrix
+from core.events.registry import Channel
+from core.models import NotificationPreference
+from membership.models import GuildStaffMembership, Member
+from tests.membership.factories import GuildStaffMembershipFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _member_user(username, **member_kwargs):
+    user = User.objects.create_user(username=username, email=f"{username}@example.com")
+    member = Member.objects.get(user=user)
+    if member_kwargs:
+        for field, value in member_kwargs.items():
+            setattr(member, field, value)
+        member.save()
+    return user, member
+
+
+def _sections(user):
+    return [section for section, _rows in settings_matrix.build_matrix(user)]
+
+
+def _section_of(user, event_key):
+    for section, rows in settings_matrix.build_matrix(user):
+        if any(row.event_key == event_key for row in rows):
+            return section
+    return None
+
+
+def describe_section_order():
+    def it_starts_with_orientations_guilds_events_for_a_plain_member():
+        user, _member = _member_user("orderplain")
+        sections = _sections(user)
+        assert "Orientations" in sections
+        assert "Guilds" in sections
+        assert "Events" in sections
+        # The three lead the page, in this relative order.
+        assert sections.index("Orientations") < sections.index("Guilds") < sections.index("Events")
+
+    def it_never_shows_the_staff_section_to_a_plain_member():
+        user, _member = _member_user("orderplain2")
+        assert settings_matrix.STAFF_SECTION not in _sections(user)
+
+    def it_renders_the_staff_section_last_for_an_admin():
+        user, _member = _member_user("orderadmin", fog_role=Member.FogRole.ADMIN)
+        sections = _sections(user)
+        assert sections[-1] == settings_matrix.STAFF_SECTION
+
+    def it_sorts_an_unknown_category_alpha_before_staff():
+        # _ordered_categories is the pure ordering rule: known categories in CATEGORY_ORDER,
+        # then unknown extras alpha, then the staff section dead-last.
+        ordered = settings_matrix._ordered_categories({"Zebra", "Guilds", settings_matrix.STAFF_SECTION, "Apple"})
+        assert ordered == ["Guilds", "Apple", "Zebra", settings_matrix.STAFF_SECTION]
+
+
+def describe_orientation_retag():
+    def it_moves_orientation_update_under_orientations():
+        user, _member = _member_user("retag1")
+        assert _section_of(user, "orientation_update") == "Orientations"
+        # And it is no longer grouped under Guilds.
+        assert _section_of(user, "orientation_update") != "Guilds"
+
+    def it_keeps_orientation_requested_in_staff_for_an_orienter():
+        user, member = _member_user("retag2")
+        GuildStaffMembershipFactory(member=member, role=GuildStaffMembership.Role.ORIENTER)
+        assert _section_of(user, "orientation_requested") == settings_matrix.STAFF_SECTION
+
+    def it_hides_orientation_requested_from_a_plain_member():
+        user, _member = _member_user("retag3")
+        assert _section_of(user, "orientation_requested") is None
+
+    def it_round_trips_a_saved_orientation_update_preference():
+        # Re-tag safety: preferences are stored per (user, event_key, channel); the category
+        # never touches the DB, so a saved row survives the re-tag and round-trips unchanged.
+        user, _member = _member_user("retag4")
+        NotificationPreference.objects.create(user=user, event_key="orientation_update", channel="email", enabled=True)
+        # build_matrix reflects the saved row as a checked email cell, under Orientations.
+        row = next(
+            r
+            for section, rows in settings_matrix.build_matrix(user)
+            if section == "Orientations"
+            for r in rows
+            if r.event_key == "orientation_update"
+        )
+        email_cell = next(c for c in row.cells if c.channel is Channel.EMAIL and c.present)
+        assert email_cell.enabled is True
+        # Saving that same checked box leaves the stored row untouched.
+        settings_matrix.save_matrix(user, {email_cell.name: "on"})
+        pref = NotificationPreference.objects.get(user=user, event_key="orientation_update", channel="email")
+        assert pref.enabled is True

--- a/tests/hub/account_tab_spec.py
+++ b/tests/hub/account_tab_spec.py
@@ -1,0 +1,45 @@
+"""The Account tab: relocated Manage Email Addresses card + the polished Danger Zone.
+
+The email card's behaviour lives in tests/hub/views_spec.py (context) and
+tests/hub/account_delete_spec.py (deletion flow); this file pins the restructure — the
+card's new home above a dedicated .pl-danger-zone card.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+pytestmark = pytest.mark.django_db
+
+
+def _login(client, username="accttab"):
+    User.objects.create_user(username=username, email=f"{username}@example.com", password="pass")
+    client.login(username=username, password="pass")
+
+
+def describe_account_tab():
+    def it_renders_the_email_card_and_add_form(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=account").content.decode()
+        assert "Manage Email Addresses" in content
+        assert "Add an Email Address" in content
+
+    def it_wraps_the_delete_flow_in_a_dedicated_danger_zone_card(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=account").content.decode()
+        assert 'class="hub-card pl-danger-zone"' in content
+        assert "pl-danger-zone__head" in content
+        assert "pl-danger-zone__footer" in content
+        assert "Danger Zone" in content
+
+    def it_uses_a_small_delete_button_in_the_footer(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=account").content.decode()
+        # Destructive trigger drops to pl-btn--sm; the modal is the real guard.
+        assert "pl-btn pl-btn--danger pl-btn--sm" in content
+        assert "Delete My Account" in content
+
+    def it_no_longer_shows_the_standalone_delete_your_account_heading(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=account").content.decode()
+        assert "Delete Your Account" not in content  # each card carries its own heading now

--- a/tests/hub/my_guilds_spec.py
+++ b/tests/hub/my_guilds_spec.py
@@ -244,9 +244,11 @@ def describe_user_settings_guilds_tab():
         assert step.done is True
 
     def it_does_not_stamp_on_other_tabs(client: Client):
+        # A bare /settings/ now lands on (and stamps) the Guilds default tab, so only the
+        # explicit non-guilds tabs must leave the answer unstamped.
         _user, member = _linked_user(client)
         client.get(reverse("hub_user_settings") + "?tab=notifications")
-        client.get(reverse("hub_user_settings"))
+        client.get(reverse("hub_user_settings") + "?tab=profile")
         member.refresh_from_db()
         assert member.guild_updates_prompt_answered_at is None
 
@@ -255,10 +257,10 @@ def describe_user_settings_guilds_tab():
         response = client.get(reverse("hub_user_settings") + "?tab=guilds")
         assert response.status_code == 200
 
-    def it_falls_back_to_profile_for_a_bogus_tab(client: Client):
+    def it_falls_back_to_guilds_for_a_bogus_tab(client: Client):
         _linked_user(client)
         response = client.get(reverse("hub_user_settings") + "?tab=bogus")
-        assert response.context["active_tab"] == "profile"
+        assert response.context["active_tab"] == "guilds"
 
     def it_passes_the_guild_rows_in_context(client: Client):
         _linked_user(client)

--- a/tests/hub/notification_prefs_token_spec.py
+++ b/tests/hub/notification_prefs_token_spec.py
@@ -48,6 +48,18 @@ def describe_user_settings_when_logged_out():
 
             assert response.status_code != 302
 
+        def it_stays_chip_and_subtitle_free(client):
+            # The token page has no Alpine tab/go(), so the jump chips and the in-page
+            # Guilds/Meetings subtitles (which route through go()) must not render here.
+            user = _member_user("token_chipfree", email="token_chipfree@example.com")
+            token = make_prefs_token(user)
+
+            content = client.get(f"{reverse('hub_user_settings')}?tab=notifications&t={token}").content.decode()
+
+            assert "pl-notif-jump__chip" not in content
+            assert "Manage which guilds send you updates" not in content
+            assert "View upcoming meetings" not in content
+
         def it_saves_a_posted_preference_for_the_tokens_user_and_redirects(client):
             user = _member_user("token_post", email="token_post@example.com")
             token = make_prefs_token(user)

--- a/tests/hub/notification_settings_spec.py
+++ b/tests/hub/notification_settings_spec.py
@@ -4,9 +4,40 @@ import pytest
 from django.contrib.auth.models import User
 from django.urls import reverse
 
+from core.events import settings_matrix
 from core.models import NotificationPreference
+from membership.models import Member
+from tests.membership.factories import GuildFactory
 
 pytestmark = pytest.mark.django_db
+
+
+def _make_admin(client, username):
+    user = User.objects.create_user(username=username, email=f"{username}@example.com", password="pw12345!")
+    member = Member.objects.get(user=user)
+    member.fog_role = Member.FogRole.ADMIN
+    member.save()
+    client.login(username=username, password="pw12345!")
+    return user, member
+
+
+def _make_officer(client, username):
+    user = User.objects.create_user(username=username, email=f"{username}@example.com", password="pw12345!")
+    member = Member.objects.get(user=user)
+    member.fog_role = Member.FogRole.GUILD_OFFICER
+    member.save()
+    client.login(username=username, password="pw12345!")
+    return user, member
+
+
+def _preview_as(client, role):
+    session = client.session
+    session["view_as_role"] = role
+    session.save()
+
+
+def _matrix_sections(response):
+    return [section for section, _rows in response.context["notif_matrix"]]
 
 
 def describe_notifications_tab():
@@ -44,3 +75,90 @@ def describe_notifications_tab():
         # uses the canonical .pl-help hover bubble, not a browser title= tooltip
         assert "pl-help__bubble" in content
         assert "Android only for now. iOS coming soon." in content
+
+
+def describe_build_matrix_staff_flag():
+    def it_omits_the_staff_section_when_false():
+        user, _member = _make_admin_matrix_user("flagadmin")
+        with_staff = [s for s, _r in settings_matrix.build_matrix(user, include_staff_section=True)]
+        without_staff = [s for s, _r in settings_matrix.build_matrix(user, include_staff_section=False)]
+        assert settings_matrix.STAFF_SECTION in with_staff
+        assert settings_matrix.STAFF_SECTION not in without_staff
+
+    def it_never_renders_a_staff_only_channel_column_in_a_member_preview():
+        # visible_channels must forward the flag: a channel only staff events offer must not
+        # survive as a dead column when the staff section is hidden.
+        user, _member = _make_admin_matrix_user("flagadmin2")
+        member_view = settings_matrix.visible_channels(user, include_staff_section=False)
+        # Every channel shown in the member-view preview is offered by some non-staff event.
+        events = settings_matrix._visible_events(user, include_staff_section=False)
+        for channel in member_view:
+            assert any(event.channel(channel) is not None for event in events)
+
+
+def _make_admin_matrix_user(username):
+    user = User.objects.create_user(username=username, email=f"{username}@example.com")
+    member = Member.objects.get(user=user)
+    member.fog_role = Member.FogRole.ADMIN
+    member.save()
+    return user, member
+
+
+def describe_view_as_staff_section():
+    def it_shows_the_staff_section_to_an_admin_viewing_as_self(client):
+        _make_admin(client, "vaself")
+        response = client.get(reverse("hub_user_settings") + "?tab=notifications")
+        assert settings_matrix.STAFF_SECTION in _matrix_sections(response)
+
+    def it_hides_the_staff_section_when_an_admin_previews_as_member(client):
+        _make_admin(client, "vamember")
+        _preview_as(client, "member")
+        response = client.get(reverse("hub_user_settings") + "?tab=notifications")
+        assert settings_matrix.STAFF_SECTION not in _matrix_sections(response)
+
+    def it_hides_the_staff_section_when_an_admin_previews_as_guest(client):
+        _make_admin(client, "vaguest")
+        _preview_as(client, "guest")
+        response = client.get(reverse("hub_user_settings") + "?tab=notifications")
+        assert settings_matrix.STAFF_SECTION not in _matrix_sections(response)
+
+    def it_shows_the_staff_section_when_an_admin_previews_as_officer(client):
+        _make_admin(client, "vaofficer")
+        _preview_as(client, "guild_officer")
+        response = client.get(reverse("hub_user_settings") + "?tab=notifications")
+        assert settings_matrix.STAFF_SECTION in _matrix_sections(response)
+
+    def it_hides_the_staff_section_when_an_officer_previews_as_member(client):
+        _make_officer(client, "offviewmember")
+        _preview_as(client, "member")
+        response = client.get(reverse("hub_user_settings") + "?tab=notifications")
+        assert settings_matrix.STAFF_SECTION not in _matrix_sections(response)
+
+    def it_keeps_the_staff_section_for_a_guild_lead_whose_role_is_member(client):
+        # A lead's fog_role is member, so include_staff stays True (the flag flips only when a
+        # higher-role holder previews down) — they keep the staff rows their led_guilds grant.
+        user = User.objects.create_user(username="leadmember", email="lead@example.com", password="pw12345!")
+        member = Member.objects.get(user=user)
+        GuildFactory(guild_lead=member)
+        client.login(username="leadmember", password="pw12345!")
+        response = client.get(reverse("hub_user_settings") + "?tab=notifications")
+        assert settings_matrix.STAFF_SECTION in _matrix_sections(response)
+
+    def it_does_not_wipe_staff_prefs_when_saving_while_previewing_as_member(client):
+        # The §5.2 wipe trap: the GET hid the staff section, so the POST omits its checkboxes.
+        # save_matrix must receive include_staff_section=False and skip staff events, or every
+        # staff pref would be written enabled=False.
+        user, _member = _make_admin(client, "wipeadmin")
+        NotificationPreference.objects.create(user=user, event_key="new_member_joined", channel="email", enabled=True)
+        _preview_as(client, "member")
+        client.post(reverse("hub_user_settings"), {"form_id": "notifications"})  # no staff checkbox present
+        pref = NotificationPreference.objects.get(user=user, event_key="new_member_joined", channel="email")
+        assert pref.enabled is True  # untouched — not silently wiped
+
+    def it_still_saves_staff_prefs_for_an_admin_viewing_as_self(client):
+        # Control: viewing as self, the staff checkbox is present, so an unchecked POST clears it.
+        user, _member = _make_admin(client, "selfsave")
+        NotificationPreference.objects.create(user=user, event_key="new_member_joined", channel="email", enabled=True)
+        client.post(reverse("hub_user_settings"), {"form_id": "notifications"})  # staff box unchecked
+        pref = NotificationPreference.objects.get(user=user, event_key="new_member_joined", channel="email")
+        assert pref.enabled is False

--- a/tests/hub/user_settings_tabs_spec.py
+++ b/tests/hub/user_settings_tabs_spec.py
@@ -1,0 +1,162 @@
+"""Tab resolution + template restructure for the User Settings page.
+
+Covers the settings-restructure tab changes: guilds default, the emails->account alias,
+the whitelist/XSS guard, the guild-updates write-on-GET (and the failed-POST guard against
+it), the allauth redirect, the moved email card + danger-zone polish, the notifications
+jump chips + subtitles, and the dirty-guard markup pins.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+pytestmark = pytest.mark.django_db
+
+_CONTACTS_MGMT = {"contacts-TOTAL_FORMS": "0", "contacts-INITIAL_FORMS": "0"}
+
+
+def _login(client, username="settingsuser"):
+    user = User.objects.create_user(username=username, email=f"{username}@example.com", password="pass")
+    client.login(username=username, password="pass")
+    return user
+
+
+def describe_tab_resolution():
+    def it_defaults_to_guilds_with_no_param(client: Client):
+        _login(client)
+        assert client.get("/settings/").context["active_tab"] == "guilds"
+
+    def it_falls_back_to_guilds_for_a_garbage_param(client: Client):
+        _login(client)
+        response = client.get("/settings/?tab=%27%2Balert(1)%2B%27")
+        assert response.context["active_tab"] == "guilds"
+        assert b"alert(1)" not in response.content
+
+    def it_aliases_the_legacy_emails_param_to_account(client: Client):
+        _login(client)
+        assert client.get("/settings/?tab=emails").context["active_tab"] == "account"
+
+    def it_passes_through_each_whitelisted_value(client: Client):
+        _login(client)
+        for tab in ("profile", "notifications", "guilds", "account"):
+            assert client.get(f"/settings/?tab={tab}").context["active_tab"] == tab
+
+
+def describe_guild_updates_stamp():
+    def it_stamps_on_a_bare_settings_get(client: Client):
+        user = _login(client)
+        member = user.member
+        assert member.guild_updates_prompt_answered_at is None
+        client.get("/settings/")
+        member.refresh_from_db()
+        assert member.guild_updates_prompt_answered_at is not None
+
+    def it_is_a_noop_on_a_second_get(client: Client):
+        user = _login(client)
+        client.get("/settings/")
+        user.member.refresh_from_db()
+        first = user.member.guild_updates_prompt_answered_at
+        client.get("/settings/")
+        user.member.refresh_from_db()
+        assert user.member.guild_updates_prompt_answered_at == first
+
+    def it_re_renders_the_profile_tab_on_a_failed_save_without_stamping(client: Client):
+        # A failed profile POST re-renders (no redirect) on the profile tab, and must NOT
+        # stamp the guild-updates answer on a landing the user never chose (§5.3).
+        user = _login(client)
+        assert user.member.guild_updates_prompt_answered_at is None
+        response = client.post(
+            "/settings/",
+            {"form_id": "profile", "phone": "1" * 40, **_CONTACTS_MGMT},  # phone > max_length=20
+        )
+        assert response.status_code == 200  # re-render, not a redirect
+        assert response.context["active_tab"] == "profile"
+        user.member.refresh_from_db()
+        assert user.member.guild_updates_prompt_answered_at is None
+
+
+def describe_account_email_redirect():
+    def it_redirects_account_email_get_to_the_account_tab(client: Client):
+        _login(client, "legacyemail")
+        response = client.get("/accounts/email/")
+        assert response.status_code == 302
+        assert response.url == "/settings/?tab=account"
+
+
+def describe_account_tab_template():
+    def it_drops_the_standalone_emails_pane(client: Client):
+        _login(client)
+        content = client.get("/settings/").content.decode()
+        assert "tab === 'emails'" not in content
+
+    def it_moves_the_email_card_into_account_above_the_danger_zone(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=account").content.decode()
+        assert "Manage Email Addresses" in content
+        assert "pl-danger-zone" in content
+        assert content.index("Manage Email Addresses") < content.index("pl-danger-zone")
+
+    def it_keeps_the_typed_delete_confirm_in_the_danger_zone(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=account").content.decode()
+        assert "confirm-delete-account" in content or "delete-account" in content
+        assert 'name="confirm_text"' in content  # typed-DELETE field, unchanged
+
+
+def describe_notifications_template():
+    def it_renders_a_jump_chip_and_anchor_per_section(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=notifications").content.decode()
+        assert "pl-notif-jump__chip" in content
+        # The Guilds section is present for everyone: chip href + matching anchor id.
+        assert 'href="#notif-guilds"' in content
+        assert 'id="notif-guilds"' in content
+
+    def it_renders_the_guilds_and_meetings_subtitles(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=notifications").content.decode()
+        assert "Manage which guilds send you updates" in content
+        assert "View upcoming meetings" in content
+
+
+def describe_dirty_guard_markup():
+    def it_marks_exactly_the_three_save_forms(client: Client):
+        # The keyed attribute lands on exactly the three batch-save forms. (The bare token
+        # "data-dirty-key" also appears in the guard JS, so assert the keyed HTML form.)
+        _login(client)
+        content = client.get("/settings/").content.decode()
+        for key in ("profile", "notifications", "tours"):
+            assert content.count(f'data-dirty-key="{key}"') == 1
+
+    def it_includes_the_discard_modal_with_a_stay_button(client: Client):
+        _login(client)
+        content = client.get("/settings/").content.decode()
+        assert "discard-settings-changes" in content
+        assert "Discard Changes" in content
+        assert "Stay" in content  # confirm_cancel_text on the discard modal
+
+    def it_keeps_cancel_as_the_default_confirm_label(client: Client):
+        # The delete-account modal passes no confirm_cancel_text, so it still says "Cancel".
+        _login(client)
+        content = client.get("/settings/?tab=account").content.decode()
+        assert ">Cancel<" in content
+
+    def it_arms_dirty_on_alpine_only_profile_controls(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=profile").content.decode()
+        assert "data-arm-dirty" in content
+
+    def it_dispatches_a_change_event_from_the_bulk_toggle(client: Client):
+        _login(client)
+        content = client.get("/settings/?tab=notifications").content.decode()
+        assert "new Event('change', { bubbles: true })" in content
+
+    def it_wires_the_boosted_navigation_guard_with_cross_form_and_async_resume(client: Client):
+        # The htmx:confirm hold, its cross-form-save branch, and the async issueRequest(true)
+        # resume are the boosted-nav guard the runtime cannot server-test — pin they render.
+        _login(client)
+        content = client.get("/settings/").content.decode()
+        assert "htmx:confirm" in content
+        assert "crossFormSave" in content
+        assert "issueRequest(true)" in content
+        assert "beforeunload" in content

--- a/tests/hub/views_spec.py
+++ b/tests/hub/views_spec.py
@@ -314,32 +314,34 @@ def describe_user_settings():
         assert response.context["capabilities_url"] is None
         assert b"Manage your admin duties" not in response.content
 
-    def it_defaults_to_profile_tab(client: Client):
+    def it_defaults_to_guilds_tab(client: Client):
         User.objects.create_user(username="tabdefault", password="pass")
         client.login(username="tabdefault", password="pass")
 
         response = client.get("/settings/")
 
-        assert response.context["active_tab"] == "profile"
+        assert response.context["active_tab"] == "guilds"
 
-    def it_honors_tab_query_param(client: Client):
+    def it_aliases_the_legacy_emails_tab_to_account(client: Client):
+        # The Emails tab folded into Account (its Manage Email Addresses card moved there),
+        # so old ?tab=emails deep links resolve to account and keep working.
         User.objects.create_user(username="tabemails", password="pass")
         client.login(username="tabemails", password="pass")
 
-        response = client.get("/settings/?tab=emails")
+        response = client.get("/settings/?tab=account")
 
-        assert response.context["active_tab"] == "emails"
+        assert response.context["active_tab"] == "account"
 
-    def it_falls_back_to_profile_when_tab_param_is_not_whitelisted(client: Client):
+    def it_falls_back_to_guilds_when_tab_param_is_not_whitelisted(client: Client):
         """Regression: ``active_tab`` flows into an Alpine x-data JS expression,
         so raw user input must not reach the template — arbitrary values are
-        coerced back to ``profile`` to prevent XSS."""
+        coerced back to the default (``guilds``) to prevent XSS."""
         User.objects.create_user(username="xssguard", password="pass")
         client.login(username="xssguard", password="pass")
 
         response = client.get("/settings/?tab=%27%2Balert(1)%2B%27")
 
-        assert response.context["active_tab"] == "profile"
+        assert response.context["active_tab"] == "guilds"
         # And the raw payload never lands in the rendered HTML.
         assert b"alert(1)" not in response.content
 
@@ -516,7 +518,7 @@ def describe_user_settings():
         EmailAddress.objects.create(user=user, email="v@example.com", verified=True, primary=True)
         client.login(username="primaryverified", password="pass")
 
-        response = client.get("/settings/?tab=emails")
+        response = client.get("/settings/?tab=account")
 
         assert response.context["primary_verified_json"] == "true"
 
@@ -528,7 +530,7 @@ def describe_user_settings():
         EmailAddress.objects.create(user=user, email="u@example.com", verified=False, primary=True)
         client.login(username="unverifiedprimary", password="pass")
 
-        response = client.get("/settings/?tab=emails")
+        response = client.get("/settings/?tab=account")
 
         assert response.context["primary_verified_json"] == "false"
 
@@ -542,7 +544,7 @@ def describe_user_settings():
         EmailAddress.objects.create(user=user, email="alias@example.com", verified=True, primary=False)
         client.login(username="emaillist", password="pass")
 
-        response = client.get("/settings/?tab=emails")
+        response = client.get("/settings/?tab=account")
 
         addrs = list(response.context["email_addresses"])
         assert {a.email for a in addrs} == {"primary@example.com", "alias@example.com"}
@@ -684,7 +686,7 @@ def describe_legacy_settings_redirects():
         response = client.get("/accounts/email/")
 
         assert response.status_code == 302
-        assert response.url == "/settings/?tab=emails"
+        assert response.url == "/settings/?tab=account"
 
     def it_sends_email_action_post_back_to_emails_tab(client: Client):
         """After allauth's EmailView handles add/remove/resend/primary, the user
@@ -699,7 +701,7 @@ def describe_legacy_settings_redirects():
         response = client.post("/accounts/email/", {"action_add": "", "email": "alias@example.com"})
 
         assert response.status_code == 302
-        assert response.url == "/settings/?tab=emails"
+        assert response.url == "/settings/?tab=account"
 
 
 _PROFILE_PHOTO_DELETE_URL = "/settings/profile-photo/delete/"


### PR DESCRIPTION
## What ships

Six related changes to `/settings/` (items 4 through 9 of the round):

1. **View-as-member hides Staff & Leadership notifications.** `build_matrix` gains an `include_staff_section` flag; critically, `save_matrix` receives the SAME flag so an admin saving while previewing as member does not silently wipe their staff prefs. The condition is picked-role in {member,guest} AND actual admin/officer, so a guild lead with `fog_role=member` keeps their staff rows.
2. **Notification section reorder** (Orientations, Guilds, Events, then the rest, Staff & Leadership last) via `CATEGORY_ORDER` + two trigger re-tags. **Jump chips** generated from rendered sections only, plus a floating **back to top** button.
3. **Emails tab folded into Account** (card moved above a polished `.pl-danger-zone`), `?tab=emails` aliases to account, typed-DELETE confirm kept byte-identical.
4. **Section subtitles**: "Manage which guilds send you updates" (Guilds) and "View upcoming meetings" (Meetings).
5. **Tab reorder**: Guilds, Notifications, Profile, Account with Guilds default (the `mark_guild_updates_answered` stamp on a bare visit is deliberate and idempotent).
6. **Unsaved-changes guard** on the Save-button forms: dirty tracking, `htmx:confirm` hold for boosted links/forms, cross-form-save hold, re-arm after hold, pane-reload Profile discard, and `beforeunload` for hard nav. The Profile discard is a pane reload (not `form.reset()`) specifically because a blanket reset corrupts the `x-model` directory checkbox and would silently delist the member.

## Spec

`docs/superpowers/plans/2026-08-27-settings-restructure.md` (fogstorm + THREE rounds of adversarial review; the guard design alone was reworked twice after the review caught a silent-delisting bug and a Safari-incompatible earlier approach elsewhere in the round).

## Test evidence

`.venv/bin/pytest tests/hub/ tests/core/ -q` → 238 settings-related specs pass (new: notification_matrix_ordering, user_settings_tabs, account_tab; incl. the pref-wipe regression, view-as omission, alias fallback, POST-tab-derivation, crossFormSave markup pins). `ruff`, `manage.py check`, `makemigrations --check` (no schema change), and pre-push mypy all clean.

The live dirty-guard runtime (Alpine flips, Stay/Discard flow, htmx:confirm hold+resume, phone-width FAB clearance, both themes) is a manual-QA checklist item; all enabling markup is pinned server-side.

https://claude.ai/code/session_01NF4MEeH2icSRQ9U4RuGTmA