### PR TITLE
feat(demo): admin guild show/hide toggle + full class with waitlist in demo data

### DIFF
--- a/core/management/commands/demo_data.py
+++ b/core/management/commands/demo_data.py
@@ -77,6 +77,15 @@ GUEST_ORDER_NUMBER = "PL-DEM2-26"
 STUDENT_PAST_ORDER_NUMBER = "PL-DMP2-26"
 STUDENT_FUTURE_ORDER_NUMBER = "PL-DMF2-26"
 
+# A capacity-filled class with a real waitlist behind it, so an admin/instructor can
+# demo removing a confirmed student and promoting ("notify next in line") the next
+# person off the waitlist. CONFIRMED count equals capacity → the class reads as full
+# (spots_remaining == 0); the WAITLISTED rows sit genuinely beyond capacity. It is
+# prod-safe like the rest (demo- slug + @pastlives.demo emails, direct ORM, no
+# Stripe/email), so it lives outside the DEBUG-gated local-dev extras.
+FULL_WAITLIST_CAPACITY = 4
+FULL_WAITLIST_WAITLISTED = 3
+
 # --- Local-dev-only personas + data (gated on settings.DEBUG) ----------------
 # The blocks below create ACTIVE demo Members, push orientation config onto real
 # guilds, and trigger no external side effects. They run on local dev only so a
@@ -141,6 +150,7 @@ class Command(BaseCommand):
         self._ensure_student_registrations(student, past_class, future_paid_class)
         self._ensure_instructor_class_rosters(past_class, current_free_class, future_paid_class)
         self._ensure_guest_registration(current_free_class)
+        full_waitlist_class = self._ensure_full_waitlist_class(category, instructor)
         self._ensure_discount_codes()
 
         # Everything below is local-dev only. Registration questions are global
@@ -176,6 +186,11 @@ class Command(BaseCommand):
             self.stdout.write(f"  Member (orientations): {PERSONA_MEMBER_EMAIL}  /  password: {password}")
         self.stdout.write("\nGuest lookup (no login):")
         self.stdout.write(f"  Last name: Guest    Order #: {GUEST_ORDER_NUMBER}")
+        self.stdout.write(f"\nFull class + waitlist: {full_waitlist_class.title}  (slug: {full_waitlist_class.slug})")
+        self.stdout.write(
+            f"  {full_waitlist_class.capacity} confirmed = capacity (full), "
+            f"{FULL_WAITLIST_WAITLISTED} waitlisted. Remove a confirmed student, then notify the next in line."
+        )
         if pending_class is not None:
             self.stdout.write(f"\nPending admin approval: {pending_class.title}  (slug: {pending_class.slug})")
         if orientation_summary:
@@ -434,6 +449,57 @@ class Command(BaseCommand):
             confirmed_at=timezone.now() - timedelta(hours=6),
             amount_paid_cents=0,
         )
+
+    def _ensure_full_waitlist_class(self, category: Category, instructor: Any) -> ClassOffering:
+        """A published, upcoming class filled to capacity with a genuine waitlist behind it.
+
+        CONFIRMED registrations exactly equal ``capacity`` so the class reads as full
+        (``ClassOffering.spots_remaining == 0``), and ``FULL_WAITLIST_WAITLISTED`` extra
+        rows sit beyond capacity as ``WAITLISTED`` — unpaid, unconfirmed, and with
+        ``waitlist_notified_at`` left at its ``None`` default. That state lets an
+        admin/instructor demo removing a confirmed student and promoting ("notify next
+        in line") the first person off the waitlist.
+
+        Prod-safe like the rest of the seed: demo- slug + @pastlives.demo emails, direct
+        ORM, no Stripe/email side effects. Idempotent — every row is keyed on its
+        ``order_number`` via :meth:`_upsert_registration`.
+        """
+        now = timezone.now()
+        offering = self._upsert_class(
+            slug=f"{DEMO_SLUG_PREFIX}full-waitlist",
+            title="[DEMO] Screen Printing Intensive (Full + Waitlist)",
+            category=category,
+            instructor=instructor,
+            price_cents=9000,
+            capacity=FULL_WAITLIST_CAPACITY,
+            session_start=now + timedelta(days=10),
+        )
+        # Fill to capacity with CONFIRMED, paid registrants → spots_remaining == 0.
+        for i in range(1, offering.capacity + 1):
+            self._upsert_registration(
+                offering=offering,
+                order_number=f"PL-DMW{i + 1}-26",
+                email=f"wl-confirmed{i}@{DEMO_EMAIL_DOMAIN}",
+                first_name="Waitlist",
+                last_name=f"Confirmed{i}",
+                status=Registration.Status.CONFIRMED,
+                confirmed_at=now - timedelta(days=1),
+                amount_paid_cents=offering.price_cents,
+            )
+        # A genuine waitlist beyond capacity: unpaid, unconfirmed, and never notified
+        # (waitlist_notified_at defaults to None and _upsert_registration never sets it).
+        for i in range(1, FULL_WAITLIST_WAITLISTED + 1):
+            self._upsert_registration(
+                offering=offering,
+                order_number=f"PL-DMX{i + 1}-26",
+                email=f"wl-waiting{i}@{DEMO_EMAIL_DOMAIN}",
+                first_name="Waitlist",
+                last_name=f"Waiting{i}",
+                status=Registration.Status.WAITLISTED,
+                confirmed_at=None,
+                amount_paid_cents=0,
+            )
+        return offering
 
     def _upsert_registration(
         self,

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -2270,6 +2270,29 @@ class GuildAnnouncementSettingsForm(forms.ModelForm):
         labels = {"allow_member_announcement_suggestions": "Let members suggest announcements"}
 
 
+class GuildVisibilityForm(forms.ModelForm):
+    """Admin-only show/hide toggle for a guild (Basic tab of the guild editor).
+
+    A single boolean on :class:`~membership.models.Guild`, rendered as a toggle. Turning
+    it off sets ``is_active=False``, which removes the guild from the sidebar, the guild
+    directory, the community calendar, and voting — but the guild page and this settings
+    page stay reachable by direct link, so an admin can turn it back on. Save is gated to
+    an actual admin in the view; a guild lead never sees or reaches this control.
+    """
+
+    class Meta:
+        model = Guild
+        fields = ["is_active"]
+        labels = {"is_active": "Visible to members"}
+        help_texts = {
+            "is_active": (
+                "When off, this guild is hidden from the sidebar, the guild directory, the "
+                "community calendar, and voting. Its guild page and this settings page stay "
+                "reachable by direct link, so an admin can turn it back on."
+            )
+        }
+
+
 class GuildAnnouncementDecisionForm(forms.Form):
     """A reviewer's decision on a proposed guild announcement.
 

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -82,6 +82,7 @@ urlpatterns = [
     path("guilds/<int:pk>/qr.<str:fmt>/", views.guild_qr_download, name="hub_guild_qr"),
     path("guilds/<int:pk>/flyer/", views.guild_flyer, name="hub_guild_flyer"),
     path("guilds/<int:pk>/delete/", views.guild_delete, name="hub_guild_delete"),
+    path("guilds/<int:pk>/visibility/save/", views.guild_visibility_save, name="hub_guild_visibility_save"),
     path("hero-adjust/", views.hub_hero_adjust, name="hub_hero_adjust"),
     path("guilds/<int:pk>/banner/delete/", views.guild_banner_delete, name="hub_guild_banner_delete"),
     path("guilds/<int:pk>/orientation/edit/", views.guild_orientation_edit, name="hub_guild_orientation_edit"),

--- a/hub/views.py
+++ b/hub/views.py
@@ -686,6 +686,7 @@ def _guild_edit_context(
         GuildOrientationSettingsForm,
         GuildStaffAddForm,
         GuildThankyouEmailForm,
+        GuildVisibilityForm,
         OrientationAvailabilityFormSet,
         OrientationSlotForm,
         StudioHoursFormSet,
@@ -747,6 +748,7 @@ def _guild_edit_context(
         ),
         "staff_by_member": guild.staff_by_member(),
         "staff_add_form": GuildStaffAddForm(member_queryset=_staff_candidates(guild), guild=guild),
+        "visibility_form": GuildVisibilityForm(instance=guild),
         "is_admin": _viewing_as_admin(request),
         "google_sync_enabled": _google_sync_enabled(),
         "notes": guild.meeting_notes.prefetch_related("attachments"),
@@ -858,6 +860,35 @@ def guild_delete(request: HttpRequest, pk: int) -> HttpResponse:
     guild.soft_delete()
     messages.success(request, f"“{guild.name}” has been deleted.")
     return redirect("home")
+
+
+@login_required
+@require_POST
+def guild_visibility_save(request: HttpRequest, pk: int) -> HttpResponse:
+    """Show/hide a guild from the Basic tab of the guild editor. Actual admin only.
+
+    Flips ``Guild.is_active`` via a single-boolean :class:`~hub.forms.GuildVisibilityForm`.
+    Gated with ``_require_admin`` (the same effective-admin gate as the Danger Zone
+    delete on this page), so a guild lead or staffer gets a 403 and never sees the
+    control. Turning it off removes the guild from the sidebar, directory, community
+    calendar, and voting (existing ``is_active`` behavior); the guild page and this
+    settings page stay reachable by direct link so an admin can turn it back on.
+    Redirects back to the Basic tab.
+    """
+    from hub.forms import GuildVisibilityForm
+
+    guild = get_object_or_404(Guild, pk=pk)
+    forbidden = _require_admin(request)
+    if forbidden is not None:
+        return forbidden
+    form = GuildVisibilityForm(request.POST, instance=guild)
+    form.is_valid()  # single-boolean form; populates cleaned_data. save() below raises loudly if ever invalid.
+    form.save()
+    messages.success(
+        request,
+        "This guild is now visible to members." if guild.is_active else "This guild is now hidden from members.",
+    )
+    return redirect(f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=basic")
 
 
 @login_required

--- a/membership/example_guild.py
+++ b/membership/example_guild.py
@@ -281,27 +281,33 @@ def seed_example_guild() -> "Guild":
 
     lead = _example_member(LEAD_NAME)
 
+    # Every seeded field stays authoritative on re-seed via ``defaults`` — EXCEPT
+    # ``is_active``, which belongs only in ``create_defaults`` (Django 5+) so it is
+    # set on first creation and never again. That way an admin who flips the guild
+    # visible for a demo keeps it visible across the next deploy's re-seed, instead
+    # of every deploy silently forcing it back to inactive.
+    guild_defaults = {
+        "name": EXAMPLE_GUILD_NAME,
+        "is_featured": False,
+        "guild_lead": lead,
+        "about": ABOUT,
+        "wishlist": WISHLIST,
+        "essential_rules": ESSENTIAL_RULES,
+        "faq_label": FAQ_LABEL,
+        "website_url": "https://members.pastlives.space/help/",
+        "youtube_url": "https://www.youtube.com/watch?v=YE7VzlLtp-4",
+        "show_members": True,
+        "meeting_schedule": MEETING_SCHEDULE,
+        "meeting_cadence": Guild.MeetingCadence.MONTHLY,
+        "meeting_weekday": 1,  # Tuesday
+        "meeting_week_of_month": 1,
+        "meeting_time": time(19, 0),
+        "meeting_location": "The Map Room (2nd floor)",
+    }
     guild, _ = Guild.objects.update_or_create(
         slug=EXAMPLE_GUILD_SLUG,
-        defaults={
-            "name": EXAMPLE_GUILD_NAME,
-            "is_active": False,
-            "is_featured": False,
-            "guild_lead": lead,
-            "about": ABOUT,
-            "wishlist": WISHLIST,
-            "essential_rules": ESSENTIAL_RULES,
-            "faq_label": FAQ_LABEL,
-            "website_url": "https://members.pastlives.space/help/",
-            "youtube_url": "https://www.youtube.com/watch?v=YE7VzlLtp-4",
-            "show_members": True,
-            "meeting_schedule": MEETING_SCHEDULE,
-            "meeting_cadence": Guild.MeetingCadence.MONTHLY,
-            "meeting_weekday": 1,  # Tuesday
-            "meeting_week_of_month": 1,
-            "meeting_time": time(19, 0),
-            "meeting_location": "The Map Room (2nd floor)",
-        },
+        defaults=guild_defaults,
+        create_defaults={**guild_defaults, "is_active": False},
     )
 
     _seed_media(guild)

--- a/templates/hub/guild_edit.html
+++ b/templates/hub/guild_edit.html
@@ -223,6 +223,25 @@
 
 {% if is_admin %}
 {% comment %}
+Guild Visibility (admin only) — show/hide the guild from every listing. Its own form
+and endpoint, sitting outside the main form. A guild lead never sees this: it is gated
+on is_admin (the same effective-admin gate as the Danger Zone below), and the save view
+403s anyone who is not an actual admin.
+{% endcomment %}
+<form method="post" action="{% url 'hub_guild_visibility_save' guild.pk %}" class="hub-form" x-show="section === 'basic'" x-cloak>
+  {% csrf_token %}
+  <div class="hub-card" style="padding:1.5rem; margin-top:2.5rem; margin-bottom:1.5rem;">
+    <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Visibility</h2>
+    <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem; max-width:46rem;">
+      Turn a guild off to hide it while you get it ready, then back on to launch it. Hiding removes it
+      from the sidebar, the guild directory, the community calendar, and voting. The guild page and this
+      settings page stay reachable by direct link, so an admin can always turn it back on.
+    </p>
+    {% include "components/form_field.html" with field=visibility_form.is_active %}
+    <button type="submit" class="pl-btn pl-btn--primary" style="margin-top:1rem;">Save</button>
+  </div>
+</form>
+{% comment %}
 Danger Zone (admin only) — soft-delete the guild. Sits outside the main form; the
 confirm modal carries its own POST form, and template content can't nest a form.
 {% endcomment %}

--- a/tests/core/management/demo_data_spec.py
+++ b/tests/core/management/demo_data_spec.py
@@ -51,11 +51,13 @@ def describe_demo_data_seed():
         assert not User.objects.filter(email__startswith="guest@").exists()
         assert Registration.objects.filter(order_number=GUEST_ORDER_NUMBER, last_name="Guest").exists()
 
-    def it_creates_three_demo_classes_with_sessions():
+    def it_creates_the_published_demo_classes_with_sessions():
         call_command("demo_data")
 
+        # Four published classes seed outside DEBUG: past, current-free, future-paid,
+        # and the full+waitlist class (the pending-approval class is DEBUG-only).
         demo_classes = ClassOffering.objects.filter(slug__startswith=DEMO_SLUG_PREFIX)
-        assert demo_classes.count() == 3
+        assert demo_classes.count() == 4
         # Every demo class has at least one session so the public list shows them.
         for c in demo_classes:
             assert c.sessions.count() >= 1
@@ -77,6 +79,64 @@ def describe_demo_data_seed():
         call_command("demo_data")
         assert get_user_model().objects.filter(email__endswith=f"@{DEMO_EMAIL_DOMAIN}").count() == first_user_count
         assert Registration.objects.filter(class_offering__slug__startswith=DEMO_SLUG_PREFIX).count() == first_reg_count
+
+
+def describe_demo_data_full_waitlist_class():
+    def it_creates_a_full_class_with_a_waitlist_behind_it():
+        from core.management.commands.demo_data import FULL_WAITLIST_CAPACITY, FULL_WAITLIST_WAITLISTED
+
+        call_command("demo_data")
+
+        offering = ClassOffering.objects.get(slug=f"{DEMO_SLUG_PREFIX}full-waitlist")
+        assert offering.status == ClassOffering.Status.PUBLISHED
+        assert offering.capacity == FULL_WAITLIST_CAPACITY
+
+        confirmed = offering.registrations.filter(status=Registration.Status.CONFIRMED)
+        waitlisted = offering.registrations.filter(status=Registration.Status.WAITLISTED)
+        # Confirmed count equals capacity → the class reads as full.
+        assert confirmed.count() == FULL_WAITLIST_CAPACITY
+        assert offering.spots_remaining == 0
+        # The waitlist sits genuinely beyond capacity.
+        assert waitlisted.count() == FULL_WAITLIST_WAITLISTED
+
+        for reg in confirmed:
+            # A paid seat-holder.
+            assert reg.amount_paid_cents == offering.price_cents
+            assert reg.confirmed_at is not None
+        for reg in waitlisted:
+            # Unpaid, unconfirmed, and never notified — so "notify next in line" is demoable.
+            assert reg.amount_paid_cents == 0
+            assert reg.confirmed_at is None
+            assert reg.waitlist_notified_at is None
+
+    def it_is_idempotent_for_the_full_waitlist_class():
+        call_command("demo_data")
+        offering = ClassOffering.objects.get(slug=f"{DEMO_SLUG_PREFIX}full-waitlist")
+        first = offering.registrations.count()
+
+        call_command("demo_data")
+        offering.refresh_from_db()
+        assert offering.registrations.count() == first
+        # Still exactly full — no duplicate confirmed rows crept over capacity.
+        assert offering.spots_remaining == 0
+
+    def it_is_torn_down_by_remove():
+        call_command("demo_data")
+        assert ClassOffering.objects.filter(slug=f"{DEMO_SLUG_PREFIX}full-waitlist").exists()
+
+        call_command("demo_data", "--remove")
+        assert not ClassOffering.objects.filter(slug=f"{DEMO_SLUG_PREFIX}full-waitlist").exists()
+        # Its confirmed + waitlisted registrations are gone too (demo-email sweep).
+        assert not Registration.objects.filter(email__startswith="wl-").exists()
+
+    def it_reports_the_full_class_in_seed_and_status_output():
+        seed_out = io.StringIO()
+        call_command("demo_data", stdout=seed_out)
+        assert "Full class + waitlist" in seed_out.getvalue()
+
+        status_out = io.StringIO()
+        call_command("demo_data", "--status", stdout=status_out)
+        assert f"{DEMO_SLUG_PREFIX}full-waitlist" in status_out.getvalue()
 
 
 def describe_demo_data_registration_questions():

--- a/tests/hub/guild_visibility_spec.py
+++ b/tests/hub/guild_visibility_spec.py
@@ -1,0 +1,104 @@
+"""BDD specs for the admin-only guild visibility (show/hide) toggle."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+
+from membership.models import Guild, Member
+from tests.membership.factories import GuildFactory, MembershipPlanFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _user(username: str, *, fog_role: str = Member.FogRole.MEMBER) -> User:
+    MembershipPlanFactory()
+    user = User.objects.create_user(username=username, email=f"{username}@example.com", password="pass")
+    member = user.member  # auto-linked via signal
+    member.fog_role = fog_role
+    member.save(update_fields=["fog_role"])
+    member.sync_user_permissions()
+    return user
+
+
+def describe_guild_visibility_save():
+    def it_lets_an_admin_hide_and_show_a_guild(client: Client):
+        _user("vis_admin", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory(is_active=True)
+        client.login(username="vis_admin", password="pass")
+        url = reverse("hub_guild_visibility_save", args=[guild.pk])
+
+        # Hide — an unchecked toggle is simply absent from the POST.
+        resp = client.post(url, data={})
+        assert resp.status_code == 302
+        assert resp["Location"] == f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=basic"
+        guild.refresh_from_db()
+        assert guild.is_active is False
+
+        # Show again.
+        resp = client.post(url, data={"is_active": "on"})
+        assert resp.status_code == 302
+        guild.refresh_from_db()
+        assert guild.is_active is True
+
+    def it_hides_the_guild_from_the_directory_when_off(client: Client):
+        _user("vis_dir", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory(is_active=True)
+        assert guild in Guild.objects.directory()
+        client.login(username="vis_dir", password="pass")
+
+        client.post(reverse("hub_guild_visibility_save", args=[guild.pk]), data={})
+        guild.refresh_from_db()
+        assert guild not in Guild.objects.directory()
+
+    def it_shows_a_success_message(client: Client):
+        _user("vis_msg", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory(is_active=True)
+        client.login(username="vis_msg", password="pass")
+        url = reverse("hub_guild_visibility_save", args=[guild.pk])
+        hide = client.post(url, data={}, follow=True)
+        assert "This guild is now hidden from members." in [m.message for m in hide.context["messages"]]
+        show = client.post(url, data={"is_active": "on"}, follow=True)
+        assert "This guild is now visible to members." in [m.message for m in show.context["messages"]]
+
+    def it_forbids_a_guild_lead(client: Client):
+        lead_user = _user("vis_lead")
+        guild = GuildFactory(guild_lead=lead_user.member, is_active=True)
+        client.login(username="vis_lead", password="pass")
+        resp = client.post(reverse("hub_guild_visibility_save", args=[guild.pk]), data={})
+        assert resp.status_code == 403
+        guild.refresh_from_db()
+        assert guild.is_active is True  # unchanged
+
+    def it_requires_login(client: Client):
+        guild = GuildFactory()
+        resp = client.post(reverse("hub_guild_visibility_save", args=[guild.pk]), data={})
+        assert resp.status_code == 302
+        assert "/accounts/login/" in resp["Location"]
+
+
+def describe_guild_visibility_control_on_the_edit_page():
+    def it_shows_the_toggle_to_an_admin(client: Client):
+        _user("vis_show", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory(is_active=True)
+        client.login(username="vis_show", password="pass")
+        resp = client.get(reverse("hub_guild_edit", args=[guild.pk]))
+        assert resp.status_code == 200
+        assert b"Visible to members" in resp.content
+
+    def it_hides_the_toggle_from_a_guild_lead(client: Client):
+        lead_user = _user("vis_hide")
+        guild = GuildFactory(guild_lead=lead_user.member, is_active=True)
+        client.login(username="vis_hide", password="pass")
+        resp = client.get(reverse("hub_guild_edit", args=[guild.pk]))
+        assert resp.status_code == 200  # a lead can still edit the guild
+        assert b"Visible to members" not in resp.content  # but never sees the visibility control
+
+    def it_keeps_the_edit_page_reachable_for_an_inactive_guild(client: Client):
+        _user("vis_inactive", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory(is_active=False)
+        client.login(username="vis_inactive", password="pass")
+        resp = client.get(reverse("hub_guild_edit", args=[guild.pk]))
+        assert resp.status_code == 200  # so an admin can flip it back on

--- a/tests/membership/example_guild_spec.py
+++ b/tests/membership/example_guild_spec.py
@@ -106,6 +106,35 @@ def describe_seed_example_guild():
             assert "/guilds/cartographers-guild/" in out.getvalue()
             assert "is_active=False" in out.getvalue()
 
+    def describe_is_active_persistence():
+        def it_creates_a_brand_new_guild_inactive(db):
+            guild = seed_example_guild()
+            assert guild.is_active is False
+
+        def it_preserves_an_admin_flip_to_active_across_reseeds(db):
+            guild = seed_example_guild()
+            # An admin turns the example guild on for a demo.
+            guild.is_active = True
+            guild.save(update_fields=["is_active"])
+            # A later deploy re-seeds — is_active must survive because it lives in
+            # create_defaults (create-only), not defaults (applied on every update).
+            again = seed_example_guild()
+            assert again.pk == guild.pk
+            again.refresh_from_db()
+            assert again.is_active is True
+
+        def it_still_refreshes_other_seeded_fields_on_reseed(db):
+            guild = seed_example_guild()
+            guild.is_active = True
+            guild.about = "hand-edited, should be overwritten"
+            guild.save(update_fields=["is_active", "about"])
+            seed_example_guild()
+            guild.refresh_from_db()
+            # is_active is preserved, but authoritative fields still refresh from the seed —
+            # proving create_defaults is a superset of defaults, not a replacement for it.
+            assert guild.is_active is True
+            assert "fictional example guild" in guild.about
+
     def describe_visibility():
         def it_stays_out_of_listings_but_renders_by_direct_link(client, db):
             guild = seed_example_guild()


### PR DESCRIPTION
Demo-prep infrastructure. No VERSION bump (admin tooling + demo data, not a member-facing announced feature). No migration (`is_active` already exists).

## Admin guild show/hide
- An actual admin can toggle any guild's visibility from a **Visibility** card on the guild edit Basic tab (`GuildVisibilityForm` + `guild_visibility_save`, gated with the same effective-admin check as the Danger Zone delete; 403 for a guild lead/staffer, control hidden for non-admins).
- Hiding removes the guild from the sidebar, directory, calendar, and voting but keeps its page reachable by link (so an admin can flip it back). `GuildManager` filters only `deleted_at`, so edit + detail stay reachable when inactive.
- **Seed persistence fix**: `seed_example_guild()` now sets `is_active` only via `create_defaults`, so a manual flip (e.g. showing Cartographers for the demo) survives redeploys instead of being reset to `False` every deploy. Every other seeded field stays authoritative.

## Demo data
- New `demo-full-waitlist` class: capacity 4, filled with 4 confirmed paid registrants (reads as full) plus 3 waitlisted rows (`waitlist_notified_at=None`), so remove-student and promote-from-waitlist are demoable. Idempotent, prod-safe (demo- slug, @pastlives.demo emails, direct ORM, no Stripe). Swept by `--remove`/`--status`.

## Testing
- `guild_visibility_spec.py` (new), `example_guild_spec.py` (is_active persistence), `demo_data_spec.py` (full+waitlist), `guild_edit_spec.py`, `orienter_hours_editor_spec.py` all green post-rebase onto #247 (174 passed together).
- ruff + mypy + manage.py check clean; `makemigrations --check` → no changes.

https://claude.ai/code/session_01NF4MEeH2icSRQ9U4RuGTmA