### PR TITLE
fix(orientation): open Stripe checkout via full page POST + restore guild calendar hover

### DIFF
--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-VERSION = "1.19.0"
+VERSION = "1.19.1"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.19.1",
+        "date": "2026-08-27",
+        "title": "Smoother orientation checkout",
+        "changes": [
+            "If your guild charges for orientations, tapping Continue to Payment now opens our "
+            "secure checkout right away. We also tidied up how guild calendars respond when you "
+            "hover over an event.",
+        ],
+    },
     {
         "version": "1.19.0",
         "date": "2026-08-27",

--- a/templates/components/confirm_modal.html
+++ b/templates/components/confirm_modal.html
@@ -9,6 +9,11 @@ Parameters (pass via {% include ... with %}):
   confirm_button_text  — optional, button label (default: "Confirm")
   confirm_button_style — optional, "danger" (default) or "primary"
   confirm_cancel_text  — optional, label for the dismiss button (default: "Cancel")
+  confirm_no_boost     — optional (plain-POST mode); when set, the form carries
+                         hx-boost="false" so it submits as a genuine full-page POST.
+                         Required when the target view redirects cross-origin (e.g. to
+                         Stripe Checkout): a boosted form issues an XHR that cannot follow
+                         a cross-origin 302, which the browser blocks as a CORS error.
 
   On open the modal records the triggering element and moves focus to the Cancel/dismiss
   button; every close path (Cancel, Escape, ×, click-outside) restores focus to the opener.
@@ -100,7 +105,7 @@ Parameters (pass via {% include ... with %}):
                     </button>
                 </form>
                 {% else %}
-                <form method="post" action="{{ confirm_action_url }}" style="flex:1;">
+                <form method="post" action="{{ confirm_action_url }}"{% if confirm_no_boost %} hx-boost="false"{% endif %} style="flex:1;">
                     {% csrf_token %}
                     {% if confirm_field_name %}<input type="hidden" name="{{ confirm_field_name }}" value="{{ confirm_field_value }}">{% endif %}
                     {% if confirm_note_name %}<input type="hidden" name="{{ confirm_note_name }}" :value="note">{% endif %}

--- a/templates/hub/partials/guild_calendar_app.html
+++ b/templates/hub/partials/guild_calendar_app.html
@@ -34,6 +34,14 @@ Context: `cal` = the calendar context dict; `guild` = the Guild.
             setTimeout(() => target.classList.remove('pl-calendar-list__item--flash'), 1800);
             return true;
         },
+        hoverEvent(pk) {
+            document.querySelectorAll('.pl-calendar-list__item[data-event-pk=\'' + pk + '\']')
+                .forEach(el => el.classList.add('pl-calendar-list__item--highlight'));
+        },
+        unhoverEvent(pk) {
+            document.querySelectorAll('.pl-calendar-list__item[data-event-pk=\'' + pk + '\']')
+                .forEach(el => el.classList.remove('pl-calendar-list__item--highlight'));
+        },
         focusEvent(pk) {
             const stateEl = document.getElementById('pl-cal-state');
             const state = stateEl ? JSON.parse(stateEl.textContent) : null;

--- a/templates/hub/partials/guild_orientation.html
+++ b/templates/hub/partials/guild_orientation.html
@@ -90,7 +90,7 @@ Member-facing orientation section on the guild page. Context:
             {% if orientation.is_paid %}
             {% with price=orientation.price_cents|cents_as_price %}
             {% with paid_msg="You'll pay "|add:price|add:" now through our secure checkout. Your booking is a request until the guild confirms it. If they decline, or it's cancelled, you get an automatic full refund." %}
-            {% include "components/confirm_modal.html" with confirm_id="book-slot-"|add:pks confirm_title="Book This Orientation?" confirm_message=paid_msg confirm_action_url=book_url confirm_button_text="Continue to Payment" confirm_button_style="primary" %}
+            {% include "components/confirm_modal.html" with confirm_id="book-slot-"|add:pks confirm_title="Book This Orientation?" confirm_message=paid_msg confirm_action_url=book_url confirm_button_text="Continue to Payment" confirm_button_style="primary" confirm_no_boost=True %}
             {% endwith %}
             {% endwith %}
             {% elif slot.orienter %}
@@ -125,7 +125,7 @@ Member-facing orientation section on the guild page. Context:
       </button>
       <div x-show="showCustom" x-cloak style="max-width:420px;">
         <p class="hub-text-muted" style="margin:0 0 0.75rem; font-size:0.85rem;">Propose your own time and the guild lead will confirm it.</p>
-        <form method="post" action="{% url 'hub_guild_orientation_request_custom' guild.pk %}" class="hub-form">
+        <form method="post" action="{% url 'hub_guild_orientation_request_custom' guild.pk %}" class="hub-form"{% if orientation.is_paid %} hx-boost="false"{% endif %}>
           {% csrf_token %}
           {% include "components/form_field.html" with field=custom_request_form.starts_at %}
           {% include "components/form_field.html" with field=custom_request_form.note %}


### PR DESCRIPTION
## What

Two fixes for the guild orientation surface, both discovered while testing paid orientation booking on prod.

### 1. Paying for an orientation was blocked by CORS (the real bug)
The paid book slot dialog posts through the shared `confirm_modal.html`, whose `<form method="post">` is intercepted by the hub's page-wide `hx-boost`. A boosted form is submitted as an XHR, and when the view returns a 302 to `checkout.stripe.com`, the browser blocks the cross origin XHR redirect as a CORS error. Result: tapping **Continue to Payment** never reached Stripe.

The public class registration form already handles this by opting out with `hx-boost="false"` (`templates/classes/public/register.html:81`). This PR applies the same escape:
- New opt-in `confirm_no_boost` flag on `components/confirm_modal.html` (documented in its header comment), set on the paid book slot dialog only.
- `hx-boost="false"` on the custom time request form when the guild charges.

Both now submit as genuine full page POSTs and follow the 302 to Stripe natively. Non paid paths are unchanged (still boosted).

### 2. Guild calendar hover threw a ReferenceError
`partials/calendar_content.html` calls `hoverEvent()` / `unhoverEvent()`, but those methods lived only in the community calendar's Alpine scope. On a guild page (`guild_calendar_app.html`) hovering an event logged `Uncaught ReferenceError: hoverEvent is not defined`. Added the two methods to the guild calendar scope.

## Testing
- `tests/e2e/orientation_booking_spec.py -m e2e` passes (exercises the shared confirm modal on its non paid path, confirming the opt-in flag did not disturb the default).
- `tests/template_comment_lint_spec.py` passes.
- Pre-push ruff + mypy clean.

## Version
Patch bump to 1.19.1 with a member facing changelog entry (this is a fix to a live feature).

https://claude.ai/code/session_01NF4MEeH2icSRQ9U4RuGTmA