### PR TITLE
polish(orientation): unify hours editing into shared popup + name orienter on paid checkout

### DIFF
--- a/hub/views.py
+++ b/hub/views.py
@@ -666,7 +666,6 @@ def _guild_edit_context(
     form: GuildEditForm | None = None,
     orientation_form: Any = None,
     thankyou_email_form: Any = None,
-    rule_formset: Any = None,
     guild_rule_formset: Any = None,
     studio_hours_formset: Any = None,
     mailing_list_formset: Any = None,
@@ -675,8 +674,8 @@ def _guild_edit_context(
 
     Shared by ``guild_edit`` (GET + invalid-POST re-render) and ``guild_orientation_edit``'s
     invalid-POST re-render, so the inlined Orientations / Meeting Notes / Events tabs always
-    have their data. Pass a bound ``form`` / ``orientation_form`` / ``rule_formset`` to surface
-    validation errors; unbound defaults are built otherwise. Orientation, FAQ, and Links each
+    have their data. Pass a bound ``form`` / ``orientation_form`` / ``guild_rule_formset`` to
+    surface validation errors; unbound defaults are built otherwise. Orientation, FAQ, and Links each
     save via their own endpoint (the FAQ/Links idiom), so their formsets are unbound here.
     """
     from hub.forms import (
@@ -698,19 +697,17 @@ def _guild_edit_context(
     ctx = _get_hub_context(request)
     recipients = guild.announcement_recipients()
 
-    # ── Orientations tab: the viewer's own hours + overview + slots ───────────
-    # Editing another staffer's hours happens in the Edit Hours modal (its own GET
-    # partial + save prefix), never by reloading this page with a ?orienter= param.
+    # ── Orientations tab: the Orientation Schedule overview + slots ───────────
+    # Every orienter edits their own recurring hours through the Edit Hours modal (its own
+    # GET partial + save prefix) from their row in the overview — never by reloading this page.
     viewer = _get_member(request)
     can_edit_others_hours = can_edit_orienter_hours(request, guild, None)
-    personal_rules_qs = (
-        guild.orientation_rules.for_orienter(viewer) if viewer is not None else guild.orientation_rules.none()
-    )
     leadership = guild.leadership_members()
     leadership_ids = {m.pk for m in leadership}
-    # An admin/officer who is not on this guild's leadership gets no self-scoped My Hours
-    # card — their personal rules would never generate slots (the save 403s that scope
-    # too). They clean up any leftover rows via the Edit Hours modal on the Former Staff row.
+    # An admin/officer who is not on this guild's leadership gets no self row in the overview —
+    # their personal rules would never generate slots (the save 403s that scope too). They clean
+    # up any leftover rows via the Edit Hours modal on the Former Staff row. show_my_hours_card
+    # now gates whether the viewer sees the Orientation Schedule (their own row within it).
     show_my_hours_card = viewer is not None and viewer.pk in leadership_ids
     rules_by_orienter: dict[int, list[Any]] = {}
     orphan_orienters: dict[int, Any] = {}
@@ -769,11 +766,6 @@ def _guild_edit_context(
             thankyou_email_form if thankyou_email_form is not None else GuildThankyouEmailForm(instance=settings_obj)
         ),
         "announcement_settings_form": GuildAnnouncementSettingsForm(instance=guild),
-        "rule_formset": (
-            rule_formset
-            if rule_formset is not None
-            else OrientationAvailabilityFormSet(instance=guild, prefix="rules", queryset=personal_rules_qs)
-        ),
         "viewer_member_pk": viewer.pk if viewer is not None else None,
         "show_my_hours_card": show_my_hours_card,
         "can_edit_others_hours": can_edit_others_hours,
@@ -931,15 +923,15 @@ def _hours_save_message(*, guild: Guild, guild_scope: bool, deleted_rules: int, 
 def _personal_hours_prefix(request: HttpRequest, *, is_htmx: bool) -> str:
     """Pick the whitelisted formset prefix for a personal-scope hours save.
 
-    The page's own My Hours card posts ``rules`` (a plain POST); the Edit Hours modal posts
-    ``modal_rules`` over HTMX. ``modal_rules`` is only accepted WITH the ``HX-Request`` header,
-    so its DOM ids never collide with the always-rendered ``rules`` formset. Any other value,
-    or ``modal_rules`` on a non-HTMX request, is a 404 (fail loudly).
+    Personal hours are edited ONLY through the Edit Hours modal, which posts ``modal_rules``
+    over HTMX. It is accepted only WITH the ``HX-Request`` header, so its DOM ids never
+    collide with anything else on the page. Any other prefix, or ``modal_rules`` on a
+    non-HTMX request, is a 404 (fail loudly).
     """
-    prefix = request.POST.get("formset_prefix", "rules")
-    if prefix not in {"rules", "modal_rules"}:
+    prefix = request.POST.get("formset_prefix", "")
+    if prefix != "modal_rules":
         raise Http404("Unknown formset prefix.")
-    if prefix == "modal_rules" and not is_htmx:
+    if not is_htmx:
         raise Http404("The modal hours editor requires an HTMX request.")
     return prefix
 
@@ -951,12 +943,11 @@ def guild_orientation_hours_save(request: HttpRequest, pk: int) -> HttpResponse:
 
     The posted hidden ``orienter_scope`` field is read FIRST and selects the target — a
     member pk scopes to that person's rows; an empty scope binds the legacy
-    ``guild_rules`` prefix to the guild-level rows. For a personal scope the ``formset_prefix``
-    field picks the prefix: the page's own My Hours card posts ``rules`` (a plain POST); the
-    Edit Hours modal posts ``modal_rules`` over HTMX (whitelisted, and only accepted WITH the
-    ``HX-Request`` header, so its DOM ids never collide with the always-rendered ``rules``
-    formset on the page). An unlisted prefix, or ``modal_rules`` on a non-HTMX request, is a
-    404 (fail loudly). Gate is ``can_edit_orienter_hours``. Deleted rows retire via
+    ``guild_rules`` prefix to the guild-level rows. A personal scope is edited ONLY through the
+    Edit Hours modal, which posts ``modal_rules`` over HTMX (the sole whitelisted personal
+    prefix, and only accepted WITH the ``HX-Request`` header). An unlisted prefix, or
+    ``modal_rules`` on a non-HTMX request, is a 404 (fail loudly). Gate is
+    ``can_edit_orienter_hours``. Deleted rows retire via
     ``retire_rule``, new rows are stamped with the scope's orienter, and saved hours
     materialize slots immediately. A valid HTMX (modal) save answers 204 + ``HX-Redirect``
     to reload the tab; an invalid modal save re-renders the bound formset inside the modal.
@@ -1005,17 +996,15 @@ def guild_orientation_hours_save(request: HttpRequest, pk: int) -> HttpResponse:
         return redirect(orientations_tab)
 
     if prefix == "modal_rules":
-        # Invalid modal POST: re-render the bound partial so field / non-form errors appear
-        # inside the open modal with everything the lead typed preserved.
+        # Invalid modal POST (the only personal-scope path now): re-render the bound partial so
+        # field / non-form errors appear inside the open modal with everything typed preserved.
         return render(
             request,
             "hub/partials/_orienter_hours_modal_form.html",
             {"guild": guild, "target": target, "formset": formset},
         )
-    if target is not None:
-        ctx = _guild_edit_context(request, guild, rule_formset=formset)
-    else:
-        ctx = _guild_edit_context(request, guild, guild_rule_formset=formset)
+    # Guild scope is the only other path here — re-render the full page with the bound formset.
+    ctx = _guild_edit_context(request, guild, guild_rule_formset=formset)
     # The invalid POST lands on the hours-save URL (no ?tab) — keep the Orientations tab open.
     ctx["active_tab"] = "orientations"
     return render(request, "hub/guild_edit.html", ctx)

--- a/templates/hub/guild_edit.html
+++ b/templates/hub/guild_edit.html
@@ -396,93 +396,19 @@ confirm modal carries its own POST form, and template content can't nest a form.
     </div>
   </form>
 
-  {# My Orientation Hours — the viewer's own personal formset (prefix "rules"). Editing anyone #}
-  {# else's hours happens in the Edit Hours modal (prefix "modal_rules"), never on this page. #}
-  {# Hidden for an admin/officer not on this guild's leadership: their own rules would never generate slots. #}
-  {% if show_my_hours_card %}
-  <form id="my-hours-form" method="post" action="{% url 'hub_guild_orientation_hours_save' guild.pk %}" class="hub-form">
-    {% csrf_token %}
-    <input type="hidden" name="orienter_scope" value="{{ viewer_member_pk|default:'' }}">
-    <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;">
-      <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">My Orientation Hours</h2>
-      <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">Weekly windows when you personally can give orientations. We turn them into bookable slots automatically — members book you by name.</p>
-      {{ rule_formset.management_form }}
-      <div id="rule-rows" class="pl-hours-rows">
-        {% for rule in rule_formset %}
-        <div class="hub-card" style="padding:1rem; background:rgba(255,255,255,0.02);">
-          {{ rule.id }}
-          <div style="display:flex; gap:0.75rem; flex-wrap:wrap;">
-            <div style="flex:1; min-width:120px;">{% include "components/form_field.html" with field=rule.weekday %}</div>
-            <div style="flex:1; min-width:90px;">{% include "components/form_field.html" with field=rule.start_time %}</div>
-            <div style="flex:1; min-width:90px;">{% include "components/form_field.html" with field=rule.end_time %}</div>
-            <div style="flex:1; min-width:70px;">{% include "components/form_field.html" with field=rule.seats %}</div>
-          </div>
-          {% include "components/form_field.html" with field=rule.is_active %}
-          {% if rule.instance.pk %}
-            {# Delete confirms first (it retires future open slots), then flips DELETE and saves the page. #}
-            <div style="display:none;">{{ rule.DELETE }}</div>
-            <button type="button" class="pl-btn pl-btn--danger pl-btn--sm" style="margin-top:0.75rem;"
-                    @click="$dispatch('open-confirm', 'rule-del-{{ rule.instance.pk }}')">
-              Delete
-            </button>
-            {% with rpks=rule.instance.pk|stringformat:"s" ruledel="document.getElementById('"|add:rule.DELETE.id_for_label|add:"').checked = true; document.getElementById('my-hours-form').requestSubmit();" %}
-            {% include "components/confirm_modal.html" with confirm_id="rule-del-"|add:rpks confirm_title="Delete these hours?" confirm_message="Upcoming open slots from this window will be removed. Slots someone already booked stay until you cancel them." confirm_button_text="Delete" confirm_js=ruledel %}
-            {% endwith %}
-          {% endif %}
-        </div>
-        {% empty %}
-        <p class="hub-text-muted">No hours yet. Add your first window and members can start booking you.</p>
-        {% endfor %}
-      </div>
-
-      {# Hidden empty-form template, cloned by the +Add button below. #}
-      <template id="rule-empty-template">
-        <div class="hub-card" style="padding:1rem; background:rgba(255,255,255,0.02);">
-          {% with rule_formset.empty_form as er %}
-            {{ er.id }}
-            <div style="display:flex; gap:0.75rem; flex-wrap:wrap;">
-              <div style="flex:1; min-width:120px;">{% include "components/form_field.html" with field=er.weekday %}</div>
-              <div style="flex:1; min-width:90px;">{% include "components/form_field.html" with field=er.start_time %}</div>
-              <div style="flex:1; min-width:90px;">{% include "components/form_field.html" with field=er.end_time %}</div>
-              <div style="flex:1; min-width:70px;">{% include "components/form_field.html" with field=er.seats %}</div>
-            </div>
-            {% include "components/form_field.html" with field=er.is_active %}
-            <button type="button" class="pl-btn pl-btn--danger pl-btn--sm" style="margin-top:0.75rem;" onclick="this.closest('.hub-card').remove();">Remove</button>
-          {% endwith %}
-        </div>
-      </template>
-
-      {# Add then Save sit together — the user asked for Save next to Add (FAQ/Links footer rhythm). #}
-      <div style="margin-top:1rem; display:flex; gap:1rem; align-items:center; flex-wrap:wrap;">
-        <button type="button" class="hub-btn hub-btn--sm"
-                onclick="
-                  const tpl = document.getElementById('rule-empty-template');
-                  const total = document.getElementById('id_rules-TOTAL_FORMS');
-                  const idx = parseInt(total.value, 10);
-                  const wrap = document.createElement('div');
-                  wrap.innerHTML = tpl.innerHTML.replaceAll('__prefix__', idx);
-                  document.getElementById('rule-rows').appendChild(wrap.firstElementChild);
-                  total.value = idx + 1;
-                ">
-          + Add hours
-        </button>
-        <button type="submit" class="pl-btn pl-btn--primary">Save</button>
-      </div>
-    </div>
-  </form>
-  {% endif %}
-
-  {# Orientation Schedule — lead/admin overview grouped by person; Edit Hours opens a modal. #}
-  {% if can_edit_others_hours %}
+  {# Orientation Schedule — everyone who can give orientations, grouped by person; Edit Hours opens a modal. #}
+  {# A lead/admin (can_edit_others_hours) sees + edits every row including their own; a plain orienter #}
+  {# (show_my_hours_card only) sees just their own row, still with an Edit Hours button. #}
+  {% if show_my_hours_card or can_edit_others_hours %}
   <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;">
     <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Orientation Schedule</h2>
-    <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:0.5rem;">Everyone on staff who can give orientations, and when.</p>
+    <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:0.5rem;">{% if can_edit_others_hours %}Everyone on staff who can give orientations, and when.{% else %}Your weekly orientation hours. Members book you by name.{% endif %}</p>
     {% for staffer, staffer_rules in orienter_overview %}
+    {% if can_edit_others_hours or staffer.pk == viewer_member_pk %}
     <div class="pl-orient-overview__group">
       <div class="pl-orient-overview__person">
         {% if staffer.profile_photo %}<img src="{{ staffer.profile_photo.url }}" alt="" class="pl-orient-avatar">{% else %}<span class="pl-orient-avatar pl-orient-avatar--initials">{{ staffer.display_name|slice:":1" }}</span>{% endif %}
         <strong>{{ staffer.display_name }}</strong>
-        {% if staffer.pk != viewer_member_pk %}
         <button type="button" class="hub-btn hub-btn--sm"
                 @click="document.getElementById('edit-hours-modal-body').innerHTML = '<p class=\'hub-text-muted\'>Loading…</p>'; $dispatch('open-modal', 'edit-hours-modal')"
                 hx-get="{% url 'hub_guild_orientation_hours_form' guild.pk %}?orienter={{ staffer.pk }}"
@@ -491,7 +417,6 @@ confirm modal carries its own POST form, and template content can't nest a form.
                 hx-on::send-error="document.getElementById('edit-hours-modal-body').innerHTML = '<p class=\'hub-text-muted\'>Could not load this editor. Close this window and try again.</p>'">
           Edit Hours
         </button>
-        {% endif %}
       </div>
       {% if staffer_rules %}
       <ul class="pl-orient-overview__rules">
@@ -503,8 +428,9 @@ confirm modal carries its own POST form, and template content can't nest a form.
       <p class="hub-text-muted" style="font-size:0.85rem; margin:0.4rem 0 0;">No hours published</p>
       {% endif %}
     </div>
+    {% endif %}
     {% endfor %}
-    {% if former_staff_overview %}
+    {% if can_edit_others_hours and former_staff_overview %}
     <h3 class="hub-detail-label" style="margin:1.25rem 0 0.25rem;">Former Staff</h3>
     <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:0.5rem;">These hours belong to people no longer on staff. They no longer generate slots. Delete them when you are ready.</p>
     {% for staffer, staffer_rules in former_staff_overview %}
@@ -512,8 +438,8 @@ confirm modal carries its own POST form, and template content can't nest a form.
       <div class="pl-orient-overview__person">
         {% if staffer.profile_photo %}<img src="{{ staffer.profile_photo.url }}" alt="" class="pl-orient-avatar">{% else %}<span class="pl-orient-avatar pl-orient-avatar--initials">{{ staffer.display_name|slice:":1" }}</span>{% endif %}
         <strong>{{ staffer.display_name }}</strong>
-        {# Deliberately ungated: a former-staff viewer (admin/officer not on this guild's leadership) #}
-        {# gets no inline My Hours card, so this modal is their only route to clean up their own rows. #}
+        {# Deliberately ungated within this lead/admin card: the Edit Hours modal is the only route #}
+        {# to clean up a former staffer's leftover rows (they no longer appear in the active list). #}
         <button type="button" class="hub-btn hub-btn--sm"
                 @click="document.getElementById('edit-hours-modal-body').innerHTML = '<p class=\'hub-text-muted\'>Loading…</p>'; $dispatch('open-modal', 'edit-hours-modal')"
                 hx-get="{% url 'hub_guild_orientation_hours_form' guild.pk %}?orienter={{ staffer.pk }}"

--- a/templates/hub/partials/_orienter_hours_modal_form.html
+++ b/templates/hub/partials/_orienter_hours_modal_form.html
@@ -2,16 +2,16 @@
 Edit Hours modal body — the orientation-availability formset for one staffer, loaded via
 HTMX into #edit-hours-modal-body (see the Orientation Schedule card in guild_edit.html).
 
-Prefix is ALWAYS "modal_rules" (never "rules"): the page permanently renders the viewer's
-own "rules"-prefixed My Orientation Hours formset, so a second "rules" formset here would
-duplicate every DOM id. The posted formset_prefix field tells the save view which prefix to
-bind (whitelisted, HTMX-only).
+Prefix is ALWAYS "modal_rules": it is the sole whitelisted personal-hours prefix, and the
+save view accepts it only on an HTMX request (the posted formset_prefix field carries it).
+Every orienter — including the viewer — edits their own hours through this modal now, so the
+page no longer renders any inline personal-hours formset that its DOM ids could collide with.
 
 Context: guild, target (the Member being edited), formset (unbound on GET; bound on an
 invalid POST re-render so errors show inside the open modal).
 {% endcomment %}
 <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Editing {{ target.display_name }}'s Hours</h2>
-<p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">Weekly windows when {{ target.display_name }} can give orientations. We turn them into bookable slots automatically — members book them by name.</p>
+<p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">Weekly windows when {{ target.display_name }} can give orientations. We turn them into bookable slots automatically. Members book them by name.</p>
 <form id="edit-hours-modal-form" class="hub-form"
       hx-post="{% url 'hub_guild_orientation_hours_save' guild.pk %}"
       hx-target="#edit-hours-modal-body" hx-swap="innerHTML">

--- a/templates/hub/partials/orientation_checkout_return_card.html
+++ b/templates/hub/partials/orientation_checkout_return_card.html
@@ -26,8 +26,10 @@ The checkout landing card. States:
   </p>
   {% if booking.status == "declined" or booking.status == "cancelled" %}
   <p class="hub-text-muted" style="margin:0 0 1.5rem; font-size:0.95rem;">This booking was {{ booking.get_status_display|lower }}. Your {{ booking.amount_paid_cents|cents_as_price }} comes back automatically as a full refund.</p>
+  {% elif booking.status == "confirmed" %}
+  <p class="hub-text-muted" style="margin:0 0 1.5rem; font-size:0.95rem;">You paid {{ booking.amount_paid_cents|cents_as_price }}. You're all set. We've emailed you the details and a calendar invite.</p>
   {% else %}
-  <p class="hub-text-muted" style="margin:0 0 1.5rem; font-size:0.95rem;">You paid {{ booking.amount_paid_cents|cents_as_price }}. The guild will confirm or decline your request. <strong>If they can't make it work, your {{ booking.amount_paid_cents|cents_as_price }} comes back automatically.</strong> We've emailed you the details and a calendar invite.</p>
+  <p class="hub-text-muted" style="margin:0 0 1.5rem; font-size:0.95rem;">You paid {{ booking.amount_paid_cents|cents_as_price }}. We sent your request to {% if booking.slot.orienter_first_name %}{{ booking.slot.orienter_first_name }}{% else %}the guild{% endif %}. Watch for them to confirm your spot. <strong>If they can't make it work, your {{ booking.amount_paid_cents|cents_as_price }} comes back automatically.</strong> We've emailed you the details and a calendar invite.</p>
   {% endif %}
   <div style="display:flex; gap:0.75rem; flex-wrap:wrap; align-items:center;">
     <a href="{% url 'hub_guild_detail' booking.guild.slug %}" class="pl-btn pl-btn--primary">Back to {{ booking.guild.name }}</a>

--- a/tests/hub/orientation_checkout_views_spec.py
+++ b/tests/hub/orientation_checkout_views_spec.py
@@ -15,6 +15,7 @@ from membership import orientations
 from membership.models import OrientationBooking, OrientationSlot
 from tests.membership.factories import (
     GuildOrientationSettingsFactory,
+    MemberFactory,
     MembershipPlanFactory,
     OrientationBookingFactory,
     OrientationSlotFactory,
@@ -122,8 +123,44 @@ def describe_orientation_checkout_return():
             reverse("hub_orientation_checkout_return", args=[orientations.make_checkout_token(booking)])
         )
         assert response.status_code == 200
-        assert "Pending Confirmation" in response.content.decode()
-        assert "$15" in response.content.decode()
+        content = response.content.decode()
+        assert "Pending Confirmation" in content
+        assert "$15" in content
+        # A guild slot (no named orienter) falls back to "the guild".
+        assert "We sent your request to the guild" in content
+        assert "Watch for them to confirm your spot" in content
+
+    def it_names_the_orienter_in_the_requested_confirmation(client: Client):
+        user = _user("ret_named")
+        settings_obj = GuildOrientationSettingsFactory(price_cents=1500)
+        slot = OrientationSlotFactory(guild=settings_obj.guild, orienter=MemberFactory(full_legal_name="Zoe Zenith"))
+        booking = OrientationBookingFactory(
+            slot=slot, member=user.member, amount_paid_cents=1500, stripe_payment_id="pi_named"
+        )
+        client.login(username="ret_named", password="pass")
+        response = client.get(
+            reverse("hub_orientation_checkout_return", args=[orientations.make_checkout_token(booking)])
+        )
+        assert response.status_code == 200
+        assert "We sent your request to Zoe" in response.content.decode()
+
+    def it_shows_the_all_set_copy_for_a_confirmed_booking(client: Client):
+        user = _user("ret_confirmed")
+        booking = OrientationBookingFactory(
+            slot=_paid_slot(),
+            member=user.member,
+            amount_paid_cents=1500,
+            stripe_payment_id="pi_conf",
+            status=OrientationBooking.Status.CONFIRMED,
+        )
+        client.login(username="ret_confirmed", password="pass")
+        response = client.get(
+            reverse("hub_orientation_checkout_return", args=[orientations.make_checkout_token(booking)])
+        )
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "You're all set." in content
+        assert "Pending Confirmation" not in content
 
     def it_renders_the_polling_state_while_the_webhook_lags(client: Client):
         user = _user("ret2")

--- a/tests/hub/orientation_settings_spec.py
+++ b/tests/hub/orientation_settings_spec.py
@@ -58,6 +58,24 @@ def _hours_payload(scope: str = "", **overrides: str) -> dict[str, str]:
     return data
 
 
+def _modal_hours_payload(scope: str, **overrides: str) -> dict[str, str]:
+    """A personal-scope hours POST through the Edit Hours modal (prefix ``modal_rules``, HTMX).
+
+    Personal hours are modal-only now; post it with ``HTTP_HX_REQUEST="true"``. ``scope`` is the
+    orienter pk. Pass ``modal_rules-*`` overrides to add/override rows.
+    """
+    data = {
+        "orienter_scope": scope,
+        "formset_prefix": "modal_rules",
+        "modal_rules-TOTAL_FORMS": "0",
+        "modal_rules-INITIAL_FORMS": "0",
+        "modal_rules-MIN_NUM_FORMS": "0",
+        "modal_rules-MAX_NUM_FORMS": "1000",
+    }
+    data.update(overrides)
+    return data
+
+
 def _guild_hours_payload(**overrides: str) -> dict[str, str]:
     """A guild-scope hours POST — empty scope binds the legacy ``guild_rules`` prefix."""
     data = {
@@ -84,10 +102,13 @@ def describe_guild_orientation_edit():
         client.login(username="ed_admin", password="pass")
         response = client.get(f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=orientations")
         assert response.status_code == 200
-        assert b"My Orientation Hours" in response.content
+        # Own hours are edited via the Edit Hours modal from the Orientation Schedule, not a
+        # separate inline My Hours card.
+        assert b"Orientation Schedule" in response.content
         assert b"Save orientation settings" in response.content
-        # Recurring hours still save through their own form/endpoint.
-        assert reverse("hub_guild_orientation_hours_save", args=[guild.pk]).encode() in response.content
+        # Recurring hours are edited through the Edit Hours modal, loaded from its own endpoint
+        # (the trigger on the viewer's Orientation Schedule row).
+        assert reverse("hub_guild_orientation_hours_form", args=[guild.pk]).encode() in response.content
         assert b"Who runs orientations" in response.content
         # The Upcoming Slots card (first UI for the slot endpoints) rides on the same tab.
         assert b"Upcoming Slots" in response.content
@@ -186,33 +207,33 @@ def describe_guild_orientation_hours_save():
     """Recurring hours save through their own form/view, separate from the settings form."""
 
     def it_saves_a_recurring_rule_and_redirects_to_the_tab(client: Client):
-        # Self-scope saves require being on the guild's leadership — hence the lead here.
+        # Self-scope saves go through the Edit Hours modal (modal_rules, HTMX) and require being
+        # on the guild's leadership — hence the lead here. A valid save answers 204 + HX-Redirect.
         user = _user_with_role("hrs_add", fog_role=Member.FogRole.MEMBER)
         guild = GuildFactory(guild_lead=user.member)
         client.login(username="hrs_add", password="pass")
         response = client.post(
             reverse("hub_guild_orientation_hours_save", args=[guild.pk]),
-            _hours_payload(
+            _modal_hours_payload(
                 scope=str(user.member.pk),
                 **{
-                    "rules-TOTAL_FORMS": "1",
-                    "rules-0-weekday": "1",
-                    "rules-0-start_time": "18:00",
-                    "rules-0-end_time": "19:00",
-                    "rules-0-seats": "5",
-                    "rules-0-is_active": "on",
+                    "modal_rules-TOTAL_FORMS": "1",
+                    "modal_rules-0-weekday": "1",
+                    "modal_rules-0-start_time": "18:00",
+                    "modal_rules-0-end_time": "19:00",
+                    "modal_rules-0-seats": "5",
+                    "modal_rules-0-is_active": "on",
                 },
             ),
-            follow=True,
+            HTTP_HX_REQUEST="true",
         )
-        assert response.status_code == 200
-        assert response.redirect_chain[-1][0] == f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=orientations"
+        assert response.status_code == 204
+        assert response["HX-Redirect"] == f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=orientations"
         rule = OrientationAvailability.objects.get(guild=guild)
         assert rule.weekday == 1
         assert rule.seats == 5
         # The posted scope stamps the new rule as the saver's personal hours.
         assert rule.orienter == user.member
-        assert "Hours saved." in [str(m) for m in response.context["messages"]]
 
     def it_edits_an_existing_guild_rule_through_the_guild_scope(client: Client):
         # Legacy guild-level rows bind through the guild_rules prefix (empty scope).
@@ -280,19 +301,20 @@ def describe_guild_orientation_hours_save():
         client.login(username="hrs_gen", password="pass")
         response = client.post(
             reverse("hub_guild_orientation_hours_save", args=[guild.pk]),
-            _hours_payload(
+            _modal_hours_payload(
                 scope=str(user.member.pk),
                 **{
-                    "rules-TOTAL_FORMS": "1",
-                    "rules-0-weekday": "1",
-                    "rules-0-start_time": "18:00",
-                    "rules-0-end_time": "19:00",
-                    "rules-0-seats": "5",
-                    "rules-0-is_active": "on",
+                    "modal_rules-TOTAL_FORMS": "1",
+                    "modal_rules-0-weekday": "1",
+                    "modal_rules-0-start_time": "18:00",
+                    "modal_rules-0-end_time": "19:00",
+                    "modal_rules-0-seats": "5",
+                    "modal_rules-0-is_active": "on",
                 },
             ),
+            HTTP_HX_REQUEST="true",
         )
-        assert response.status_code == 302
+        assert response.status_code == 204
         slot = OrientationSlot.objects.filter(guild=guild, source=OrientationSlot.Source.GENERATED).first()
         assert slot is not None
         # Generated slots carry their rule's orienter through.
@@ -306,45 +328,47 @@ def describe_guild_orientation_hours_save():
         client.login(username="hrs_keep", password="pass")
         response = client.post(
             reverse("hub_guild_orientation_hours_save", args=[guild.pk]),
-            _hours_payload(
+            _modal_hours_payload(
                 scope=str(user.member.pk),
                 **{
-                    "rules-TOTAL_FORMS": "1",
-                    "rules-0-weekday": "2",
-                    "rules-0-start_time": "10:00",
-                    "rules-0-end_time": "11:00",
-                    "rules-0-seats": "3",
-                    "rules-0-is_active": "on",
+                    "modal_rules-TOTAL_FORMS": "1",
+                    "modal_rules-0-weekday": "2",
+                    "modal_rules-0-start_time": "10:00",
+                    "modal_rules-0-end_time": "11:00",
+                    "modal_rules-0-seats": "3",
+                    "modal_rules-0-is_active": "on",
                 },
             ),
+            HTTP_HX_REQUEST="true",
         )
-        assert response.status_code == 302
+        assert response.status_code == 204
         settings_obj.refresh_from_db()
         assert settings_obj.is_enabled is True
         assert settings_obj.default_location == "Front desk"
 
     def it_rejects_a_rule_whose_end_is_before_its_start(client: Client):
-        # The bad time range re-renders the page with the field error and saves nothing.
+        # The bad time range re-renders the modal partial with the field error and saves nothing.
         user = _user_with_role("hrs_bad", fog_role=Member.FogRole.MEMBER)
         guild = GuildFactory(guild_lead=user.member)
         client.login(username="hrs_bad", password="pass")
         response = client.post(
             reverse("hub_guild_orientation_hours_save", args=[guild.pk]),
-            _hours_payload(
+            _modal_hours_payload(
                 scope=str(user.member.pk),
                 **{
-                    "rules-TOTAL_FORMS": "1",
-                    "rules-0-weekday": "1",
-                    "rules-0-start_time": "19:00",
-                    "rules-0-end_time": "18:00",
-                    "rules-0-seats": "4",
-                    "rules-0-is_active": "on",
+                    "modal_rules-TOTAL_FORMS": "1",
+                    "modal_rules-0-weekday": "1",
+                    "modal_rules-0-start_time": "19:00",
+                    "modal_rules-0-end_time": "18:00",
+                    "modal_rules-0-seats": "4",
+                    "modal_rules-0-is_active": "on",
                 },
             ),
+            HTTP_HX_REQUEST="true",
         )
         assert response.status_code == 200
         assert OrientationAvailability.objects.filter(guild=guild).count() == 0
-        assert response.context["rule_formset"].errors
+        assert b"Editing" in response.content  # the bound modal partial re-renders with errors
 
     def it_lets_the_guild_lead_save_hours(client: Client):
         user = _user_with_role("hrs_lead", fog_role=Member.FogRole.MEMBER)
@@ -352,19 +376,20 @@ def describe_guild_orientation_hours_save():
         client.login(username="hrs_lead", password="pass")
         response = client.post(
             reverse("hub_guild_orientation_hours_save", args=[guild.pk]),
-            _hours_payload(
+            _modal_hours_payload(
                 scope=str(user.member.pk),
                 **{
-                    "rules-TOTAL_FORMS": "1",
-                    "rules-0-weekday": "1",
-                    "rules-0-start_time": "18:00",
-                    "rules-0-end_time": "19:00",
-                    "rules-0-seats": "5",
-                    "rules-0-is_active": "on",
+                    "modal_rules-TOTAL_FORMS": "1",
+                    "modal_rules-0-weekday": "1",
+                    "modal_rules-0-start_time": "18:00",
+                    "modal_rules-0-end_time": "19:00",
+                    "modal_rules-0-seats": "5",
+                    "modal_rules-0-is_active": "on",
                 },
             ),
+            HTTP_HX_REQUEST="true",
         )
-        assert response.status_code == 302
+        assert response.status_code == 204
         assert OrientationAvailability.objects.filter(guild=guild).count() == 1
 
     def it_forbids_a_regular_member(client: Client):

--- a/tests/hub/orienter_hours_editor_spec.py
+++ b/tests/hub/orienter_hours_editor_spec.py
@@ -93,12 +93,15 @@ def _form_url(guild: object, orienter_pk: object) -> str:
 
 def describe_my_hours_scope_binding():
     def it_lets_a_staffer_save_their_own_hours(client: Client):
+        # Own hours now save through the Edit Hours modal (prefix modal_rules, HTMX): a valid
+        # save answers 204 + HX-Redirect back to the tab, not a plain 302.
         guild = GuildFactory()
         user = _member_user("sc_own", name="Bob Placeholder")
         GuildStaffMembershipFactory(guild=guild, member=user.member, role=GuildStaffMembership.Role.ORIENTER)
         client.login(username="sc_own", password="pass")
-        response = client.post(_hours_url(guild), _rule_payload(str(user.member.pk)))
-        assert response.status_code == 302
+        response = client.post(_hours_url(guild), _modal_rule_payload(str(user.member.pk)), HTTP_HX_REQUEST="true")
+        assert response.status_code == 204
+        assert response["HX-Redirect"] == _tab_url(guild)
         rule = OrientationAvailability.objects.get(guild=guild)
         assert rule.orienter == user.member
 
@@ -110,16 +113,17 @@ def describe_my_hours_scope_binding():
         client.login(username="sc_edit", password="pass")
         response = client.post(
             _hours_url(guild),
-            _rule_payload(
+            _modal_rule_payload(
                 str(user.member.pk),
                 **{
-                    "rules-INITIAL_FORMS": "1",
-                    "rules-0-id": str(rule.pk),
-                    "rules-0-seats": "6",
+                    "modal_rules-INITIAL_FORMS": "1",
+                    "modal_rules-0-id": str(rule.pk),
+                    "modal_rules-0-seats": "6",
                 },
             ),
+            HTTP_HX_REQUEST="true",
         )
-        assert response.status_code == 302
+        assert response.status_code == 204
         rule.refresh_from_db()
         assert rule.seats == 6
         assert rule.orienter == user.member
@@ -131,7 +135,7 @@ def describe_my_hours_scope_binding():
         alice = MemberFactory(full_legal_name="Alice Ash")
         GuildStaffMembershipFactory(guild=guild, member=alice, role=GuildStaffMembership.Role.ORIENTER)
         client.login(username="sc_other", password="pass")
-        response = client.post(_hours_url(guild), _rule_payload(str(alice.pk)))
+        response = client.post(_hours_url(guild), _modal_rule_payload(str(alice.pk)), HTTP_HX_REQUEST="true")
         assert response.status_code == 403
         assert not OrientationAvailability.objects.filter(guild=guild).exists()
 
@@ -141,8 +145,8 @@ def describe_my_hours_scope_binding():
         bob = MemberFactory(full_legal_name="Bob Placeholder")
         GuildStaffMembershipFactory(guild=guild, member=bob, role=GuildStaffMembership.Role.ORIENTER)
         client.login(username="sc_lead", password="pass")
-        response = client.post(_hours_url(guild), _rule_payload(str(bob.pk)))
-        assert response.status_code == 302
+        response = client.post(_hours_url(guild), _modal_rule_payload(str(bob.pk)), HTTP_HX_REQUEST="true")
+        assert response.status_code == 204
         assert OrientationAvailability.objects.get(guild=guild).orienter == bob
 
     def it_forbids_non_lead_staff_posting_the_guild_scope(client: Client):
@@ -186,36 +190,41 @@ def describe_my_hours_scope_binding():
         user = _member_user("sc_bad", name="Lead Person")
         guild = GuildFactory(guild_lead=user.member)
         client.login(username="sc_bad", password="pass")
-        response = client.post(_hours_url(guild), _rule_payload("bogus"))
+        response = client.post(_hours_url(guild), _modal_rule_payload("bogus"), HTTP_HX_REQUEST="true")
         assert response.status_code == 404
 
-    def it_re_renders_an_invalid_own_hours_post_on_the_orientations_tab(client: Client):
-        # A plain (non-HTMX) own-hours POST that fails validation re-renders the full page
-        # with the tab kept open and the bound formset's errors surfaced.
+    def it_re_renders_an_invalid_own_hours_modal_post(client: Client):
+        # An own-hours modal POST that fails validation re-renders the bound modal partial with
+        # the errors surfaced inside the open editor; nothing is saved.
         user = _member_user("sc_invalid", name="Lead Person")
         guild = GuildFactory(guild_lead=user.member)
         client.login(username="sc_invalid", password="pass")
         response = client.post(
             _hours_url(guild),
-            _rule_payload(str(user.member.pk), **{"rules-0-start_time": "19:00", "rules-0-end_time": "18:00"}),
+            _modal_rule_payload(
+                str(user.member.pk), **{"modal_rules-0-start_time": "19:00", "modal_rules-0-end_time": "18:00"}
+            ),
+            HTTP_HX_REQUEST="true",
         )
         assert response.status_code == 200
-        assert response.context["active_tab"] == "orientations"  # tab stays open on the error
-        assert response.context["rule_formset"].errors
+        assert b"Editing Lead Person" in response.content  # the bound modal partial
         assert not OrientationAvailability.objects.filter(guild=guild).exists()
 
 
 def describe_my_hours_rendering():
+    # The inline My Hours card is gone; a staffer edits their own hours through the same Edit
+    # Hours modal partial as everyone else, opened from their row in the Orientation Schedule.
     def it_renders_a_saved_rule_with_its_delete_confirm_modal(client: Client):
         guild = GuildFactory()
         user = _member_user("rw_row", name="Bob Placeholder")
         GuildStaffMembershipFactory(guild=guild, member=user.member, role=GuildStaffMembership.Role.ORIENTER)
         rule = OrientationAvailabilityFactory(guild=guild, orienter=user.member)
         client.login(username="rw_row", password="pass")
-        response = client.get(_tab_url(guild))
+        response = client.get(_form_url(guild, user.member.pk))
         assert response.status_code == 200
+        assert b"Editing Bob Placeholder" in response.content
         assert b"Delete these hours?" in response.content
-        assert f"rule-del-{rule.pk}".encode() in response.content
+        assert f"modal-rule-del-{rule.pk}".encode() in response.content
         assert b"+ Add hours" in response.content
 
     def it_shows_the_empty_state_for_a_staffer_with_no_hours(client: Client):
@@ -223,8 +232,8 @@ def describe_my_hours_rendering():
         user = _member_user("rw_empty", name="Empty Staffer")
         GuildStaffMembershipFactory(guild=guild, member=user.member, role=GuildStaffMembership.Role.ORIENTER)
         client.login(username="rw_empty", password="pass")
-        response = client.get(_tab_url(guild))
-        assert b"No hours yet. Add your first window and members can start booking you." in response.content
+        response = client.get(_form_url(guild, user.member.pk))
+        assert b"No hours yet. Add a window and members can start booking Empty Staffer." in response.content
 
 
 def describe_non_leadership_admin_self_scope():
@@ -254,17 +263,21 @@ def describe_non_leadership_admin_self_scope():
         bob = MemberFactory(full_legal_name="Bob Placeholder")
         GuildStaffMembershipFactory(guild=guild, member=bob, role=GuildStaffMembership.Role.ORIENTER)
         client.login(username="nl_behalf", password="pass")
-        response = client.post(_hours_url(guild), _rule_payload(str(bob.pk)))
-        assert response.status_code == 302
+        response = client.post(_hours_url(guild), _modal_rule_payload(str(bob.pk)), HTTP_HX_REQUEST="true")
+        assert response.status_code == 204
         assert OrientationAvailability.objects.get(guild=guild).orienter == bob
 
-    def it_shows_the_card_again_when_the_admin_is_also_on_staff(client: Client):
+    def it_shows_their_own_editable_row_when_the_admin_is_also_on_staff(client: Client):
+        # A staffed admin gets no inline card either — their own row shows in the Orientation
+        # Schedule with an Edit Hours trigger scoped to themselves.
         guild = GuildFactory()
         user = _member_user("nl_staffed", name="Staffed Admin", fog_role=Member.FogRole.ADMIN)
         GuildStaffMembershipFactory(guild=guild, member=user.member, role=GuildStaffMembership.Role.ORIENTER)
         client.login(username="nl_staffed", password="pass")
         response = client.get(_tab_url(guild))
-        assert b"My Orientation Hours" in response.content
+        assert b"My Orientation Hours" not in response.content
+        assert b"Orientation Schedule" in response.content
+        assert f"orienter={user.member.pk}".encode() in response.content
 
 
 def describe_upcoming_slots_query_count():
@@ -410,24 +423,29 @@ def describe_rule_delete_retirement():
         )
         OrientationBookingFactory(slot=booked)
         client.login(username="del_lead", password="pass")
+        # The lead deletes Bob's rule through the Edit Hours modal (modal_rules, HTMX). A valid
+        # save answers 204 + HX-Redirect; the retirement flash renders on the reloaded tab.
         response = client.post(
             _hours_url(guild),
-            _rule_payload(
+            _modal_rule_payload(
                 str(bob.pk),
                 **{
-                    "rules-INITIAL_FORMS": "1",
-                    "rules-0-id": str(rule.pk),
-                    "rules-0-weekday": str(rule.weekday),
-                    "rules-0-start_time": "18:00",
-                    "rules-0-end_time": "19:00",
-                    "rules-0-seats": str(rule.seats),
-                    "rules-0-DELETE": "on",
+                    "modal_rules-INITIAL_FORMS": "1",
+                    "modal_rules-0-id": str(rule.pk),
+                    "modal_rules-0-weekday": str(rule.weekday),
+                    "modal_rules-0-start_time": "18:00",
+                    "modal_rules-0-end_time": "19:00",
+                    "modal_rules-0-seats": str(rule.seats),
+                    "modal_rules-0-DELETE": "on",
                 },
             ),
-            follow=True,
+            HTTP_HX_REQUEST="true",
         )
-        assert response.status_code == 200
-        joined = " ".join(str(m) for m in response.context["messages"])
+        assert response.status_code == 204
+        assert response["HX-Redirect"] == _tab_url(guild)
+        # Follow the HX-Redirect to consume the queued flash on the reloaded tab.
+        followup = client.get(_tab_url(guild))
+        joined = " ".join(str(m) for m in followup.context["messages"])
         assert "Hours deleted." in joined
         assert "Removed 1 upcoming open slot." in joined
         assert "1 booked slot kept." in joined
@@ -485,27 +503,34 @@ def describe_orientation_schedule_overview():
         assert b"No hours published" in response.content  # the lead has none
         assert f"orienter={bob.pk}".encode() in response.content  # Edit Hours modal trigger (hx-get)
 
-    def it_hides_the_edit_hours_button_on_the_viewers_own_row(client: Client):
-        # The viewer edits their own hours via the inline My Hours card; an Edit Hours modal
-        # over their own row would open a second editor over the same rows. Every OTHER
-        # active-staff row still gets the modal trigger.
+    def it_shows_the_edit_hours_button_on_the_viewers_own_row(client: Client):
+        # The viewer now edits their own hours through the same Edit Hours modal as everyone
+        # else, so their own row carries the modal trigger. Every other staff row does too.
         user = _member_user("ov_ownrow", name="Lead Person")
         guild = GuildFactory(guild_lead=user.member)
         bob = MemberFactory(full_legal_name="Bob Placeholder")
         GuildStaffMembershipFactory(guild=guild, member=bob, role=GuildStaffMembership.Role.ORIENTER)
         client.login(username="ov_ownrow", password="pass")
         content = client.get(_tab_url(guild)).content
-        assert f"orienter={user.member.pk}".encode() not in content
+        assert f"orienter={user.member.pk}".encode() in content
         assert f"orienter={bob.pk}".encode() in content
 
-    def it_hides_the_overview_from_plain_staff(client: Client):
+    def it_shows_a_plain_staffer_only_their_own_row(client: Client):
+        # A plain orienter (no authority over others) now sees the Orientation Schedule scoped
+        # to their own row with its Edit Hours trigger — never another staffer's row.
         guild = GuildFactory()
         user = _member_user("ov_staff", name="Bob Placeholder")
         GuildStaffMembershipFactory(guild=guild, member=user.member, role=GuildStaffMembership.Role.ORIENTER)
+        other = MemberFactory(full_legal_name="Other Orienter")
+        GuildStaffMembershipFactory(guild=guild, member=other, role=GuildStaffMembership.Role.ORIENTER)
         client.login(username="ov_staff", password="pass")
         response = client.get(_tab_url(guild))
         assert response.status_code == 200
-        assert b"Orientation Schedule" not in response.content
+        assert b"Orientation Schedule" in response.content
+        assert f"orienter={user.member.pk}".encode() in response.content
+        # The other staffer's Orientation Schedule row + Edit Hours trigger are not rendered
+        # (their name still appears on the Staff tab, so assert on the schedule trigger, not it).
+        assert f"orienter={other.pk}".encode() not in response.content
         # Changelog guard (§10): the retired heading must never resurface on a hub page —
         # the changelog text renders into every page's context, so keep asserting its absence.
         assert b"All Orientation Hours" not in response.content
@@ -556,6 +581,36 @@ def describe_guild_hours_legacy_card():
         assert b"Guild Hours (Any Orienter)" in response.content
         assert b"Only the guild lead can change them." in response.content
         assert b"guild_rules-TOTAL_FORMS" not in response.content
+
+    def it_re_renders_an_invalid_guild_scope_post_on_the_tab(client: Client):
+        # A guild-scope (legacy shared) hours POST that fails validation re-renders the full
+        # page with the bound guild_rules formset and the Orientations tab kept open; the
+        # personal path is modal-only, so this full-page arm is guild scope alone now.
+        user = _member_user("gh_invalid", name="Lead Person")
+        guild = GuildFactory(guild_lead=user.member)
+        rule = OrientationAvailabilityFactory(guild=guild)  # a guild-level (orienter=None) row
+        client.login(username="gh_invalid", password="pass")
+        response = client.post(
+            _hours_url(guild),
+            {
+                "orienter_scope": "",
+                "guild_rules-TOTAL_FORMS": "1",
+                "guild_rules-INITIAL_FORMS": "1",
+                "guild_rules-MIN_NUM_FORMS": "0",
+                "guild_rules-MAX_NUM_FORMS": "1000",
+                "guild_rules-0-id": str(rule.pk),
+                "guild_rules-0-weekday": str(rule.weekday),
+                "guild_rules-0-start_time": "19:00",
+                "guild_rules-0-end_time": "18:00",
+                "guild_rules-0-seats": str(rule.seats),
+                "guild_rules-0-is_active": "on",
+            },
+        )
+        assert response.status_code == 200
+        assert response.context["active_tab"] == "orientations"
+        assert response.context["guild_rule_formset"].errors
+        rule.refresh_from_db()
+        assert rule.start_time.hour == 18  # nothing saved
 
 
 def describe_upcoming_slots_card():

--- a/tests/hub/orienters_spec.py
+++ b/tests/hub/orienters_spec.py
@@ -61,7 +61,9 @@ def describe_orienter_access_to_the_config_editor():
         client.login(username="o_edit", password="pass")
         response = client.get(reverse("hub_guild_orientation_edit", args=[guild.pk]), follow=True)
         assert response.status_code == 200
-        assert b"My Orientation Hours" in response.content
+        # An orienter now sees the Orientation Schedule (scoped to their own editable row),
+        # not a separate inline My Hours card.
+        assert b"Orientation Schedule" in response.content
 
     def it_still_forbids_an_unrelated_member(client: Client):
         guild = GuildFactory()


### PR DESCRIPTION
Two orientation-surface refinements. No VERSION bump (polish to already-shipped 1.19.x surfaces, so no member announcement).

## 1. Unify orientation hours editing (guild edit Orientations tab)
Removes the separate "My Orientation Hours" inline card. Everyone who can give orientations now edits their own recurring hours from their own row in the **Orientation Schedule** via the same **Edit Hours** popup used for every other orienter. One editing path instead of two.
- Overview now shows to `show_my_hours_card or can_edit_others_hours`; each row renders for `can_edit_others_hours or staffer.pk == viewer_member_pk`; the own-row Edit Hours guard is removed.
- Personal hours save only through the modal (`modal_rules` over HTMX); the dead inline `rules` plain-POST path, its full-page invalid re-render arm, and the `rule_formset` context are removed.
- A plain staff orienter still sees + edits their own row (not stranded); editing others stays lead/admin-only.

## 2. Name the orienter on the paid checkout confirmation
The requested-state return card now reads "We sent your request to {orienter first name}. Watch for them to confirm your spot." (falls back to "the guild" for an any-orienter slot), and a confirmed booking shows "You're all set." instead of the request wording.

## Testing
- `tests/hub/orienter_hours_editor_spec.py` (47), plus `orientation_settings_spec.py`, `orienters_spec.py`, `modal_static_spec.py`, `guild_edit_spec.py` all green.
- `tests/hub/orientation_checkout_views_spec.py` (32) green, incl. new named-orienter, guild-fallback, and confirmed-state cases.
- ruff + mypy + manage.py check clean. No e2e touches these surfaces.

https://claude.ai/code/session_01NF4MEeH2icSRQ9U4RuGTmA