### PR TITLE
feat(guilds): Join This Guild front door + opt-in per-guild welcome email (1.20.0)

### DIFF
--- a/core/events/registry.py
+++ b/core/events/registry.py
@@ -450,6 +450,7 @@ BILLING_CHARGE_FAILED_ADMIN = "billing.charge_failed_admin"  # a member's tab ch
 WAITLIST_PROMOTED = "waitlist_promoted"  # staff hand-picked a waitlister into the class (plain "you're in")
 WAITLIST_PROMOTED_PAY = "waitlist_promoted_pay"  # promoted with a balance due — "you're in" + pay link
 REGISTRATION_REMOVED = "registration_removed"  # staff removed a registrant (seat-holder or waitlister)
+GUILD_WELCOME = "guild_welcome"  # transactional per-guild join welcome — email only via email_to, no matrix row
 
 # event.reminder keeps Discord OFF (the bell is enough; per-offset channel posts would
 # clutter the guild channel) but declares it so a lead can flip it on later; happening-now
@@ -779,6 +780,22 @@ _NEW_EVENTS: list[EventType] = [
         category="Guilds",
         recipient=Recipients.REGISTRANT,
         channels=(_EMAIL_FORCED,),
+        activity_kind=None,
+    ),
+    # 20b. guild_welcome — the per-guild join welcome email. Transactional: addressed with an
+    #      explicit ``email_to`` (sends regardless of preferences — the member deliberately
+    #      joined), so it declares NO channel at all. The REGISTRANT resolver reads
+    #      ``context["member"]`` = None, so the unused in-app/push fan-out finds nobody, and
+    #      declaring no EMAIL channel keeps it off the member settings matrix (like the
+    #      orientation thank-you, which piggybacks on orientation_update). ``activity_kind``
+    #      stays None — member_joined_guild's guild_joined emit already logs GUILD_JOINED.
+    EventType(
+        key=GUILD_WELCOME,
+        label="Welcome to the guild",
+        description="A warm welcome when a member joins one of your guilds.",
+        category="Guilds",
+        recipient=Recipients.REGISTRANT,
+        channels=(),
         activity_kind=None,
     ),
     # 21. orientation.completed — a member finished their orientation; welcome them to the

--- a/docs/superpowers/plans/2026-08-27-join-this-guild.md
+++ b/docs/superpowers/plans/2026-08-27-join-this-guild.md
@@ -1,0 +1,345 @@
+# Join This Guild (+ revived per-guild Welcome Email) — Spec & Implementation Plan
+
+**Status:** Spec only — not yet approved to build.
+**Date:** 2026-08-27
+**Surface:** FOG hub + public guilds surface (`guilds.pastlives.app`) — guild page (`templates/hub/guild_detail.html`); guild editor (`templates/hub/guild_edit.html`); Member Directory (`templates/hub/member_directory.html`); one transactional email.
+**Related:**
+- `docs/superpowers/plans/2026-08-26-guild-subscriptions.md` — the round (#237) that removed the old "Join This Guild" button and reframed a `GuildMembership` row as "following for updates."
+- `docs/superpowers/plans/2026-08-27-guild-orientation-announcement-polish.md` — the round (#244) that dropped the per-guild welcome-email fields + templates.
+
+---
+
+## 1. Summary
+
+A member browsing a guild page can join that guild in one click from a bold **Join This Guild** button in the page hero (and a sticky mini button that follows them down long pages), instead of hunting for a toggle buried in Settings. Joining is benefit framed, not a scary confirm: a short modal spells out what they get. The moment they join they land on the guild roster, pick up a guild badge on their Member Directory card, start receiving that guild's announcements, and get a warm, guild specific **welcome email** (with the guild's banner at the top and a "here's what your guild page can do" section) that guild leads can rewrite in their own voice. Once joined, the button quietly reads **Member**, with **Leave guild** tucked into an overflow menu.
+
+This is a **revival**, not a green field feature. The join *mechanism* (`GuildMembership` + `Member.subscribe_to_guild`) is fully alive and already powers the first login picker, the Settings toggle, and the Discord `/join-guild` command. Two rounds ago the *button* was removed; one round ago the *welcome email* was stripped. We are re-attaching a front door and re-lighting the welcome email onto plumbing that already exists.
+
+### Locked decisions (from brainstorm Q&A + senior-UX pass)
+
+| Decision | Choice |
+|---|---|
+| New membership model? | **No.** "On the roster" and "subscribed to announcements" are already the *same* `GuildMembership` row (the `guild_members` resolver reads it directly). We reuse it verbatim; zero data migration for membership. |
+| The one join path | `Member.subscribe_to_guild(guild)` (fat model). The hero button, sticky button, join modal, Settings toggle, first-login picker, and Discord `/join-guild` all funnel through it. No second subscribe path is created. |
+| Where the welcome-email fields live | **Restore on `GuildOrientationSettings`**, mirroring the surviving `thankyou_email_*` trio field-for-field. That model is `get_or_create`'d for every guild in the editor already and is the established home for lead-authored guild emails. |
+| Field naming | Name them `welcome_email_*` (not the old `join_email_*`) for parallelism with `thankyou_email_*`. Since the old columns are already dropped, this is a clean add, not a rename. |
+| Default enabled? | **On by default** (`welcome_email_enabled` default `True`) with shared default copy, mirroring the thank-you email. The old field defaulted `False` (opt-in); the owner's new requirement is "fires automatically on join," so a lead does nothing and members still get a good welcome. |
+| Welcome email editor location | A **new "Welcome Email" tab** on the guild editor, not buried under Orientations (where the thank-you email lives). The welcome email is join scoped, not orientation scoped; a guild that never runs orientations still wants to welcome new members. Reuses the existing `hub_guild_emails_save` multi-form endpoint. |
+| Welcome email delivery class | **Transactional, no opt-out**, deduped once per (member, guild) forever. It is a direct response to an action the member just took (joining), like the orientation thank-you. |
+| Fires on which join paths | **All of them** (hero button, Settings toggle, first-login picker, Discord `/join-guild`) uniformly, from inside `member_joined_guild`. The first-login picker can therefore send several at once; accepted because each is genuinely per-guild and useful (see §10 for the deferred batch option). |
+| Member profile badge surface | There is **no standalone member profile page** in plfog. The Member Directory card *is* the member's public profile. Guild badges + the guild filter are re-added there. |
+| Copy | Member-facing copy uses no em/standard dashes (arrow `->` allowed), Title Case headings, single-line `{# #}` comments only. |
+
+---
+
+## 2. What already exists (reuse, don't reinvent)
+
+This is the heart of the plan: almost everything is assembly.
+
+| Need | Existing thing | Location |
+|---|---|---|
+| Roster + subscription record | `GuildMembership` (member↔guild, `source` app/discord, unique) + `GuildMembershipManager.record_app_join` | `membership/models.py:4300-4367` |
+| The single join path (records row, fires fan-out, self-heals Discord role) | `Member.subscribe_to_guild(guild) -> bool` | `membership/models.py:720-738` |
+| The single leave path | `Member.unsubscribe_from_guild(guild)` | `membership/models.py:740-745` |
+| Join fan-out hook (lead notice + activity today; **welcome email goes back here**) | `orientations.member_joined_guild(guild, member)` | `membership/orientations.py:944-962` |
+| Announcement audience already reads membership | `resolvers.guild_members(context)` → `Member.objects.filter(guild_memberships__guild=…, status=ACTIVE)` | `core/events/resolvers.py:242-263` |
+| Existing HTMX subscribe/unsubscribe endpoint (Settings toggle) | `hub.views.guild_membership_set` (`hub_guild_membership_set`) | `hub/views.py:2444-2472` |
+| "My Guilds" grid data builder | `build_my_guilds_rows(member)` | `hub/guild_membership.py` |
+| The email send helper the removed welcome used (renders `.txt`/`.html` shell, `email_to` bypasses prefs) | `emit_with_email_shell(...)` | `core/events/senders.py:75-149` |
+| The exact "guild-lead-authored, per-guild, warm" email pattern to mirror | Revived orientation thank-you: fields, resolvers, form, templates, sender | fields `membership/models.py:8169-8207`; form `hub/forms.py:1585-1620`; templates `templates/membership/emails/orientation_thankyou.{html,txt}`; send in `orientations.complete_orientation` `membership/orientations.py:780-799` |
+| Default-copy-with-lead-override pattern | `GuildOrientationSettings.resolved_thankyou_subject/body` + `membership/orientation_copy.py` | `membership/models.py:8195-8207`, `membership/orientation_copy.py` |
+| Multi-form-per-endpoint save (via `form_id`) | `hub.views.guild_emails_save` (currently handles only `thankyou_email`) | `hub/views.py:3150-3182` |
+| Guild banner image (+ crop/object-position) | `Guild.banner_image` ImageField; `HeroCropMixin.hero_object_position` | `membership/models.py:1635-1643`; `core/models.py:24-86` |
+| Guild logo for badges | `Guild.logo_prefix` → `img/guild_logos/<prefix>_color.svg` (color) / `_bw.svg` | `membership/models.py:1808-1812` |
+| Branded email shell | `templates/membership/emails/_base.html` (+ `_footer.html`, `_hero.html`) | `templates/membership/emails/` |
+| Rich text: editor widget, sanitizer, email filters | `RichTextEditorWidget`, `sanitize_rich_html`, `rich_email_body` / `rich_email_text` | `hub/forms.py`, `membership/templatetags/rich_text.py` |
+| Single email choke point + audit log | `core.email.send(...)` → `TransactionalEmailLog` | `core/email.py:61-73` |
+| Absolute URL for member surface (email links + banner src) | `settings.MEMBER_BASE_URL`; `orientations._absolute_url()` | `plfog/settings.py:74`; `membership/orientations.py:43` |
+| Back-to-top FAB pattern to mirror for the sticky mini-CTA | `.pl-scroll-top` (Alpine `show` past 400px) | `templates/hub/user_settings.html:695-703`; `static/css/hub.css:7116-7143` |
+| Guild-page context flags | `is_member_of_guild`, `roster`, `member_count`, `guild.show_members`, `show_orientation`, `is_oriented` | `hub/views.py` `guild_detail` (~470-590) |
+| Modal / confirm / toggle / form-field / toast components | `components/modal.html`, `confirm_modal.html`, `toggle.html`, `form_field.html`, `trigger_toast()` | `templates/components/`, `hub/toast.py` |
+| Announcement composer email-preview partial (pattern for the editor preview) | `_compose_email_preview.html` | `templates/hub/partials/` |
+
+**Genuine gaps to close (kept minimal):**
+
+1. **Storage:** re-add four `welcome_email_*` fields to `GuildOrientationSettings` + two `resolved_welcome_*` properties (migration `0146`).
+2. **Send:** re-attach the welcome email inside `member_joined_guild` (mirror the removed `emit_with_email_shell` call) + create `guild_welcome.{html,txt}` (now with a banner block) + a `guild_welcome_copy.py` default.
+3. **Front door:** hero Join/Member CTA + sticky mini-CTA + benefit-framed join modal + thin join/leave views returning an HTMX partial.
+4. **Editor:** a "Welcome Email" tab (form + preview + "Send test to me"), extending `guild_emails_save`.
+5. **Directory:** re-add per-card guild badges + the guild filter dropdown.
+6. **Housekeeping:** fix the stale `subscribe_to_guild` docstring ("welcome email when configured"); flip `guild_joined`'s `no_email` handling is *unchanged* (see §7 — the member welcome is a separate send, the lead "new follower" notice stays email-less).
+
+---
+
+## 3. Where the code lives
+
+```
+membership/
+  models.py                 # + welcome_email_* fields & resolved_* props on GuildOrientationSettings; fix subscribe_to_guild docstring
+  orientations.py           # member_joined_guild: re-add the welcome-email send (emit_with_email_shell)
+  guild_welcome_copy.py     # NEW — STANDARD_WELCOME_BODY + standard_welcome_subject() (mirrors orientation_copy.py)
+  migrations/
+    0146_readd_guild_welcome_email.py   # NEW — AddField x4 (auto-reverse = RemoveField x4)
+hub/
+  forms.py                  # NEW GuildWelcomeEmailForm (mirror GuildThankyouEmailForm)
+  views.py                  # NEW guild_join / guild_leave (thin, return _guild_join_cta.html); extend guild_emails_save + guild_welcome_test; add guild badges/filter to member_directory + _guild_edit_context
+  urls.py                   # revive hub_guild_join / hub_guild_leave; add hub_guild_welcome_test
+templates/
+  hub/
+    guild_detail.html       # hero CTA block + sticky mini-CTA + join modal; update Get Involved panel
+    guild_edit.html         # new "Welcome Email" tab (mirror the Thank-you card)
+    member_directory.html   # re-add guild badges on cards + guild filter <select>
+    partials/
+      _guild_join_cta.html      # NEW — hero CTA states (Join / Member+overflow), swapped by join/leave
+      _guild_welcome_preview.html  # NEW — rendered welcome-email preview (modal body)
+  membership/emails/
+    guild_welcome.html      # NEW (banner block + greeting + body + "what you can do" + CTA)
+    guild_welcome.txt       # NEW (text twin)
+static/css/hub.css          # .pl-guild-join-fab (sticky), .pl-guild-cta, badge tweaks — tokens only
+```
+
+Home apps: `membership` (model + send + copy), `hub` (views/forms/templates). Everything stays inside the existing coverage/mypy scope (`source = ["plfog", "core", "membership"]` plus the hub tree already tested under `tests/hub/`).
+
+---
+
+## 4. Data model
+
+**No new model.** `GuildMembership` is reused unchanged. The only schema change is restoring the welcome-email columns on `GuildOrientationSettings`.
+
+### Re-added fields on `GuildOrientationSettings` (mirror `thankyou_email_*`)
+
+| Field | Type | Note |
+|---|---|---|
+| `welcome_email_enabled` | `BooleanField(default=True)` | On by default; renders as a toggle. `help_text`: "Send a welcome email when a member joins this guild. On by default; leave the subject and body blank to send the standard welcome, or write your own." |
+| `welcome_email_subject` | `CharField(max_length=200, blank=True, default="")` | Blank → standard subject. `help_text`: "Subject line of the welcome email." |
+| `welcome_email_body` | `TextField(blank=True, default="")` | Blank → standard body. Rich text (sanitized). `help_text`: "Body of the welcome email (your personal note; line breaks preserved)." |
+| `welcome_email_updated_at` | `DateTimeField(null=True, blank=True)` | Stamped on edit. `help_text`: "When the welcome email was last edited." |
+
+All four carry `help_text` (house rule). No `TextChoices` needed (no choice fields here).
+
+### Properties (mirror `resolved_thankyou_*`)
+
+```python
+@property
+def welcome_email_subject_resolved(self) -> str:
+    from membership.guild_welcome_copy import standard_welcome_subject
+    return self.welcome_email_subject or standard_welcome_subject(self.guild.name)
+
+@property
+def welcome_email_body_resolved(self) -> str:
+    from membership.guild_welcome_copy import STANDARD_WELCOME_BODY
+    return self.welcome_email_body or STANDARD_WELCOME_BODY
+
+@property
+def welcome_email_ready(self) -> bool:
+    """On + always has resolvable copy, so enabled alone is enough to send."""
+    return self.welcome_email_enabled
+```
+
+### Default copy (`membership/guild_welcome_copy.py`, mirrors `orientation_copy.py`)
+
+Single source of truth so the copy-review gallery and the send path read the same text. No dashes; arrow allowed.
+
+```python
+STANDARD_WELCOME_BODY = (
+    "We're really glad you're here. Following a guild means you'll hear about what's happening, "
+    "you'll show up on the guild roster, and you'll pick up the guild's Discord role automatically. "
+    "Look around your guild page whenever you like, and come say hi in the channel. See you around the space!"
+)
+
+def standard_welcome_subject(guild_name: str) -> str:
+    return f"Welcome to {guild_name}!"
+```
+
+The "here's what you can do on your guild page" list + the help-guide link are **static structure in the email template** (guild-agnostic, always correct), so the editable body stays the lead's short personal note. This mirrors the thank-you email, where the template supplies the greeting/eyebrow and `{{ body }}` is the lead's words.
+
+### Migration
+
+`0146_readd_guild_welcome_email.py` — four `migrations.AddField` on `guildorientationsettings` (immediately after the current head `0145_remove_guild_welcome_email`). Django auto-generates the reverse (`RemoveField` x4), so it runs backward cleanly — **no `RunPython`, so no hand-written reverse function is required** (the "migrations need reverse functions" rule applies to data migrations; this is a pure schema `AddField`, inherently reversible). Header comment must note: this restores *empty* columns; any copy a guild had before the `0145` drop is not recoverable (it was destroyed then), and leads re-author from the seeded default.
+
+---
+
+## 5. Business logic (fat models)
+
+### Join (reused as-is)
+`Member.subscribe_to_guild(guild)` already: `record_app_join` → on new/upgrade calls `member_joined_guild` → self-heals the Discord role → returns whether it was new/upgraded. **The hero button changes nothing here.** The thin view calls this method.
+
+### Leave (reused as-is)
+`Member.unsubscribe_from_guild(guild)` deletes the row + drops the Discord role.
+
+### Welcome email — re-attach inside `member_joined_guild` (the one change)
+
+Currently `member_joined_guild` is a bare `emit("guild_joined", …)` (lead-only in-app "New follower", `no_email=True`). Re-add a **second, member-facing** send beside it — do not overload the lead notice:
+
+```python
+def member_joined_guild(guild: Guild, member: Member) -> None:
+    # (unchanged) lead-only in-app "New follower" + GUILD_JOINED activity
+    emit("guild_joined", actor=member.user, target=guild, context={"guild": guild},
+         title="New follower", body=f"{member.display_name} now follows {guild.name}.",
+         url=reverse("hub_guild_detail", args=[guild.slug]),
+         period=f"guild:{guild.pk}:join:{member.pk}")
+
+    # (new) member-facing welcome email — transactional, once per (member, guild) ever
+    settings_obj = GuildOrientationSettings.objects.filter(guild=guild).first()
+    if settings_obj is None or not settings_obj.welcome_email_ready:
+        return
+    guild_url = _absolute_url(reverse("hub_guild_detail", args=[guild.slug]))
+    banner_url = _absolute_url(guild.banner_image.url) if guild.banner_image else ""
+    help_url = _absolute_url(reverse("hub_help_article", args=["getting-started", "your-guild-page"]))  # category+article slugs; see §7 note
+    emit_with_email_shell(
+        "guild_welcome",  # registered member-facing event (see §7); resolver finds nobody, explicit email_to carries it
+        target=guild,
+        context={"member": None},  # suppress in-app dup — email-only, like _emit_member_email's request-received path
+        subject=settings_obj.welcome_email_subject_resolved,
+        text_template="membership/emails/guild_welcome.txt",
+        html_template="membership/emails/guild_welcome.html",
+        template_context={
+            "guild": guild, "greeting_name": member.display_name,
+            "body": settings_obj.welcome_email_body_resolved,
+            "guild_url": guild_url, "banner_url": banner_url, "help_url": help_url,
+        },
+        email_to=member.primary_email,
+        email_trigger_kind="guild_welcome",  # TransactionalEmailLog audit label
+        period=f"guild:{guild.pk}:welcome:{member.pk}",
+    )
+```
+
+Guards / side effects:
+- **Fires once per (member, guild) forever** via the `period` key — a leave-then-rejoin months later does not re-welcome (safe, non-spammy; matches how `guild_joined` keys its period).
+- **Discord *reaction* mirror never triggers this** — `record_discord_join` (used by the reaction sync) does not call `member_joined_guild`, by existing design. Only explicit joins do. Kept.
+- **No opt-out** (transactional). It rides the explicit `email_to` path, which bypasses preferences on purpose.
+- Fix the stale docstring on `subscribe_to_guild` ("welcome email when configured, lead notice, activity row") so it once again matches reality.
+
+### Editor validation lives in the form (not the view)
+`GuildWelcomeEmailForm.clean_welcome_email_body` runs `sanitize_rich_html` (mirrors `clean_thankyou_email_body`). Because the email is on-by-default with default fallback copy, **no subject/body is required to enable it** (same as thank-you) — so there is no "you enabled it but left it blank" error to surface. `save()` stamps `welcome_email_updated_at` only when a welcome field actually changed.
+
+---
+
+## 6. UI / UX (completeness checklist applied per screen)
+
+### 6.1 Guild page hero — Join / Member CTA  (`templates/hub/guild_detail.html`, hero at lines 54-105; partial `partials/_guild_join_cta.html`)
+
+- **Layout & container:** a primary CTA in the hero `__content` block, directly under the guild name / "Led by" line, in the existing `display:flex; gap:0.5rem; flex-wrap:wrap` action row (currently editor-only buttons). It sits **before** the editor buttons for a logged-in non-member so Join is the first thing in the row. Rendered from `_guild_join_cta.html` so join/leave can swap just this fragment.
+- **States (the CTA is a small state machine):**
+  - **Not a member (linked member):** `<button class="pl-btn pl-btn--primary pl-guild-cta">Join This Guild</button>` that opens the join modal (`@click="$dispatch('open-modal','join-guild')"`). Bold, high contrast (brand gold on navy per tokens).
+  - **Member:** a quiet `pl-btn pl-btn--secondary` reading **Member** with a check glyph, plus a **⋯ overflow** button (Alpine dropdown, `pl-guild-cta__overflow`) whose single item is **Leave guild** → opens the leave confirm modal. The overflow is a real button (44px tap target), theme-tokened popover using `--hub-elevated`.
+  - **Not authenticated:** the hero shows no Join (the existing "Log in to the members hub" CTA already lives in Get Involved); on the public guilds surface the hero Join is hidden (joins happen on the members hub) — mirror the existing `is_guilds_surface` gate that already redirects shopping to the members hub.
+  - **Unlinked account (`member is None`, authenticated):** no Join button (no membership to attach); Get Involved's existing branches already handle this.
+- **Components used:** `modal.html` (join), `confirm_modal.html` (leave), `trigger_toast()`.
+- **Feedback:** join POSTs to `hub_guild_join` (HTMX), which returns the re-rendered `_guild_join_cta.html` (now the Member state) swapped into the hero **plus** OOB swaps for (a) the sticky mini-CTA, (b) the Get Involved panel, (c) the member-count stat chip, (d) the roster card — and `trigger_toast("You joined {guild}! Check your inbox for a welcome.", "success")`. Leave mirrors it back to the Join state with an info toast.
+- **Error state:** unlinked/expired session → toast "Your account is not linked to a membership." (mirrors `guild_membership_set`). A failed POST leaves the button as-is and toasts "Couldn't update — please try again."
+
+### 6.2 Sticky mini-CTA  (`guild_detail.html`; CSS `.pl-guild-join-fab` in `hub.css`)
+
+- **Pattern:** clone the back-to-top FAB (`.pl-scroll-top`): `position: fixed; bottom; right; z-index:90`, Alpine `x-data="{ show:false }" x-init="window.addEventListener('scroll', () => show = window.scrollY > 400, {passive:true})" x-show="show" x-cloak`. Reveals only after ~400px of scroll so it never covers the hero's own button.
+- **Content mirrors the hero state:** not a member → a gold pill "Join {Guild}" opening the same `join-guild` modal; member → a quiet "Member" pill (no action, or opens the same overflow). Included in the OOB swap set so join/leave keeps it in sync.
+- **Mobile:** offset so it clears the phone bottom-nav / safe-area (`env(safe-area-inset-bottom)`), same as `.pl-scroll-top`. Single tap target, thumb reachable.
+- **Dark + light:** tokens only (`--hub-elevated`, `--color-tuscan-yellow`, `--hub-border`); no inline color.
+
+### 6.3 Join modal — benefit framed  (`components/modal.html` with `modal_id="join-guild"`, `modal_size="md"`)
+
+- **Title:** "Join {Guild}?" **Body:** an intro line ("Here's what joining {Guild} gets you.") then icon rows (each an inline SVG + text, `pl-benefit-row`):
+  1. **You're added to the guild roster.**
+  2. **A {Guild} badge appears on your profile** — the phrase "your profile" **links to the Member Directory** (`{% url 'hub_member_directory' %}?guild={{ guild.slug }}`).
+  3. **You get this guild's updates and announcements** (email, in app, or Discord — your choice in Settings).
+  4. **You can book orientations for this guild** — "orientations" **links to the Orientations tab** (`#guild-orientation`, the existing anchor the Get Involved button already scrolls to). Shown only when `show_orientation`.
+  5. **You get the guild's Discord role automatically** (shown only when `guild.discord_role_ids`).
+  6. Conditionally, real extras that exist: **See the guild's events, meetings, and calendar**; **Browse the gallery** (if `gallery_images`); **See the wishlist** (if `guild.wishlist or guild.donate_url`); **You're eligible to vote on guild funding** (member-wide, always true — include as a benefit).
+- **Controls:** primary `pl-btn pl-btn--primary` **Join {Guild}** (HTMX POST → `hub_guild_join`, closes modal on success via the toast/OOB swap); secondary `pl-btn pl-btn--secondary` **Not now** (`@click="$dispatch('close-modal','join-guild')"`). Footnote in `hub-text-muted`: "You can leave any time."
+- **States:** the modal is static content (no list editor, no loading fetch); the only in-flight state is the Join button's HTMX request — disable it with `hx-disabled-elt="this"` while posting. Success = modal closes + toast. Error = toast, modal stays open.
+- **Not a destructive action** → plain modal, not `confirm_modal`. (Leave *is* destructive → `confirm_modal`, see 6.4.)
+
+### 6.4 Leave guild — confirm  (`components/confirm_modal.html`, `confirm_id="leave-guild"`)
+
+- Opened from the Member-state overflow. `confirm_title="Leave {Guild}?"`, `confirm_message="You'll stop getting this guild's updates, drop off its roster, and lose its Discord role. You can rejoin any time."`, `confirm_button_text="Leave guild"`, `confirm_button_style="danger"`. Posts to `hub_guild_leave` (HTMX) → returns `_guild_join_cta.html` in the Join state + the same OOB swaps + info toast. No typed-confirmation needed (low stakes, reversible).
+
+### 6.5 Get Involved panel  (`guild_detail.html:290-338`)
+
+- Replace the current follow-language copy. When **not** a member: drop the "Choose your guild updates in Settings" paragraph (the hero Join now owns that job) and keep the other actions (Teach a Class, Contact, Discord, Website). When a member: keep the quiet "You get this guild's updates" confirmation line; change "Manage in Settings" to a plain secondary link (updates channel prefs still live in Settings). The panel is part of the OOB swap set so it flips with join/leave. Keep the existing `data-help-key="guild.join-leave"`.
+
+### 6.6 Member count chip + roster card  (`guild_detail.html:108-113`, `:355-367`)
+
+Both are in the OOB swap set. On join, the "{n} members" chip increments and the joining member appears in the roster card (`guild.show_members` gated, `roster` from `Guild.roster_members()`), so the page reflects the join without a reload. Empty roster state (no members yet): the card is already conditionally hidden (`{% if … and roster %}`) — after the first join it appears.
+
+### 6.7 Guild editor — new "Welcome Email" tab  (`templates/hub/guild_edit.html`; tabs at lines 14-24)
+
+- **Layout & container:** a new tab button `Welcome Email` in the tab row, and an `x-show="section === 'welcome_email'"` pane. Inside, **one `hub-card`** holding the editor form — a near-verbatim clone of the Thank-you Email card (lines 385-397).
+- **Form:** `GuildWelcomeEmailForm` (ModelForm on `GuildOrientationSettings`), own `<form method="post" action="{% url 'hub_guild_emails_save' guild.pk %}">` with `<input type="hidden" name="form_id" value="welcome_email">` (the house multi-form pattern; `guild_emails_save` gains a `welcome_email` branch).
+- **Fields (all via `components/form_field.html`):**
+  - `welcome_email_enabled` → auto-renders as a **toggle** (boolean rule).
+  - `welcome_email_subject` → text input, hint "Leave blank to use: Welcome to {guild}!".
+  - `welcome_email_body` → `RichTextEditorWidget` (wrapped in `.hub-form-group` so it inherits input tokens — Rule 13), hint "Your personal welcome note. Leave blank to use the standard welcome.".
+- **Controls, named:**
+  - **Save** — `pl-btn pl-btn--primary` labeled exactly **"Save"**, last element in the form, `margin-top:1rem` clear of the field above (Rules 18, 21). Full-page POST → on success `messages.success(request, "Welcome email saved.")` + redirect back to `?tab=welcome_email`; on invalid re-render the editor on this tab with form errors (mirror `guild_emails_save`'s thank-you branch).
+  - **Preview** — a secondary button that HTMX-GETs `_guild_welcome_preview.html` (server-rendered welcome email using the *current saved* values + a sample member name) into a `modal.html` body (`modal_id="welcome-preview"`), reusing the announcement composer's preview approach (`_compose_email_preview.html`). Rendered, not guessed, so leads see the real banner + copy.
+  - **Send test to me** — a secondary button (HTMX POST → `hub_guild_welcome_test`) that fires the actual welcome email to the editing lead's own `primary_email` and returns a toast "Test sent to {email}." (mirrors the classes welcome email's "Send a test to me", documented in `help_content.py`). Immediate-effect control, placed **above** the batch Save form so Save stays the last thing on the tab (Rule 21).
+- **This tab is not a list editor** — no formset, so no "+ Add"/Delete controls apply. (The list-editor rule is N/A here; called out so the reviewer isn't looking for an Add button that shouldn't exist.)
+- **States:** empty (fresh guild) → toggle on, subject/body blank, hints tell the lead the defaults that will be used; the Preview still renders (from defaults). Error → sanitizer never rejects (it cleans), so the realistic error path is only a server/validation re-render with field errors shown by `form_field.html`. Success → Django message + redirect (full-page form) / toast (test send, HTMX).
+- **Dark + light:** tokens only; the rich-text body wrapped in `.hub-form-group`; the preview modal inherits component styling. Verify both themes.
+- **Mobile:** single-column card, full-width controls (matches the thank-you card), Save reachable.
+
+### 6.8 Member Directory — badges + guild filter  (`templates/hub/member_directory.html`; view `hub/views.py:267-330`)
+
+- **Re-add the guild filter** to the existing `.pl-directory-filters` `<form method="get">` (beside the Skill select): a `<select name="guild" onchange="this.form.submit()">` with "All guilds" + one `<option value="{{ g.slug }}">{{ g.name }}</option>` per active guild, `selected` on the current `?guild=`. Style via `.pl-filter-control` (already token-scoped — Rule 13) and set `select option { background; color }` in the filter CSS if not already present.
+- **View:** re-add `member_qs.filter(guild_memberships__guild__slug=guild_slug)` when `?guild=` is set (validate against active guilds; unknown slug → ignore, show all), and add `guilds` (active, name-ordered) + `selected_guild` to the context. Add `guild_memberships__guild` to `prefetch_related` (with an ordered `Prefetch` on `Member.joined_guilds`) so the per-card badges are N+1 free.
+- **Re-add per-card badges:** below the identity block, render the member's joined guilds as chips (reuse `hub-badge`): each chip links to `{% url 'hub_member_directory' %}?guild={{ g.slug }}` and shows the guild logo (`img/guild_logos/<logo_prefix>_color.svg`, guarded on `logo_prefix`) + name. Respect directory privacy: badges show the same set the roster does (active membership); this does not leak hidden profiles because the directory queryset is already `directory_visible()` for non-admins.
+- **Empty states:** a member in no guilds → no badge row (not an empty box). Filtered to a guild with zero visible members → the existing "{n} active members" count reads 0 and the grid is empty; add a one-line "No members match this filter." message (currently the grid just renders empty — close that dead end).
+- **Dark + light + mobile:** chips wrap; filter row already reflows (existing `.pl-directory-filters`). Tokens only.
+
+### 6.9 The welcome email itself  (`templates/membership/emails/guild_welcome.{html,txt}`)
+
+Extends `membership/emails/_base.html`; mirrors `orientation_thankyou.html` with a banner added at the top. Structure:
+1. **Banner** — `{% if banner_url %}<img src="{{ banner_url }}" width="100%" ... alt="{{ guild.name }}">{% endif %}` (absolute URL; if no banner, a simple branded header band — no broken image). Inline styles are expected in emails (Rule 15 exception).
+2. **Greeting** — "Hi {{ greeting_name }},"
+3. **Eyebrow** — "Welcome to {{ guild.name }}!" where **{{ guild.name }} is a link to `{{ guild_url }}`** (Rule 15 — subject noun is a link, never dead text).
+4. **Body** — `{{ body|rich_email_body }}` (the lead's note or the default).
+5. **"What You Can Do On Your Guild Page"** — a static styled list (Title Case heading): read announcements; book an orientation; see meetings and the calendar; meet the roster; check the wishlist. In `.txt`, prefix each with an arrow `-> ` (no dash bullets — honors the no-dash rule).
+6. **Help link** — "New here? Read the quick guide to your guild page." linking `{{ help_url }}`.
+7. **Primary CTA** — a "View Guild Page" button → `{{ guild_url }}`.
+8. `_footer.html` (already carries the manage-prefs link via `core.email.send`).
+
+`.txt` twin says the same thing, arrow bullets, absolute URLs. Subject and body share the project/Portland timezone context (no dates in this email, so no tz hazard, but keep the shell consistent).
+
+---
+
+## 7. Notifications / emails / activity
+
+- **New event:** register `guild_welcome` in `core/events/registry.py` as a **member-facing transactional** email event. Because the send passes `context={"member": None}` and an explicit `email_to`, the resolver deliberately finds nobody (no in-app/push duplicate) and the explicit-email path delivers — exactly the `_emit_member_email` "request-received" trick already used for orientations. Add its member-facing copy row so the copy-review gallery can show it. It is **not** added to the member settings matrix as an opt-out (transactional, like the thank-you).
+- **Unchanged:** `guild_joined` stays the **lead-only, email-less** "New follower" in-app notice (`no_email=True`). The member welcome is a *separate* send; we do not overload the lead notice (which is what made the old combined call confusing).
+- **Activity:** the existing `GUILD_JOINED` `SiteActivity` row (from the `guild_joined` emit) already records the join for the guild pulse — no new activity kind.
+- **`TransactionalEmailLog`:** every welcome send logs one row under `trigger_kind="guild_welcome"` via the `core.email.send` choke point (audit + deliverability).
+- **Dedup / delivery:** `period=f"guild:{pk}:welcome:{member.pk}"` → once per (member, guild) ever, so the first-login picker's multiple joins each send once and never double-send.
+- **Help article:** the welcome email links a new-member guide. The Help Center URL is `hub_help_article` and takes **two** slugs — `category_slug` + `article_slug` (`help/<category_slug>/<article_slug>/`). Recommend a short new article `your-guild-page` under an existing category such as `getting-started` (authored per `docs/HELP_AUTHORING.md`); until it exists, fall back to the existing `welcome-to-fog` article (under its own category). The email builds the URL with `_absolute_url(reverse("hub_help_article", args=[category_slug, article_slug]))` — absolute, never a bare path (Rule 15). Confirm the exact category slug against `membership/help_content.py` at build time.
+
+---
+
+## 8. Build order (phased; each phase ships green)
+
+1. **Model + copy + migration.** Add the four `welcome_email_*` fields + `resolved`/`ready` properties to `GuildOrientationSettings`; add `membership/guild_welcome_copy.py`; generate `0146_readd_guild_welcome_email`. Run `manage.py check` (CI system checks catch index/constraint issues local pytest skips) + `manage.py makemigrations --check`. Ships green with model specs.
+2. **Send path + email templates + event.** Re-attach the welcome send in `member_joined_guild`; register the `guild_welcome` event + copy; create `guild_welcome.{html,txt}`; fix the `subscribe_to_guild` docstring. Now every existing join path (Settings toggle, first-login picker, Discord `/join-guild`) already emails — provable by tests before any new UI exists.
+3. **Front door (hero + sticky + modal + join/leave views).** `_guild_join_cta.html`; `guild_join`/`guild_leave` thin views + revived URL names returning the partial with OOB swaps; hero CTA, sticky FAB, join modal, leave confirm; Get Involved panel + count/roster OOB. CSS (tokens only, both themes).
+4. **Editor tab.** `GuildWelcomeEmailForm`; extend `guild_emails_save` (`welcome_email` branch) + `guild_welcome_test` view/URL; the Welcome Email tab with Save + Preview + Send-test; `_guild_welcome_preview.html`.
+5. **Directory.** Guild filter + per-card badges + view filter/prefetch + empty-state message.
+6. **Housekeeping + release.** Help article (`your-guild-page`); run `ruff format . && ruff check --fix .`, `mypy` (via pre-push hook), full `pytest`, `manage.py check`; bump `plfog/version.py` VERSION + **one** member-friendly `CHANGELOG` entry stamped at the new VERSION (see §10 note on changelog collisions).
+
+> Spec only — do not build until approved.
+
+## 9. Testing
+
+BDD `*_spec.py`, `describe_*`/`it_*`, factory-boy, ≥ the repo's coverage gate (100% branch target), run in the `plfog-web` Docker image. Note the two-location convention: model/email specs under `tests/membership/`, view/template specs under `tests/hub/`.
+
+- **Model (`GuildOrientationSettings`):** `welcome_email_body_resolved`/`subject_resolved` return the lead override when set and the standard copy when blank; `welcome_email_ready` tracks `enabled`; `save()` stamps `welcome_email_updated_at` only on a welcome-field change (not on an unrelated save).
+- **Send (`member_joined_guild`):** joining via `subscribe_to_guild` (created) sends exactly one welcome email to `member.primary_email` with the resolved subject/body and the banner URL in context; an idempotent re-subscribe / leave-then-rejoin does **not** re-send (period dedup); a guild with `welcome_email_enabled=False` sends none; the lead "New follower" in-app still fires regardless; a Discord *reaction* join (`record_discord_join`) sends **no** welcome. Assert the `TransactionalEmailLog` row (`trigger_kind="guild_welcome"`). Use `respx` only if any HTTP is involved (none expected); never mock the DB/models.
+- **First-login picker burst:** `answer_guild_updates_prompt([g1,g2,g3])` sends three welcomes (one per guild), each once.
+- **Join/leave views:** `hub_guild_join` on a linked member creates the membership + returns `_guild_join_cta.html` in the Member state (+ toast trigger header); unlinked/anonymous → guarded (toast/redirect), no row; `hub_guild_leave` deletes + returns the Join state; public guilds surface hides the hero Join (gate honored).
+- **Editor:** `GuildWelcomeEmailForm` sanitizes body HTML; `guild_emails_save` with `form_id="welcome_email"` saves + redirects to `?tab=welcome_email`; invalid re-renders on that tab; unknown `form_id` → 404; non-lead is forbidden (`_require_can_edit_guild`); `guild_welcome_test` sends to the lead's own email and toasts; preview renders without sending.
+- **Directory:** `?guild=<slug>` filters to that guild's members; unknown slug → all; badges render per joined guild with the correct logo/link and are N+1 free (assert query count); hidden profiles never surface via a badge; zero-match filter shows the empty-state line.
+- **Template lint:** run `tests/template_comment_lint_spec.py` (single-line `{# #}` only) after touching `guild_detail.html` / `guild_edit.html` / `member_directory.html`.
+- **Copy-review:** the `guild_welcome` event copy renders cream-on-dark with gold links in the shell (Rule: copy-mode emails must be styled, not just wrapped) — but here we pass a real `.html` template, so verify the banner + linked guild name + CTA render in both a banner and no-banner guild.
+
+## 10. Open / deferred
+
+- **First-login welcome burst.** Firing one welcome per picked guild is accepted (each is genuinely per-guild). If members find 3+ at once noisy, a deferred option is to have `answer_guild_updates_prompt` suppress the per-guild welcome and send a single "welcome to your guilds" digest instead. Not built now (adds a second email path for a hypothetical complaint).
+- **Help article `your-guild-page`.** Recommended but its authoring (screenshots per `HELP_AUTHORING.md`) is a small separate content task; the email falls back to `welcome-to-fog` until it lands.
+- **Changelog collision guard.** The `CHANGELOG` text renders into every hub page's context; keep the new entry free of any literal marker strings that negative tests assert on (see the "changelog renders everywhere" gotcha). One curated entry per feature, stamped at the new VERSION.
+- **Out of scope:** a standalone public member profile page (none exists; the Directory card is the profile); changing how announcement *channel* preferences work (still Settings → Notifications); any change to the Discord reaction sync or `discord_welcome_message` (that Discord-only field is separate from this email and stays as-is).

--- a/hub/discord_commands.py
+++ b/hub/discord_commands.py
@@ -191,10 +191,13 @@ def _join_guild(interaction: Interaction, member: Member | None) -> dict:
                 hook,
                 Message(title=f"Welcome {member.display_name} to {guild.name}!", body=_welcome_body(guild)),
             )
-        # Welcome fan-out (activity + lead notification + optional welcome email), wrapped so
-        # an email hiccup can never swallow the member's confirmation.
+        # Welcome fan-out (activity + lead "New follower" notice), wrapped so an email hiccup
+        # can never swallow the member's confirmation. /join-guild is a deliberate join, so the
+        # member-facing welcome email fires too (there is no opt-out checkbox in Discord — a
+        # member who typed the command wants in). Both are wrapped best-effort.
         try:
             orientations.member_joined_guild(guild, member)
+            member.send_guild_welcome(guild)
         except Exception:
             logger.exception("join-guild: welcome fan-out failed for guild=%s member=%s", guild.pk, member.pk)
 

--- a/hub/forms.py
+++ b/hub/forms.py
@@ -1620,6 +1620,60 @@ class GuildThankyouEmailForm(forms.ModelForm):
         return cast(GuildOrientationSettings, super().save(commit=commit))
 
 
+class GuildWelcomeEmailForm(forms.ModelForm):
+    """Edit a guild's lead-authored welcome email.
+
+    Lives on the Welcome Email tab of the guild editor — it is the join-lifecycle email,
+    sent once a member deliberately joins (the "Join This Guild" button with the welcome
+    box checked, or the Discord ``/join-guild`` command). The email *data* stays on
+    :class:`~membership.models.GuildOrientationSettings`; only the editing UI lives here.
+    The welcome email is on by default and falls back to the standard copy, so enabling it
+    needs no subject or body. Saving stamps ``welcome_email_updated_at`` when a welcome
+    field changed.
+    """
+
+    class Meta:
+        model = GuildOrientationSettings
+        fields = [
+            "welcome_email_enabled",
+            "welcome_email_subject",
+            "welcome_email_body",
+        ]
+        widgets = {
+            "welcome_email_body": RichTextEditorWidget(attrs={"rows": 6}),
+        }
+        labels = {
+            "welcome_email_enabled": "Send a welcome email when a member joins this guild",
+            "welcome_email_subject": "Welcome subject",
+            "welcome_email_body": "Welcome message",
+        }
+
+    def clean_welcome_email_body(self) -> str:
+        return sanitize_rich_html(self.cleaned_data.get("welcome_email_body") or "")
+
+    _WELCOME_EMAIL_FIELDS = ("welcome_email_enabled", "welcome_email_subject", "welcome_email_body")
+
+    def save(self, commit: bool = True) -> GuildOrientationSettings:
+        if set(self.changed_data).intersection(self._WELCOME_EMAIL_FIELDS):
+            self.instance.welcome_email_updated_at = timezone.now()
+        return cast(GuildOrientationSettings, super().save(commit=commit))
+
+
+class GuildJoinForm(forms.Form):
+    """The join-modal opt-in: one toggle for the welcome email.
+
+    Not persisted — it only carries the member's welcome-packet choice with the join POST.
+    The toggle is checked by default (opt-out within the deliberate join, honoring "ask
+    first"). The view reads ``send_welcome`` off the POST directly.
+    """
+
+    send_welcome = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Email me the guild welcome guide",
+    )
+
+
 class OrientationAvailabilityForm(forms.ModelForm):
     """A single recurring orientation-availability row.
 

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -239,7 +239,11 @@ urlpatterns = [
         views.guild_announcement_review_decision,
         name="hub_guild_announcement_review_decision",
     ),
+    path("guilds/<int:pk>/join/", views.guild_join, name="hub_guild_join"),
+    path("guilds/<int:pk>/leave/", views.guild_leave, name="hub_guild_leave"),
     path("guilds/<int:pk>/emails/save/", views.guild_emails_save, name="hub_guild_emails_save"),
+    path("guilds/<int:pk>/welcome-email/test/", views.guild_welcome_test, name="hub_guild_welcome_test"),
+    path("guilds/<int:pk>/welcome-email/preview/", views.guild_welcome_preview, name="hub_guild_welcome_preview"),
     path(
         "guilds/<int:pk>/announcement-settings/save/",
         views.guild_announcement_settings_save,

--- a/hub/views.py
+++ b/hub/views.py
@@ -291,12 +291,20 @@ def member_directory(request: HttpRequest) -> HttpResponse:
     skill_slug = request.GET.get("skill", "")
     if skill_slug:
         member_qs = member_qs.with_skill(skill_slug)
+    # Guild filter: an unknown slug is ignored (show all), never an error.
+    guilds = Guild.objects.filter(is_active=True).order_by("name")
+    guild_slug = request.GET.get("guild", "")
+    selected_guild = guilds.filter(slug=guild_slug).first() if guild_slug else None
+    if selected_guild is not None:
+        member_qs = member_qs.filter(guild_memberships__guild=selected_guild)
     commissions_only = request.GET.get("commissions") == "1"
     if commissions_only:
         member_qs = member_qs.open_for_commissions()
     query = request.GET.get("q", "").strip()
     if query:
         member_qs = member_qs.search_skills(query)
+    from membership.models import GuildMembership
+
     members = (
         member_qs.select_related("membership_plan", "user")
         .prefetch_related(
@@ -311,6 +319,14 @@ def member_directory(request: HttpRequest) -> HttpResponse:
                 queryset=MemberContact.objects.filter(show_in_directory=True),
                 to_attr="visible_contacts",
             ),
+            # Per-card guild badges, N+1-free: active guilds only, name-ordered.
+            Prefetch(
+                "guild_memberships",
+                queryset=GuildMembership.objects.filter(guild__is_active=True)
+                .select_related("guild")
+                .order_by("guild__name"),
+                to_attr="directory_guild_memberships",
+            ),
         )
         .order_by("full_legal_name")
     )
@@ -324,6 +340,8 @@ def member_directory(request: HttpRequest) -> HttpResponse:
             "is_admin": is_admin,
             "skill_categories": _skill_categories_with_approved(),
             "selected_skill": skill_slug,
+            "guilds": guilds,
+            "selected_guild": selected_guild,
             "commissions_only": commissions_only,
             "query": query,
         },
@@ -564,9 +582,10 @@ def guild_detail(request: HttpRequest, slug: str) -> HttpResponse:
             label = orienter_labels.get(slot.orienter_id, "")
             slot.with_display = f"with {label}" if label else slot.with_label
 
-    from hub.forms import OrientationCustomRequestForm
+    from hub.forms import GuildJoinForm, OrientationCustomRequestForm
 
     custom_request_form = OrientationCustomRequestForm()
+    join_form = GuildJoinForm()
 
     guild_ct = ContentType.objects.get_for_model(Guild)
 
@@ -609,6 +628,7 @@ def guild_detail(request: HttpRequest, slug: str) -> HttpResponse:
             "show_orientation": show_orientation,
             "orientation_slots": orientation_slots,
             "custom_request_form": custom_request_form,
+            "join_form": join_form,
         },
     )
 
@@ -666,6 +686,7 @@ def _guild_edit_context(
     form: GuildEditForm | None = None,
     orientation_form: Any = None,
     thankyou_email_form: Any = None,
+    welcome_email_form: Any = None,
     guild_rule_formset: Any = None,
     studio_hours_formset: Any = None,
     mailing_list_formset: Any = None,
@@ -687,6 +708,7 @@ def _guild_edit_context(
         GuildStaffAddForm,
         GuildThankyouEmailForm,
         GuildVisibilityForm,
+        GuildWelcomeEmailForm,
         OrientationAvailabilityFormSet,
         OrientationSlotForm,
         StudioHoursFormSet,
@@ -763,6 +785,9 @@ def _guild_edit_context(
         ),
         "orientation_form": (
             orientation_form if orientation_form is not None else GuildOrientationSettingsForm(instance=settings_obj)
+        ),
+        "welcome_email_form": (
+            welcome_email_form if welcome_email_form is not None else GuildWelcomeEmailForm(instance=settings_obj)
         ),
         "thankyou_email_form": (
             thankyou_email_form if thankyou_email_form is not None else GuildThankyouEmailForm(instance=settings_obj)
@@ -2492,6 +2517,129 @@ def guild_membership_set(request: HttpRequest, pk: int) -> HttpResponse:
     return response
 
 
+def _guild_cta_context(request: HttpRequest, guild: Guild, member: Member | None) -> dict[str, Any]:
+    """Shared context for the hero Join/Member CTA partial and its OOB sibling fragments.
+
+    Recomputed after a join/leave so the swapped fragments (hero CTA, sticky mini-CTA,
+    member-count chip, roster card, Get Involved status) each render standalone and in
+    sync. The initial page render reuses the keys ``guild_detail`` already builds.
+    """
+    is_member = member is not None and guild.memberships.filter(member=member).exists()
+    roster = guild.roster_members() if guild.show_members and member is not None else None
+    return {
+        "guild": guild,
+        "member": member,
+        "is_member_of_guild": is_member,
+        "member_count": guild.memberships.count(),
+        "roster": roster,
+    }
+
+
+@login_required
+@require_POST
+def guild_join(request: HttpRequest, pk: int) -> HttpResponse:
+    """Join a guild from the hero button (HTMX). Members-surface only.
+
+    The one deliberate web join path: records the subscription (fat model), stamps the
+    first-login prompt as answered, and — only when the member is newly joined AND left
+    the modal's "send welcome packet" box checked — sends the guild's welcome email once.
+    Returns the flipped CTA plus the OOB sibling fragments and a success toast. An
+    unlinked account gets a guarded error toast and no row.
+    """
+    guild = get_object_or_404(Guild, pk=pk)
+    member = _get_member(request)
+    if member is None:
+        response = HttpResponse(status=204)
+        trigger_toast(response, "Your account is not linked to a membership.", "error")
+        return response
+    joined = member.subscribe_to_guild(guild)
+    member.mark_guild_updates_answered()
+    welcomed = bool(joined and request.POST.get("send_welcome"))
+    if welcomed:
+        member.send_guild_welcome(guild)
+    ctx = _guild_cta_context(request, guild, member)
+    ctx["oob"] = True
+    response = render(request, "hub/partials/_guild_join_cta.html", ctx)
+    message = f"You joined {guild.name}! Check your inbox for a welcome." if welcomed else f"You joined {guild.name}!"
+    trigger_toast(response, message, "success")
+    return response
+
+
+@login_required
+@require_POST
+def guild_leave(request: HttpRequest, pk: int) -> HttpResponse:
+    """Leave a guild from the Member-state overflow (HTMX). Members-surface only.
+
+    Deletes the subscription (fat model, drops the Discord role) and returns the CTA
+    flipped back to the Join state plus the OOB sibling fragments and an info toast.
+    """
+    guild = get_object_or_404(Guild, pk=pk)
+    member = _get_member(request)
+    if member is None:
+        response = HttpResponse(status=204)
+        trigger_toast(response, "Your account is not linked to a membership.", "error")
+        return response
+    member.unsubscribe_from_guild(guild)
+    ctx = _guild_cta_context(request, guild, member)
+    ctx["oob"] = True
+    response = render(request, "hub/partials/_guild_join_cta.html", ctx)
+    trigger_toast(response, f"You left {guild.name}. You can rejoin any time.", "info")
+    return response
+
+
+@login_required
+@require_POST
+def guild_welcome_test(request: HttpRequest, pk: int) -> HttpResponse:
+    """Send the guild's welcome email to the editing lead's own inbox (HTMX; 204 + toast).
+
+    Editor only. Fires the real welcome send to the lead's ``primary_email`` so they can
+    proof the exact banner + copy members receive.
+    """
+    guild = get_object_or_404(Guild, pk=pk)
+    forbidden = _require_can_edit_guild(request, guild)
+    if forbidden is not None:
+        return forbidden
+    member = _get_member(request)
+    response = HttpResponse(status=204)
+    if member is None:
+        trigger_toast(response, "Your account is not linked to a membership.", "error")
+        return response
+    from membership.orientations import send_guild_welcome_test
+
+    send_guild_welcome_test(guild, member)
+    trigger_toast(response, f"Test sent to {member.primary_email}.", "success")
+    return response
+
+
+@login_required
+def guild_welcome_preview(request: HttpRequest, pk: int) -> HttpResponse:
+    """Render the guild's welcome email into the editor preview modal (editor only).
+
+    Renders the real ``guild_welcome.html`` shell with the guild's *current saved* copy and a
+    sample greeting name, so a lead proofs the exact banner + copy without sending. Reuses the
+    announcement composer's iframe preview partial.
+    """
+    from django.template.loader import render_to_string
+
+    from membership.models import GuildOrientationSettings
+    from membership.orientations import _guild_welcome_context
+
+    guild = get_object_or_404(Guild, pk=pk)
+    forbidden = _require_can_edit_guild(request, guild)
+    if forbidden is not None:
+        return forbidden
+    settings_obj, _ = GuildOrientationSettings.objects.get_or_create(guild=guild)
+    member = _get_member(request)
+    sample_name = member.display_name if member is not None else "Sample Member"
+    email_ctx = _guild_welcome_context(guild, sample_name, settings_obj.welcome_email_body_resolved)
+    preview_html = render_to_string("membership/emails/guild_welcome.html", email_ctx)
+    return render(
+        request,
+        "hub/partials/_compose_email_preview.html",
+        {"preview_html": preview_html, "preview_subject": settings_obj.welcome_email_subject_resolved},
+    )
+
+
 @login_required
 @require_POST
 def guild_image_delete(request: HttpRequest, pk: int, image_pk: int) -> HttpResponse:
@@ -3177,7 +3325,7 @@ def guild_emails_save(request: HttpRequest, pk: int) -> HttpResponse:
     guild edit page on the Orientations tab with the form's errors. An unknown or missing
     ``form_id`` on a POST is a 404 (fail loudly).
     """
-    from hub.forms import GuildThankyouEmailForm
+    from hub.forms import GuildThankyouEmailForm, GuildWelcomeEmailForm
     from membership.models import GuildOrientationSettings
 
     guild = get_object_or_404(Guild, pk=pk)
@@ -3187,19 +3335,28 @@ def guild_emails_save(request: HttpRequest, pk: int) -> HttpResponse:
     orientations_tab = f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=orientations"
     if request.method != "POST":
         return redirect(orientations_tab)
-    if request.POST.get("form_id") != "thankyou_email":
-        raise Http404("Unknown email form.")
-
+    form_id = request.POST.get("form_id")
     settings_obj, _ = GuildOrientationSettings.objects.get_or_create(guild=guild)
-    form = GuildThankyouEmailForm(request.POST, instance=settings_obj)
-    if form.is_valid():
-        form.save()
-        messages.success(request, "Thank-you email saved.")
-        return redirect(orientations_tab)
-
-    ctx = _guild_edit_context(request, guild, thankyou_email_form=form)
-    ctx["active_tab"] = "orientations"
-    return render(request, "hub/guild_edit.html", ctx)
+    if form_id == "thankyou_email":
+        form = GuildThankyouEmailForm(request.POST, instance=settings_obj)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Thank-you email saved.")
+            return redirect(orientations_tab)
+        ctx = _guild_edit_context(request, guild, thankyou_email_form=form)
+        ctx["active_tab"] = "orientations"
+        return render(request, "hub/guild_edit.html", ctx)
+    if form_id == "welcome_email":
+        welcome_tab = f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=welcome_email"
+        welcome_form = GuildWelcomeEmailForm(request.POST, instance=settings_obj)
+        if welcome_form.is_valid():
+            welcome_form.save()
+            messages.success(request, "Welcome email saved.")
+            return redirect(welcome_tab)
+        ctx = _guild_edit_context(request, guild, welcome_email_form=welcome_form)
+        ctx["active_tab"] = "welcome_email"
+        return render(request, "hub/guild_edit.html", ctx)
+    raise Http404("Unknown email form.")
 
 
 @login_required

--- a/membership/guild_welcome_copy.py
+++ b/membership/guild_welcome_copy.py
@@ -1,0 +1,28 @@
+"""Standard (default) copy for the per-guild join welcome email.
+
+The welcome email is ON by default: when a member deliberately joins a guild (the
+"Join This Guild" button with the welcome box checked, or the Discord ``/join-guild``
+command) they get a warm welcome, whether or not the guild wrote their own. A guild MAY
+still customize the subject and body on the Welcome Email tab of their guild editor; when
+they leave those blank, the standard copy below stands in.
+
+Kept in one place so it is the single source of truth: the send path and the
+copy-review gallery both read it, so what a reviewer sees on copy-review.pastlives.space
+is exactly what ships. The body is rendered through the rich-text email filter, so plain
+sentences with line breaks are fine; the surrounding template already greets the member
+by name, adds the "Welcome to <guild>" eyebrow (linked to the guild page), and supplies
+the static "what you can do on your guild page" section.
+"""
+
+from __future__ import annotations
+
+STANDARD_WELCOME_BODY = (
+    "We're really glad you're here. Following a guild means you'll hear about what's happening, "
+    "you'll show up on the guild roster, and you'll pick up the guild's Discord role automatically. "
+    "Look around your guild page whenever you like, and come say hi in the channel. See you around the space!"
+)
+
+
+def standard_welcome_subject(guild_name: str) -> str:
+    """The default welcome subject line for a guild with no custom subject set."""
+    return f"Welcome to {guild_name}!"

--- a/membership/migrations/0146_readd_guild_welcome_email.py
+++ b/membership/migrations/0146_readd_guild_welcome_email.py
@@ -1,0 +1,58 @@
+# Re-adds the four welcome-email columns to GuildOrientationSettings, restoring the
+# per-guild join welcome email that migration 0145 dropped when the "Join This Guild"
+# button was temporarily removed. This is a pure AddField x4, so Django auto-generates
+# the reverse (RemoveField x4) and it runs backward cleanly with no hand-written reverse.
+#
+# NOTE: this restores EMPTY columns. Any welcome-email subject/body a guild had stored
+# before the 0145 drop is NOT recoverable (it was destroyed then). Leads re-author from
+# the seeded default copy (membership/guild_welcome_copy.py).
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("membership", "0145_remove_guild_welcome_email"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="guildorientationsettings",
+            name="welcome_email_body",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text="Body of the welcome email (your personal note; line breaks preserved).",
+            ),
+        ),
+        migrations.AddField(
+            model_name="guildorientationsettings",
+            name="welcome_email_enabled",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "Send a welcome email when a member joins this guild. On by default; "
+                    "leave the subject and body blank to send the standard welcome, or write your own."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="guildorientationsettings",
+            name="welcome_email_subject",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Subject line of the welcome email.",
+                max_length=200,
+            ),
+        ),
+        migrations.AddField(
+            model_name="guildorientationsettings",
+            name="welcome_email_updated_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text="When the welcome email was last edited.",
+                null=True,
+            ),
+        ),
+    ]

--- a/membership/models.py
+++ b/membership/models.py
@@ -721,9 +721,12 @@ class Member(models.Model):
         """Subscribe this member to ``guild``'s updates (idempotent).
 
         The one subscribe path: records the app-sourced :class:`GuildMembership` row,
-        fires the ``guild_joined`` fan-out (welcome email when configured, lead notice,
-        activity row) only when the row is new or upgraded from a Discord reaction, and
-        always self-heals the Discord role (idempotent, best-effort).
+        fires the ``guild_joined`` fan-out (lead "New follower" notice + activity row, no
+        email) only when the row is new or upgraded from a Discord reaction, and always
+        self-heals the Discord role (idempotent, best-effort). The member-facing welcome
+        email is a *separate*, deliberate-join-only send (:meth:`send_guild_welcome`) — it
+        is intentionally not fired here, so the first-login picker and Settings toggle stay
+        silent.
 
         Returns:
             Whether this was a new or upgraded subscription (the fan-out fired).
@@ -736,6 +739,19 @@ class Member(models.Model):
             orientations.member_joined_guild(guild, self)
         discord_roles.on_membership_changed(guild, self, joined=True)
         return created or upgraded
+
+    def send_guild_welcome(self, guild: Guild) -> None:
+        """Send this member the guild's welcome email once (idempotent per (member, guild)).
+
+        The deliberate-join welcome. Called by the hero Join view (only when the member
+        left the modal's welcome box checked) and the Discord ``/join-guild`` command —
+        never by :meth:`subscribe_to_guild`, so the first-login picker and Settings toggle
+        never trigger it. Gated on the guild's ``welcome_email_enabled``; deduped forever
+        per (member, guild).
+        """
+        from membership import orientations
+
+        orientations.send_guild_welcome(guild, self)
 
     def unsubscribe_from_guild(self, guild: Guild) -> None:
         """Remove this member's subscription to ``guild`` (idempotent) and drop the Discord role."""
@@ -8182,6 +8198,22 @@ class GuildOrientationSettings(models.Model):
     thankyou_email_updated_at = models.DateTimeField(
         null=True, blank=True, help_text="When the thank-you email was last edited."
     )
+    welcome_email_enabled = models.BooleanField(
+        default=True,
+        help_text=(
+            "Send a welcome email when a member joins this guild. On by default; "
+            "leave the subject and body blank to send the standard welcome, or write your own."
+        ),
+    )
+    welcome_email_subject = models.CharField(
+        max_length=200, blank=True, default="", help_text="Subject line of the welcome email."
+    )
+    welcome_email_body = models.TextField(
+        blank=True, default="", help_text="Body of the welcome email (your personal note; line breaks preserved)."
+    )
+    welcome_email_updated_at = models.DateTimeField(
+        null=True, blank=True, help_text="When the welcome email was last edited."
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -8205,6 +8237,25 @@ class GuildOrientationSettings(models.Model):
         from membership.orientation_copy import STANDARD_THANKYOU_BODY
 
         return self.thankyou_email_body or STANDARD_THANKYOU_BODY
+
+    @property
+    def welcome_email_subject_resolved(self) -> str:
+        """The guild's custom welcome subject, or the standard one when they left it blank."""
+        from membership.guild_welcome_copy import standard_welcome_subject
+
+        return self.welcome_email_subject or standard_welcome_subject(self.guild.name)
+
+    @property
+    def welcome_email_body_resolved(self) -> str:
+        """The guild's custom welcome body, or the standard copy when they left it blank."""
+        from membership.guild_welcome_copy import STANDARD_WELCOME_BODY
+
+        return self.welcome_email_body or STANDARD_WELCOME_BODY
+
+    @property
+    def welcome_email_ready(self) -> bool:
+        """On + always has resolvable copy, so ``enabled`` alone is enough to send."""
+        return self.welcome_email_enabled
 
     @property
     def is_accepting(self) -> bool:

--- a/membership/orientations.py
+++ b/membership/orientations.py
@@ -960,3 +960,78 @@ def member_joined_guild(guild: Guild, member: Member) -> None:
         url=reverse("hub_guild_detail", args=[guild.slug]),
         period=f"guild:{guild.pk}:join:{member.pk}",
     )
+
+
+def _guild_welcome_context(guild: Guild, greeting_name: str, body: str) -> dict[str, Any]:
+    """Build the render context for the guild-welcome email shell.
+
+    The editable ``body`` is the lead's note (or the standard default); the static
+    "what you can do" section + help link live in the template. ``help_url`` points at
+    the member-facing guilds guide (the lead-authoring "your guild page" article is a
+    different, guild_lead-audience page).
+    """
+    return {
+        "guild": guild,
+        "greeting_name": greeting_name,
+        "body": body,
+        "guild_url": _absolute_url(reverse("hub_guild_detail", args=[guild.slug])),
+        "banner_url": _absolute_url(guild.banner_image.url) if guild.banner_image else "",
+        "help_url": _absolute_url(reverse("hub_help_article", args=["guilds", "guilds-and-guild-pages"])),
+    }
+
+
+def send_guild_welcome(guild: Guild, member: Member) -> None:
+    """Send a member the guild's welcome email once, on a deliberate join (idempotent).
+
+    Fired ONLY on a deliberate join: the hero "Join This Guild" button with the welcome
+    box checked, or the Discord ``/join-guild`` command. It is deliberately NOT called
+    from :meth:`Member.subscribe_to_guild` / :func:`member_joined_guild`, so the
+    first-login interest picker and the Settings notification toggle subscribe silently.
+
+    Transactional, addressed with an explicit ``email_to`` (bypasses preferences — the
+    member just asked to join). Deduped once per (member, guild) forever via the ``period``
+    key, so a leave-then-rejoin months later never re-welcomes. Gated on the guild's
+    ``welcome_email_enabled``; a guild with no settings row sends nothing.
+    """
+    from membership.models import GuildOrientationSettings
+
+    settings_obj = GuildOrientationSettings.objects.filter(guild=guild).first()
+    if settings_obj is None or not settings_obj.welcome_email_ready:
+        return
+    emit_with_email_shell(
+        "guild_welcome",
+        target=guild,
+        context={"member": None},  # resolver finds nobody → email-only, no in-app/push dup
+        subject=settings_obj.welcome_email_subject_resolved,
+        text_template="membership/emails/guild_welcome.txt",
+        html_template="membership/emails/guild_welcome.html",
+        template_context=_guild_welcome_context(guild, member.display_name, settings_obj.welcome_email_body_resolved),
+        email_to=member.primary_email,
+        email_trigger_kind="guild_welcome",
+        period=f"guild:{guild.pk}:welcome:{member.pk}",
+    )
+
+
+def send_guild_welcome_test(guild: Guild, member: Member) -> None:
+    """Send the guild's welcome email to a lead's own inbox as a proof (always sends).
+
+    Powers the "Send test to me" button on the Welcome Email editor tab. Unlike the
+    member-facing send it ignores the enabled gate (a lead may proof a draft before turning
+    it on) and uses a per-instant idempotency bucket so repeated proofs all go out.
+    """
+    from membership.models import GuildOrientationSettings
+
+    settings_obj, _created = GuildOrientationSettings.objects.get_or_create(guild=guild)
+    stamp = timezone.now().strftime("%Y%m%d%H%M%S%f")
+    emit_with_email_shell(
+        "guild_welcome",
+        target=guild,
+        context={"member": None},
+        subject=settings_obj.welcome_email_subject_resolved,
+        text_template="membership/emails/guild_welcome.txt",
+        html_template="membership/emails/guild_welcome.html",
+        template_context=_guild_welcome_context(guild, member.display_name, settings_obj.welcome_email_body_resolved),
+        email_to=member.primary_email,
+        email_trigger_kind="guild_welcome",
+        period=f"guild:{guild.pk}:welcome:test:{member.pk}:{stamp}",
+    )

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
-VERSION = "1.19.1"
+VERSION = "1.20.0"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.20.0",
+        "date": "2026-08-27",
+        "title": "Join your favorite guilds",
+        "changes": [
+            "Every guild page now has a Join This Guild button. Joining adds you to the guild's "
+            "roster, puts a badge on your member directory card, keeps you in the loop on that "
+            "guild's announcements, and lets you sign up for its orientations. When you join you "
+            "can choose to get a welcome guide by email, and guild leads can write their own "
+            "welcome note. You can leave a guild any time.",
+        ],
+    },
     {
         "version": "1.19.1",
         "date": "2026-08-27",

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -7134,6 +7134,135 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
     transform: translateY(-2px);
 }
 
+/* ── Guild Join / Member hero CTA ────────────────────────────────────────── */
+.pl-guild-cta {
+    display: inline-flex;
+}
+.pl-guild-cta__member {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+.pl-guild-cta__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: default;
+}
+.pl-guild-cta__overflow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+}
+.pl-guild-cta__menu {
+    position: absolute;
+    top: calc(100% + 0.35rem);
+    right: 0;
+    z-index: 40;
+    min-width: 160px;
+    padding: 0.35rem;
+    border-radius: 8px;
+    border: 1px solid var(--hub-border);
+    background: var(--hub-elevated);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+.pl-guild-cta__menu-item {
+    display: block;
+    width: 100%;
+    padding: 0.55rem 0.75rem;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--hub-text);
+    text-align: left;
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+.pl-guild-cta__menu-item:hover {
+    background: var(--hub-surface);
+}
+
+/* ── Sticky mini Join CTA (clones .pl-scroll-top placement) ──────────────── */
+.pl-guild-join-fab {
+    position: fixed;
+    bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+    right: 1.25rem;
+    z-index: 90;
+}
+.pl-guild-join-fab__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.7rem 1.15rem;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    cursor: pointer;
+}
+.pl-guild-join-fab__pill--join {
+    border: 1px solid var(--color-tuscan-yellow);
+    background: var(--color-tuscan-yellow);
+    color: var(--color-navy);
+}
+.pl-guild-join-fab__pill--join:hover {
+    transform: translateY(-2px);
+}
+.pl-guild-join-fab__pill--member {
+    border: 1px solid var(--hub-border);
+    background: var(--hub-elevated);
+    color: var(--hub-text-muted);
+    cursor: default;
+}
+
+/* ── Join-modal benefit rows ─────────────────────────────────────────────── */
+.pl-benefit-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.pl-benefit-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    font-size: 0.92rem;
+    color: var(--hub-text);
+    line-height: 1.4;
+}
+.pl-benefit-row svg {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    margin-top: 0.1rem;
+    color: var(--color-tuscan-yellow);
+}
+.pl-benefit-row a {
+    color: var(--color-tuscan-yellow);
+}
+
+/* ── Member Directory guild badges ───────────────────────────────────────── */
+.pl-directory-guilds {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.75rem;
+}
+.pl-directory-guild {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    text-decoration: none;
+}
+.pl-directory-guild img {
+    display: block;
+    width: 14px;
+    height: 14px;
+}
+
 /* Phone clearance: the fixed back-to-top FAB floats over a padded strip, never over the
    page's last row of controls (Guilds toggles, danger-zone footer, Tours Save). */
 @media (max-width: 768px) {

--- a/templates/hub/guild_detail.html
+++ b/templates/hub/guild_detail.html
@@ -60,6 +60,7 @@
         </div>
         {% if guild.guild_lead %}<div class="pl-guild-hero__lead" style="margin-top:0;">Led by {{ guild.guild_lead.display_name }}</div>{% endif %}
         <div style="display:flex; gap:0.5rem; margin-top:0.75rem; flex-wrap:wrap; align-items:center;">
+            {% include "hub/partials/_guild_join_cta.html" %}
             {% if can_edit_this_guild %}
             <a href="{% url 'hub_guild_edit' guild.pk %}" class="pl-btn pl-btn--secondary" title="Guild Settings" x-show="!isAdjusting">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:0.25rem;"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
@@ -107,7 +108,7 @@
 
 {# ── STAT CHIPS ── #}
 <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin:0 0 1rem;">
-    {% if member_count %}<span class="hub-badge">{{ member_count }} member{{ member_count|pluralize }}</span>{% endif %}
+    {% include "hub/partials/_guild_member_count.html" %}
     {% if class_count %}<span class="hub-badge">{{ class_count }} class{{ class_count|pluralize:"es" }}</span>{% endif %}
     {% with next_meeting=guild.next_meeting_occurrence %}{% if next_meeting %}<span class="hub-badge">Next meeting {{ next_meeting.when|date:"M j" }}</span>{% endif %}{% endwith %}
 </div>
@@ -290,21 +291,11 @@
         <div class="hub-card">
             <h3 class="hub-detail-label">Get Involved</h3>
             <div style="display:flex; flex-direction:column; gap:0.5rem;">
-                {# No join button here by design — subscription management lives in Settings. An unlinked account (member is None, authenticated) hits no branch and just sees the card's other actions. #}
+                {# Joining lives in the hero Join button now; this panel keeps the member's quiet updates confirmation + channel prefs link. An unlinked account (member is None, authenticated) just sees the card's other actions. #}
                 {% if not user.is_authenticated %}
                 <a href="{% url 'account_login' %}?next={{ request.path|urlencode }}" class="pl-btn pl-btn--primary" style="width:100%;">Log in to the members hub</a>
-                {% elif member and is_member_of_guild %}
-                <div class="hub-text-muted" style="display:flex; align-items:center; gap:0.4rem; font-size:0.9rem;">
-                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
-                    You get this guild's updates
-                </div>
-                <a href="{% if is_guilds_surface %}{{ MEMBER_BASE_URL }}{% endif %}{% url 'hub_user_settings' %}?tab=guilds" class="pl-btn pl-btn--secondary" style="width:100%;" data-help-key="guild.join-leave" {% if is_guilds_surface %}hx-boost="false"{% endif %}>Manage in Settings</a>
-                {% elif member %}
-                <p class="hub-text-muted" style="font-size:0.9rem; margin:0;" data-help-key="guild.join-leave">
-                    Want announcements from this guild? Choose your guild updates in
-                    <a href="{% if is_guilds_surface %}{{ MEMBER_BASE_URL }}{% endif %}{% url 'hub_user_settings' %}?tab=guilds" {% if is_guilds_surface %}hx-boost="false"{% endif %}>Settings</a>.
-                </p>
                 {% endif %}
+                {% include "hub/partials/_guild_get_involved_status.html" %}
                 {% if show_orientation and not is_oriented %}
                 <button type="button" class="pl-btn pl-btn--primary" style="width:100%;" data-help-key="orientation.book-slot"
                         @click="section = 'orientations'; $nextTick(() => document.getElementById('guild-orientation')?.scrollIntoView({ behavior: 'smooth' }))">
@@ -352,19 +343,7 @@
         </div>
         {% endif %}
 
-        {% if user.is_authenticated and guild.show_members and roster %}
-        <div class="hub-card">
-            <h3 class="hub-detail-label">Members</h3>
-            <div class="pl-guild-roster">
-                {% for m in roster %}
-                <div class="hub-member-row">
-                    <div class="hub-member-avatar">{{ m.display_name|make_list|first|upper }}</div>
-                    <span class="hub-member-name">{{ m.display_name }}</span>
-                </div>
-                {% endfor %}
-            </div>
-        </div>
-        {% endif %}
+        {% include "hub/partials/_guild_roster_card.html" %}
 
         {% if links %}
         <div class="hub-card">
@@ -753,6 +732,95 @@
         </div>
     </div>
 </div>
+{% endif %}
+
+{# Join / Leave front door — members surface only (joins happen on the hub). #}
+{% if member and not is_guilds_surface %}
+{# Benefit-framed join modal. Mirrors components/modal.html's pl-modal structure (this file's convention for static-body modals, e.g. the lead-profile + EYOP modals above). #}
+<div x-data="{ open: false }"
+     x-show="open"
+     x-transition:enter="modal-enter"
+     x-transition:leave="modal-leave"
+     @open-modal.window="if ($event.detail === 'join-guild') open = true"
+     @close-modal.window="if ($event.detail === 'join-guild') open = false"
+     @keydown.escape.window="open = false"
+     class="pl-modal-backdrop"
+     style="display: none;"
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="join-guild-title">
+    <div class="pl-modal pl-modal--md" @click.outside="open = false">
+        <div class="pl-modal__header">
+            <h2 class="pl-modal__title" id="join-guild-title">Join {{ guild.name }}?</h2>
+            <button type="button" @click="open = false" class="pl-modal__close" aria-label="Close">&times;</button>
+        </div>
+        <div class="pl-modal__body" id="join-guild-body">
+            <p class="hub-text-muted" style="margin:0 0 1rem;">Here's what joining {{ guild.name }} gets you.</p>
+            <div class="pl-benefit-rows">
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                    <span>You're added to the guild roster.</span>
+                </div>
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 3.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H8a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V8a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+                    <span>A {{ guild.name }} badge appears on <a href="{% url 'hub_member_directory' %}?guild={{ guild.slug }}">your profile</a>.</span>
+                </div>
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+                    <span>You get this guild's updates and announcements (email, in app, or Discord, your choice in Settings).</span>
+                </div>
+                {% if show_orientation %}
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                    <span>You can book <a href="{% url 'hub_guild_detail' guild.slug %}?tab=orientations" @click="open = false">orientations</a> for this guild.</span>
+                </div>
+                {% endif %}
+                {% if guild.discord_role_ids %}
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+                    <span>You get the guild's Discord role automatically.</span>
+                </div>
+                {% endif %}
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                    <span>See the guild's events, meetings, and calendar.</span>
+                </div>
+                {% if gallery_images %}
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+                    <span>Browse the guild's gallery.</span>
+                </div>
+                {% endif %}
+                {% if guild.wishlist or guild.donate_url %}
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+                    <span>See the guild's wishlist.</span>
+                </div>
+                {% endif %}
+                <div class="pl-benefit-row">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+                    <span>You're eligible to vote on guild funding.</span>
+                </div>
+            </div>
+            <form hx-post="{% url 'hub_guild_join' guild.pk %}" hx-target="#guild-join-cta" hx-swap="outerHTML"
+                  @htmx:after-request="if ($event.detail.successful) $dispatch('close-modal', 'join-guild')"
+                  style="margin-top:1.25rem;">
+                {% csrf_token %}
+                {% include "components/toggle.html" with field=join_form.send_welcome toggle_label="Email me the "|add:guild.name|add:" welcome guide" toggle_description="A warm welcome with everything your guild page can do." %}
+                <div class="pl-modal__actions" style="margin-top:1rem;">
+                    <button type="submit" class="pl-btn pl-btn--primary" style="flex:1;" hx-disabled-elt="this">Join {{ guild.name }}</button>
+                    <button type="button" class="pl-btn pl-btn--secondary" style="flex:1;" @click="$dispatch('close-modal', 'join-guild')">Not now</button>
+                </div>
+                <p class="hub-text-muted" style="font-size:0.85rem; margin:0.75rem 0 0;">You can leave any time.</p>
+            </form>
+        </div>
+    </div>
+</div>
+
+{% url 'hub_guild_leave' guild.pk as leave_guild_url %}
+{% include "components/confirm_modal.html" with confirm_id="leave-guild" confirm_title="Leave "|add:guild.name|add:"?" confirm_message="You'll stop getting this guild's updates, drop off its roster, and lose its Discord role. You can rejoin any time." confirm_button_text="Leave guild" confirm_button_style="danger" confirm_hx_post=leave_guild_url confirm_hx_target="#guild-join-cta" %}
+
+{% include "hub/partials/_guild_join_fab.html" %}
 {% endif %}
 
 </div>{# /x-data guildCart #}

--- a/templates/hub/guild_edit.html
+++ b/templates/hub/guild_edit.html
@@ -18,6 +18,7 @@
   <button type="button" class="vote-tab" :class="section === 'meeting_notes' ? 'vote-tab--active' : ''" @click="section = 'meeting_notes'">Meeting Notes</button>
   <button type="button" class="vote-tab" :class="section === 'events' ? 'vote-tab--active' : ''" @click="section = 'events'">Events</button>
   <button type="button" class="vote-tab" data-help-key="guild.run-orientations" :class="section === 'orientations' ? 'vote-tab--active' : ''" @click="section = 'orientations'">Orientations</button>
+  <button type="button" class="vote-tab" :class="section === 'welcome_email' ? 'vote-tab--active' : ''" @click="section = 'welcome_email'">Welcome Email</button>
   <button type="button" class="vote-tab" :class="section === 'images' ? 'vote-tab--active' : ''" @click="section = 'images'">Images</button>
   <button type="button" class="vote-tab" :class="section === 'content' ? 'vote-tab--active' : ''" @click="section = 'content'">FAQ &amp; Links</button>
   <button type="button" class="vote-tab" data-help-key="guild.announcements" :class="section === 'announcements' ? 'vote-tab--active' : ''" @click="section = 'announcements'">Announcements</button>
@@ -600,6 +601,37 @@ confirm modal carries its own POST form, and template content can't nest a form.
       </div>
     </div>
   </div>
+</div>
+
+{# ── Welcome Email — the join-lifecycle email; own form + endpoint (multi-form via form_id). ──── #}
+{# Immediate-effect controls (Preview + Send test) sit ABOVE the batch Save form so Save is the #}
+{# last thing on the tab with nothing under it (Rule 21). #}
+<div x-show="section === 'welcome_email'" x-cloak>
+  <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;">
+    <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Welcome Email</h2>
+    <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">Sent to a member when they deliberately join this guild (the Join This Guild button, or the Discord /join-guild command). On by default; leave the subject and body blank to send the standard welcome.</p>
+    <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
+      <button type="button" class="pl-btn pl-btn--secondary"
+              @click="$dispatch('open-modal', 'welcome-preview')"
+              hx-get="{% url 'hub_guild_welcome_preview' guild.pk %}"
+              hx-target="#welcome-preview-body" hx-swap="innerHTML">Preview</button>
+      <button type="button" class="pl-btn pl-btn--secondary"
+              hx-post="{% url 'hub_guild_welcome_test' guild.pk %}" hx-swap="none">Send test to me</button>
+    </div>
+  </div>
+
+  <form method="post" action="{% url 'hub_guild_emails_save' guild.pk %}" class="hub-form">
+    {% csrf_token %}
+    <input type="hidden" name="form_id" value="welcome_email">
+    <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;">
+      {% include "components/form_field.html" with field=welcome_email_form.welcome_email_enabled %}
+      {% include "components/form_field.html" with field=welcome_email_form.welcome_email_subject field_hint="Leave blank to use: Welcome to "|add:guild.name|add:"!" %}
+      {% include "components/form_field.html" with field=welcome_email_form.welcome_email_body field_hint="Your personal welcome note. Leave blank to use the standard welcome." %}
+      <button type="submit" class="pl-btn pl-btn--primary" style="margin-top:1rem;">Save</button>
+    </div>
+  </form>
+
+  {% include "components/modal.html" with modal_id="welcome-preview" modal_title="Welcome Email Preview" modal_size="lg" %}
 </div>
 
 {# ── FAQ & Links (each its own form, outside the main form — you can't nest forms) ──── #}

--- a/templates/hub/member_directory.html
+++ b/templates/hub/member_directory.html
@@ -1,5 +1,6 @@
 {% extends "hub/base.html" %}
 {% load hub_tags %}
+{% load static %}
 {% block title %}Member Directory{% endblock %}
 
 {% block content %}
@@ -22,6 +23,15 @@
                 {% endfor %}
             </optgroup>
             {% endif %}
+            {% endfor %}
+        </select>
+    </label>
+    <label class="pl-filter-field">
+        <span class="pl-filter-label">Guild</span>
+        <select name="guild" class="pl-filter-control" onchange="this.form.submit()">
+            <option value="">All guilds</option>
+            {% for g in guilds %}
+            <option value="{{ g.slug }}"{% if selected_guild and g.slug == selected_guild.slug %} selected{% endif %}>{{ g.name }}</option>
             {% endfor %}
         </select>
     </label>
@@ -172,7 +182,20 @@
         {% endwith %}
         {% endif %}
 
+        {% if member.directory_guild_memberships %}
+        <div class="pl-directory-guilds">
+            {% for gm in member.directory_guild_memberships %}
+            <a href="{% url 'hub_member_directory' %}?guild={{ gm.guild.slug }}" class="hub-badge pl-directory-guild">
+                {% if gm.guild.logo_prefix %}<img src="{% static 'img/guild_logos/'|add:gm.guild.logo_prefix|add:'_color.svg' %}" width="14" height="14" alt="">{% endif %}
+                {{ gm.guild.name }}
+            </a>
+            {% endfor %}
+        </div>
+        {% endif %}
+
     </div>
+    {% empty %}
+    <p class="hub-text-muted" style="grid-column:1 / -1;">No members match this filter.</p>
     {% endfor %}
 </div>
 {% endblock %}

--- a/templates/hub/partials/_guild_get_involved_status.html
+++ b/templates/hub/partials/_guild_get_involved_status.html
@@ -1,0 +1,12 @@
+{# The membership-status lines inside Get Involved. A member sees a quiet confirmation #}
+{# plus a plain link to channel prefs; a non-member sees nothing here (the hero Join owns #}
+{# that job now). Kept in an OOB-swappable wrapper so it flips with join/leave. #}
+<div id="guild-get-involved-status"{% if oob %} hx-swap-oob="true"{% endif %}>
+    {% if member and is_member_of_guild %}
+    <div class="hub-text-muted" style="display:flex; align-items:center; gap:0.4rem; font-size:0.9rem;">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+        You get this guild's updates
+    </div>
+    <a href="{% if is_guilds_surface %}{{ MEMBER_BASE_URL }}{% endif %}{% url 'hub_user_settings' %}?tab=guilds" class="pl-btn pl-btn--secondary" style="width:100%;" data-help-key="guild.join-leave"{% if is_guilds_surface %} hx-boost="false"{% endif %}>Manage in Settings</a>
+    {% endif %}
+</div>

--- a/templates/hub/partials/_guild_join_cta.html
+++ b/templates/hub/partials/_guild_join_cta.html
@@ -1,0 +1,30 @@
+{# Hero Join / Member CTA state machine. Primary HTMX swap target for join/leave. #}
+{# On those responses (oob) it also carries the OOB sibling fragments, so the sticky #}
+{# mini-CTA, member-count chip, roster card, and Get Involved status all stay in sync #}
+{# without a reload. Members surface only: joins happen on the hub, not the guest surface. #}
+<div id="guild-join-cta" class="pl-guild-cta">
+    {% if member and not is_guilds_surface %}
+        {% if is_member_of_guild %}
+        <div class="pl-guild-cta__member" x-data="{ menu: false }">
+            <span class="pl-btn pl-btn--secondary pl-guild-cta__badge">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+                Member
+            </span>
+            <button type="button" class="pl-btn pl-btn--secondary pl-guild-cta__overflow" @click="menu = !menu" @click.outside="menu = false" aria-haspopup="true" :aria-expanded="menu" aria-label="Guild membership options">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg>
+            </button>
+            <div class="pl-guild-cta__menu" x-show="menu" x-cloak @click="menu = false">
+                <button type="button" class="pl-guild-cta__menu-item" @click="$dispatch('open-confirm', 'leave-guild')">Leave guild</button>
+            </div>
+        </div>
+        {% else %}
+        <button type="button" class="pl-btn pl-btn--primary pl-guild-cta__join" @click="$dispatch('open-modal', 'join-guild')">Join This Guild</button>
+        {% endif %}
+    {% endif %}
+</div>
+{% if oob %}
+{% include "hub/partials/_guild_join_fab.html" with oob=True %}
+{% include "hub/partials/_guild_member_count.html" with oob=True %}
+{% include "hub/partials/_guild_roster_card.html" with oob=True %}
+{% include "hub/partials/_guild_get_involved_status.html" with oob=True %}
+{% endif %}

--- a/templates/hub/partials/_guild_join_fab.html
+++ b/templates/hub/partials/_guild_join_fab.html
@@ -1,0 +1,17 @@
+{# Sticky mini-CTA that follows the reader down long guild pages (clones .pl-scroll-top). #}
+{# Reveals past ~400px so it never covers the hero's own Join button. Mirrors the hero #}
+{# state: Join pill for a non-member, quiet Member pill for a member. Members surface only. #}
+<div id="guild-join-fab" class="pl-guild-join-fab"{% if oob %} hx-swap-oob="true"{% endif %}
+     x-data="{ show: false }" x-show="show" x-cloak
+     x-init="window.addEventListener('scroll', () => { show = window.scrollY > 400 }, { passive: true })">
+    {% if member and not is_guilds_surface %}
+        {% if is_member_of_guild %}
+        <span class="pl-guild-join-fab__pill pl-guild-join-fab__pill--member">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+            Member
+        </span>
+        {% else %}
+        <button type="button" class="pl-guild-join-fab__pill pl-guild-join-fab__pill--join" @click="$dispatch('open-modal', 'join-guild')">Join {{ guild.name }}</button>
+        {% endif %}
+    {% endif %}
+</div>

--- a/templates/hub/partials/_guild_member_count.html
+++ b/templates/hub/partials/_guild_member_count.html
@@ -1,0 +1,3 @@
+{# The "{n} members" hero stat chip. Always renders its wrapper span so the OOB swap #}
+{# after a join/leave always has a target, even when the guild had zero members. #}
+<span id="guild-member-count"{% if oob %} hx-swap-oob="true"{% endif %}>{% if member_count %}<span class="hub-badge">{{ member_count }} member{{ member_count|pluralize }}</span>{% endif %}</span>

--- a/templates/hub/partials/_guild_roster_card.html
+++ b/templates/hub/partials/_guild_roster_card.html
@@ -1,0 +1,17 @@
+{# The Members roster card. Wrapper always renders so the OOB swap after a join/leave #}
+{# always lands; the card itself appears once the guild opts in and has a roster. #}
+<div id="guild-roster-card"{% if oob %} hx-swap-oob="true"{% endif %}>
+    {% if user.is_authenticated and guild.show_members and roster %}
+    <div class="hub-card">
+        <h3 class="hub-detail-label">Members</h3>
+        <div class="pl-guild-roster">
+            {% for m in roster %}
+            <div class="hub-member-row">
+                <div class="hub-member-avatar">{{ m.display_name|make_list|first|upper }}</div>
+                <span class="hub-member-name">{{ m.display_name }}</span>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+</div>

--- a/templates/membership/emails/guild_welcome.html
+++ b/templates/membership/emails/guild_welcome.html
@@ -1,0 +1,30 @@
+{% extends "membership/emails/_base.html" %}
+{% load rich_text %}
+{% block content %}
+{% if banner_url %}
+<div style="margin: 0 0 24px; border-radius: 10px; overflow: hidden;">
+    <img src="{{ banner_url }}" width="100%" alt="{{ guild.name }}" style="display: block; width: 100%; max-width: 100%; height: auto; border-radius: 10px;">
+</div>
+{% else %}
+<div style="margin: 0 0 24px; border-radius: 10px; background: linear-gradient(135deg, #092E4C, #0d4876); padding: 28px 20px; text-align: center;">
+    <span style="font-size: 18px; font-weight: 700; color: #FFFFFF; letter-spacing: 0.02em;">{{ guild.name }}</span>
+</div>
+{% endif %}
+<p style="margin: 0 0 8px; font-size: 14px; color: #55697a;">Hi {{ greeting_name }},</p>
+<p style="margin: 0 0 16px; font-size: 18px; font-weight: 700; color: #33424f;">Welcome to <a href="{{ guild_url }}" style="color: #0d4876; text-decoration: none;">{{ guild.name }}</a>!</p>
+<div style="font-size: 14px; color: #33424f; line-height: 1.7;">{{ body|rich_email_body }}</div>
+<div style="margin: 28px 0 0; padding: 20px 22px; background-color: #eef4f9; border-radius: 10px;">
+    <p style="margin: 0 0 12px; font-size: 12px; font-weight: 700; color: #0d4876; text-transform: uppercase; letter-spacing: 0.08em;">What You Can Do On Your Guild Page</p>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="font-size: 14px; color: #33424f; line-height: 1.6;">
+        <tr><td style="padding: 3px 0;">Read the guild's announcements</td></tr>
+        <tr><td style="padding: 3px 0;">Book an orientation</td></tr>
+        <tr><td style="padding: 3px 0;">See meetings and the calendar</td></tr>
+        <tr><td style="padding: 3px 0;">Meet the roster</td></tr>
+        <tr><td style="padding: 3px 0;">Check the wishlist</td></tr>
+    </table>
+</div>
+<p style="margin: 20px 0 0; font-size: 14px; color: #55697a;">New here? Read the <a href="{{ help_url }}" style="color: #0d4876;">quick guide to your guild page</a>.</p>
+<div style="text-align: center; margin: 28px 0 0;">
+    <a href="{{ guild_url }}" style="display: inline-block; padding: 12px 32px; background-color: #0d4876; color: #FFFFFF; font-size: 14px; font-weight: 700; text-decoration: none; border-radius: 6px;">View Guild Page</a>
+</div>
+{% endblock %}

--- a/templates/membership/emails/guild_welcome.txt
+++ b/templates/membership/emails/guild_welcome.txt
@@ -1,0 +1,18 @@
+{% load rich_text %}Hi {{ greeting_name }},
+
+Welcome to {{ guild.name }}!
+
+{{ body|rich_email_text }}
+
+What you can do on your guild page:
+-> Read the guild's announcements
+-> Book an orientation
+-> See meetings and the calendar
+-> Meet the roster
+-> Check the wishlist
+
+New here? Read the quick guide to your guild page: {{ help_url }}
+
+View guild page: {{ guild_url }}
+
+{% include "membership/emails/_footer.txt" %}

--- a/tests/core/email_gallery_completeness_spec.py
+++ b/tests/core/email_gallery_completeness_spec.py
@@ -44,6 +44,7 @@ EXPECTED_PAIRS = {
     "orientation_cancelled",
     "orientation_lead_request",
     "orientation_thankyou",
+    "guild_welcome",
     # billing
     "charge_failed_admin",
     "receipt",
@@ -64,10 +65,10 @@ def describe_email_gallery_completeness():
             "on copy-review.pastlives.space."
         )
 
-    def it_discovers_the_expected_25_pairs():
+    def it_discovers_the_expected_26_pairs():
         """Pins the discovery rule so it never silently sweeps in (or drops) templates."""
         assert discover_template_pairs() == EXPECTED_PAIRS
-        assert len(EXPECTED_PAIRS) == 25
+        assert len(EXPECTED_PAIRS) == 26
 
     def it_excludes_shells_and_partials():
         discovered = discover_template_pairs()

--- a/tests/core/events/registry_spec.py
+++ b/tests/core/events/registry_spec.py
@@ -52,6 +52,7 @@ _BRAND_NEW_KEYS = {
     "waitlist_promoted",
     "waitlist_promoted_pay",
     "registration_removed",
+    "guild_welcome",
 }
 
 
@@ -89,6 +90,7 @@ def describe_event_registry():
                 "member.invited",
                 "member.login_invite",
                 "discord_guilds_imported",
+                "guild_welcome",
                 "voting.discord_reminder",
                 "voting.results_discord",
             }

--- a/tests/e2e/email_gallery/context.py
+++ b/tests/e2e/email_gallery/context.py
@@ -531,6 +531,24 @@ def discord_guilds_imported_context(data: SampleData) -> dict[str, Any]:
     }
 
 
+def guild_welcome_context(data: SampleData) -> dict[str, Any]:
+    """Mirrors ``membership.orientations.send_guild_welcome``.
+
+    The sample guild leaves the welcome copy blank, so this renders the STANDARD welcome
+    (the on-by-default copy) via the resolved_* fallbacks — what most members receive.
+    """
+    from membership.models import GuildOrientationSettings
+    from membership.orientations import _guild_welcome_context
+
+    settings_obj, _created = GuildOrientationSettings.objects.get_or_create(guild=data.guild)
+    return {
+        "subject": settings_obj.welcome_email_subject_resolved,
+        "template_context": _guild_welcome_context(
+            data.guild, data.member.display_name, settings_obj.welcome_email_body_resolved
+        ),
+    }
+
+
 # --- Billing --------------------------------------------------------------------
 
 

--- a/tests/e2e/email_gallery/registry.py
+++ b/tests/e2e/email_gallery/registry.py
@@ -483,6 +483,27 @@ STRUCTURAL_EMAILS: list[GalleryEmail] = [
         html_template="membership/emails/discord_guilds_imported.html",
         context_builder="discord_guilds_imported_context",
     ),
+    GalleryEmail(
+        key="guild_welcome",
+        name="Guild welcome (member joined)",
+        section="Guilds & Orientations",
+        renderer=Renderer.SHELL_TEMPLATE,
+        trigger_note=(
+            "Sent when a member deliberately joins a guild (the Join This Guild button with the "
+            "welcome box checked, or the Discord /join-guild command). ON by default: every guild "
+            "sends it unless they turn it off. This card shows the standard copy; a guild may write "
+            "its own subject and body to override it. Goes to the member who just joined."
+        ),
+        edit_pointer=(
+            "Guild-authored (guild editor → Welcome Email tab); "
+            "shell in templates/membership/emails/guild_welcome.{txt,html}"
+        ),
+        audience="The member who just joined the guild.",
+        event_keys=frozenset({"guild_welcome"}),
+        text_template="membership/emails/guild_welcome.txt",
+        html_template="membership/emails/guild_welcome.html",
+        context_builder="guild_welcome_context",
+    ),
     # --- Billing ---------------------------------------------------------------
     GalleryEmail(
         key="receipt",

--- a/tests/hub/discord_commands_spec.py
+++ b/tests/hub/discord_commands_spec.py
@@ -16,13 +16,20 @@ from unittest import mock
 import httpx
 import pytest
 import respx
+from django.contrib.auth.models import User
+from django.core import mail
 
 from core.events import discord as discord_module
 from core.events import discord_roles
 from hub.discord_commands import JOIN_GUILD, _guild_choices, _join_guild, _welcome_body
 from membership import orientations
 from membership.models import GuildMembership
-from tests.membership.factories import GuildFactory, MemberFactory
+from tests.membership.factories import (
+    GuildFactory,
+    GuildOrientationSettingsFactory,
+    MemberFactory,
+    MembershipPlanFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -92,6 +99,31 @@ def describe_join_guild_handler():
             assert result["data"]["flags"] == 64
             assert "You now follow **Forge**" in result["data"]["content"]
             assert "From the lead!" in result["data"]["content"]
+
+    def describe_the_member_welcome_email():
+        def _linked_member(username: str, discord_id: str) -> object:
+            MembershipPlanFactory()
+            user = User.objects.create_user(username=username, password="pw", email=f"{username}@example.com")
+            member = user.member
+            member.discord_user_id = discord_id
+            member.save(update_fields=["discord_user_id"])
+            return member
+
+        def it_sends_the_welcome_on_a_brand_new_join(spies):
+            member = _linked_member("dcw1", "901")
+            guild = GuildFactory(discord_webhook_url=_WEBHOOK)
+            GuildOrientationSettingsFactory(guild=guild)
+            _join_guild(_interaction(guild.slug), member)
+            assert len(mail.outbox) == 1
+            assert mail.outbox[0].to == [member.primary_email]
+
+        def it_does_not_welcome_on_an_upgraded_reaction_join(spies):
+            member = _linked_member("dcw2", "902")
+            guild = GuildFactory(discord_webhook_url=_WEBHOOK)
+            GuildOrientationSettingsFactory(guild=guild)
+            GuildMembership.objects.record_discord_join(guild, member)
+            _join_guild(_interaction(guild.slug), member)
+            assert mail.outbox == []
 
     def describe_welcome_copy():
         def it_uses_the_generic_fallback_when_blank(spies):

--- a/tests/hub/guild_guest_surface_spec.py
+++ b/tests/hub/guild_guest_surface_spec.py
@@ -166,15 +166,18 @@ def describe_guest_guild_page():
             guild = GuildFactory(name="Join Guild")
             body = _guest_get(client, guild).content.decode()
             assert "Log in to the members hub" in body
-            assert "Join This Guild" not in body
+            # Assert the hero-join element's absence by its class, not the bare label
+            # (the release-notes changelog renders "Join This Guild" into every page).
+            assert "pl-guild-cta__join" not in body
 
-        def it_points_a_logged_in_non_subscriber_at_settings_instead_of_a_join_form(client: Client):
+        def it_hides_the_hero_join_button_on_the_guest_surface(client: Client):
+            # Joins happen on the members hub, so the guest surface never shows the hero Join
+            # (the is_guilds_surface gate) nor the old "Want announcements" settings pointer.
             guild = GuildFactory(name="Join Guild")
             _login_member(client)
             body = _guest_get(client, guild).content.decode()
-            assert "Want announcements from this guild?" in body
-            assert "?tab=guilds" in body
-            assert "Join This Guild" not in body
+            assert "pl-guild-cta__join" not in body
+            assert "Want announcements from this guild?" not in body
             assert "Log in to the members hub" not in body
 
         def it_shows_the_updates_line_and_no_leave_button_to_a_subscriber(client: Client):

--- a/tests/hub/guild_join_view_spec.py
+++ b/tests/hub/guild_join_view_spec.py
@@ -1,0 +1,142 @@
+"""BDD specs for the hero Join / Leave guild views (HTMX front door).
+
+Join is the one deliberate web join path: it records the subscription and, only when the
+member left the modal's welcome box checked, sends the guild's welcome email once. Leave
+removes the subscription. Both return the flipped CTA partial plus a toast.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth.models import User
+from django.core import mail
+from django.test import Client
+from django.urls import reverse
+
+from core.models import Notification
+from membership.models import GuildMembership, Member
+from tests.membership.factories import (
+    GuildFactory,
+    GuildOrientationSettingsFactory,
+    MembershipPlanFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _linked_user(username: str) -> User:
+    MembershipPlanFactory()
+    return User.objects.create_user(username=username, password="pw", email=f"{username}@example.com")
+
+
+def _toast(response: object) -> dict:
+    return json.loads(response["HX-Trigger"])["showToast"]
+
+
+def describe_guild_join():
+    def it_joins_and_sends_the_welcome_when_the_box_is_checked(client: Client):
+        user = _linked_user("joiner")
+        guild = GuildFactory(name="Wood Guild")
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="joiner", password="pw")
+
+        response = client.post(reverse("hub_guild_join", args=[guild.pk]), {"send_welcome": "on"})
+
+        assert response.status_code == 200
+        assert GuildMembership.objects.filter(guild=guild, member=user.member).exists()
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [user.member.primary_email]
+        assert b"Member" in response.content
+        assert _toast(response)["type"] == "success"
+
+    def it_joins_without_a_welcome_when_the_box_is_unchecked(client: Client):
+        user = _linked_user("joiner2")
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="joiner2", password="pw")
+
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {})
+
+        assert GuildMembership.objects.filter(guild=guild, member=user.member).exists()
+        assert mail.outbox == []
+
+    def it_sends_no_welcome_when_the_guild_disabled_it(client: Client):
+        _linked_user("joiner3")
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild, welcome_email_enabled=False)
+        client.login(username="joiner3", password="pw")
+
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {"send_welcome": "on"})
+
+        assert mail.outbox == []
+
+    def it_fires_the_lead_new_follower_notice_on_join(client: Client):
+        lead = _linked_user("lead_notice").member
+        guild = GuildFactory(guild_lead=lead)
+        GuildOrientationSettingsFactory(guild=guild)
+        _linked_user("joiner4")
+        client.login(username="joiner4", password="pw")
+
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {"send_welcome": "on"})
+
+        assert Notification.objects.filter(user=lead.user, trigger="guild_joined").exists()
+
+    def it_does_not_re_send_on_a_repeat_join(client: Client):
+        _linked_user("joiner5")
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="joiner5", password="pw")
+
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {"send_welcome": "on"})
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {"send_welcome": "on"})
+
+        assert len(mail.outbox) == 1
+
+    def it_guards_an_account_with_no_member(client: Client):
+        MembershipPlanFactory()
+        user = User.objects.create_user(username="nomem", password="pw")
+        Member.objects.filter(user=user).delete()
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="nomem", password="pw")
+
+        response = client.post(reverse("hub_guild_join", args=[guild.pk]), {"send_welcome": "on"})
+
+        assert response.status_code == 204
+        assert _toast(response)["type"] == "error"
+        assert not GuildMembership.objects.filter(guild=guild).exists()
+        assert mail.outbox == []
+
+    def it_requires_login(client: Client):
+        guild = GuildFactory()
+        response = client.post(reverse("hub_guild_join", args=[guild.pk]))
+        assert response.status_code == 302
+
+
+def describe_guild_leave():
+    def it_leaves_and_returns_the_join_state(client: Client):
+        user = _linked_user("leaver")
+        guild = GuildFactory()
+        GuildMembership.objects.create(guild=guild, member=user.member)
+        client.login(username="leaver", password="pw")
+
+        response = client.post(reverse("hub_guild_leave", args=[guild.pk]))
+
+        assert response.status_code == 200
+        assert not GuildMembership.objects.filter(guild=guild, member=user.member).exists()
+        assert b"Join This Guild" in response.content
+        assert _toast(response)["type"] == "info"
+
+    def it_guards_an_account_with_no_member(client: Client):
+        MembershipPlanFactory()
+        user = User.objects.create_user(username="nomem2", password="pw")
+        Member.objects.filter(user=user).delete()
+        guild = GuildFactory()
+        client.login(username="nomem2", password="pw")
+
+        response = client.post(reverse("hub_guild_leave", args=[guild.pk]))
+
+        assert response.status_code == 204
+        assert _toast(response)["type"] == "error"

--- a/tests/hub/guild_pages_spec.py
+++ b/tests/hub/guild_pages_spec.py
@@ -91,18 +91,19 @@ def describe_guild_detail():
             assert response.context["tab"] is None
 
     def describe_get_involved_subscription_states():
-        def it_never_shows_a_join_button(client: Client):
+        def it_shows_the_join_button_to_a_non_member(client: Client):
             guild = GuildFactory()
             _linked_user(client)
             response = client.get(f"/guilds/{guild.slug}/")
-            assert b"Join This Guild" not in response.content
+            assert b"Join This Guild" in response.content
 
-        def it_points_an_unsubscribed_member_at_the_settings_guilds_tab(client: Client):
+        def it_drops_the_old_settings_pointer_copy_for_a_non_member(client: Client):
+            # The hero Join now owns "how do I get updates," so the Get Involved panel no
+            # longer nags a non-member with the "Want announcements ... Settings" paragraph.
             guild = GuildFactory()
             _linked_user(client)
             response = client.get(f"/guilds/{guild.slug}/")
-            assert b"Want announcements from this guild?" in response.content
-            assert b"?tab=guilds" in response.content
+            assert b"Want announcements from this guild?" not in response.content
 
         def it_shows_the_updates_line_and_manage_link_to_a_subscriber(client: Client):
             from membership.models import GuildMembership
@@ -123,7 +124,9 @@ def describe_guild_detail():
             Member.objects.filter(user=user).delete()
             client.login(username="unlinked_join", password="pass")
             response = client.get(f"/guilds/{guild.slug}/")
-            assert b"Join This Guild" not in response.content
+            # Assert absence by the button class, not the bare label (the changelog text
+            # "Join This Guild" renders into every page's context).
+            assert b"pl-guild-cta__join" not in response.content
             assert b"Want announcements from this guild?" not in response.content
 
     def describe_stat_chips():
@@ -150,11 +153,11 @@ def describe_guild_detail():
             user, _ = _linked_user(client)
             GuildMembership.objects.create(guild=guild, member=user.member)
             response = client.get(f"/guilds/{guild.slug}/")
-            from django.urls import reverse
-
             html = response.content.decode()
             assert '<span class="hub-badge">1 member</span>' in html
-            assert f"{reverse('hub_member_directory')}?guild=" not in html
+            # The count chip is plain text, not a link (the directory ?guild= link that now
+            # appears elsewhere on the page is the join modal's "your profile" benefit row).
+            assert "1 member</a>" not in html
 
     def describe_faq_tab():
         def it_shows_a_faq_tab_when_the_guild_has_faqs(client: Client):

--- a/tests/hub/guild_roster_spec.py
+++ b/tests/hub/guild_roster_spec.py
@@ -6,7 +6,7 @@ import pytest
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
-from django.urls import NoReverseMatch, reverse
+from django.urls import reverse
 
 from membership.models import GuildImage, GuildMembership, Member
 from tests.membership.factories import GuildFactory, MembershipPlanFactory
@@ -42,10 +42,10 @@ def describe_subscribe_unsubscribe():
         client.post(reverse("hub_guild_membership_set", args=[guild.pk]))
         assert not GuildMembership.objects.filter(guild=guild, member__user=user).exists()
 
-    def it_no_longer_routes_the_removed_join_and_leave_urls():
+    def it_routes_the_revived_join_and_leave_urls():
+        # Revived with the "Join This Guild" front door (they were briefly removed).
         for name in ("hub_guild_join", "hub_guild_leave"):
-            with pytest.raises(NoReverseMatch):
-                reverse(name, args=[1])
+            assert reverse(name, args=[1]) != ""
 
 
 @pytest.mark.django_db

--- a/tests/hub/guild_welcome_editor_spec.py
+++ b/tests/hub/guild_welcome_editor_spec.py
@@ -1,0 +1,214 @@
+"""BDD specs for the guild welcome-email editor (Welcome Email tab).
+
+The welcome email is the join-lifecycle email; its editor lives on its own Welcome Email
+tab of the guild editor as a card + form (hidden ``form_id="welcome_email"``), posting to
+the shared ``guild_emails_save`` view. Save, Preview, and Send-test are all covered here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth.models import User
+from django.core import mail
+from django.test import Client
+from django.urls import reverse
+
+from hub.forms import GuildWelcomeEmailForm
+from membership.models import GuildOrientationSettings, Member
+from tests.membership.factories import (
+    GuildFactory,
+    GuildOrientationSettingsFactory,
+    MembershipPlanFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _user_with_role(username: str, *, fog_role: str = Member.FogRole.MEMBER) -> User:
+    MembershipPlanFactory()
+    user = User.objects.create_user(username=username, password="pass", email=f"{username}@example.com")
+    member = user.member
+    member.fog_role = fog_role
+    member.save(update_fields=["fog_role"])
+    member.sync_user_permissions()
+    return user
+
+
+def _form_data_from(instance: GuildOrientationSettings, **overrides: object) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for name in GuildWelcomeEmailForm.Meta.fields:
+        value = getattr(instance, name)
+        if isinstance(value, bool):
+            if value:
+                data[name] = "on"
+        else:
+            data[name] = "" if value is None else str(value)
+    for name, value in overrides.items():
+        if value is None:
+            data.pop(name, None)
+        else:
+            data[name] = str(value)
+    return data
+
+
+def describe_GuildWelcomeEmailForm():
+    def it_stamps_updated_at_when_a_welcome_field_changes():
+        settings_obj = GuildOrientationSettingsFactory()
+        form = GuildWelcomeEmailForm(
+            data=_form_data_from(settings_obj, welcome_email_subject="Hey!", welcome_email_body="Come in."),
+            instance=settings_obj,
+        )
+        assert form.is_valid(), form.errors
+        saved = form.save()
+        assert saved.welcome_email_updated_at is not None
+
+    def it_stamps_nothing_when_nothing_changes():
+        settings_obj = GuildOrientationSettingsFactory()
+        form = GuildWelcomeEmailForm(data=_form_data_from(settings_obj), instance=settings_obj)
+        assert form.is_valid(), form.errors
+        saved = form.save()
+        assert saved.welcome_email_updated_at is None
+
+    def it_allows_enabling_with_no_subject_or_body():
+        settings_obj = GuildOrientationSettingsFactory()
+        form = GuildWelcomeEmailForm(
+            data=_form_data_from(
+                settings_obj, welcome_email_enabled="on", welcome_email_subject="", welcome_email_body=""
+            ),
+            instance=settings_obj,
+        )
+        assert form.is_valid(), form.errors
+        saved = form.save()
+        assert saved.welcome_email_enabled is True
+
+    def it_sanitizes_the_body_and_strips_script():
+        settings_obj = GuildOrientationSettingsFactory()
+        form = GuildWelcomeEmailForm(
+            data=_form_data_from(settings_obj, welcome_email_body="<p>Hi!</p><script>a()</script>"),
+            instance=settings_obj,
+        )
+        assert form.is_valid(), form.errors
+        assert "<script" not in form.cleaned_data["welcome_email_body"]
+        assert "Hi!" in form.cleaned_data["welcome_email_body"]
+
+    def it_rejects_an_over_length_subject():
+        settings_obj = GuildOrientationSettingsFactory()
+        form = GuildWelcomeEmailForm(
+            data=_form_data_from(settings_obj, welcome_email_subject="x" * 201),
+            instance=settings_obj,
+        )
+        assert not form.is_valid()
+        assert "welcome_email_subject" in form.errors
+
+
+def describe_guild_emails_save_welcome_branch():
+    def it_saves_the_welcome_email_and_redirects_to_the_welcome_tab(client: Client):
+        _user_with_role("we_save", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory()
+        client.login(username="we_save", password="pass")
+        response = client.post(
+            reverse("hub_guild_emails_save", args=[guild.pk]),
+            {
+                "form_id": "welcome_email",
+                "welcome_email_enabled": "on",
+                "welcome_email_subject": "Welcome aboard",
+                "welcome_email_body": "Glad you joined.",
+            },
+        )
+        assert response.status_code == 302
+        assert response["Location"] == f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=welcome_email"
+        settings_obj = GuildOrientationSettings.objects.get(guild=guild)
+        assert settings_obj.welcome_email_subject == "Welcome aboard"
+        assert settings_obj.welcome_email_updated_at is not None
+
+    def it_re_renders_on_the_welcome_tab_when_invalid(client: Client):
+        _user_with_role("we_invalid", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory()
+        client.login(username="we_invalid", password="pass")
+        response = client.post(
+            reverse("hub_guild_emails_save", args=[guild.pk]),
+            {"form_id": "welcome_email", "welcome_email_subject": "x" * 201},
+        )
+        assert response.status_code == 200
+        assert response.context["active_tab"] == "welcome_email"
+        assert response.context["welcome_email_form"].errors
+
+    def it_lets_the_guild_lead_save(client: Client):
+        user = _user_with_role("we_lead", fog_role=Member.FogRole.MEMBER)
+        guild = GuildFactory(guild_lead=user.member)
+        client.login(username="we_lead", password="pass")
+        response = client.post(
+            reverse("hub_guild_emails_save", args=[guild.pk]),
+            {"form_id": "welcome_email", "welcome_email_enabled": "on"},
+        )
+        assert response.status_code == 302
+        assert GuildOrientationSettings.objects.get(guild=guild).welcome_email_enabled is True
+
+    def it_forbids_a_regular_member(client: Client):
+        _user_with_role("we_reg", fog_role=Member.FogRole.MEMBER)
+        guild = GuildFactory()
+        client.login(username="we_reg", password="pass")
+        response = client.post(reverse("hub_guild_emails_save", args=[guild.pk]), {"form_id": "welcome_email"})
+        assert response.status_code == 403
+
+    def it_renders_the_welcome_tab_on_the_editor(client: Client):
+        _user_with_role("we_tab", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory()
+        client.login(username="we_tab", password="pass")
+        response = client.get(reverse("hub_guild_edit", args=[guild.pk]))
+        assert b"Welcome Email" in response.content
+        assert b'value="welcome_email"' in response.content
+
+
+def describe_guild_welcome_test():
+    def it_sends_a_test_to_the_editing_lead(client: Client):
+        user = _user_with_role("wt_lead", fog_role=Member.FogRole.MEMBER)
+        guild = GuildFactory(guild_lead=user.member)
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="wt_lead", password="pass")
+        response = client.post(reverse("hub_guild_welcome_test", args=[guild.pk]))
+        assert response.status_code == 204
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [user.member.primary_email]
+        assert "Test sent" in json.loads(response["HX-Trigger"])["showToast"]["message"]
+
+    def it_forbids_a_regular_member(client: Client):
+        _user_with_role("wt_reg", fog_role=Member.FogRole.MEMBER)
+        guild = GuildFactory()
+        client.login(username="wt_reg", password="pass")
+        response = client.post(reverse("hub_guild_welcome_test", args=[guild.pk]))
+        assert response.status_code == 403
+        assert mail.outbox == []
+
+    def it_reports_an_unlinked_editor_without_sending(client: Client):
+        # An admin (passes the edit gate via is_staff) whose account has no linked Member:
+        # the test-send bails with an error toast, sends nothing.
+        user = _user_with_role("wt_unlinked", fog_role=Member.FogRole.ADMIN)
+        Member.objects.filter(user=user).delete()
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="wt_unlinked", password="pass")
+        response = client.post(reverse("hub_guild_welcome_test", args=[guild.pk]))
+        assert response.status_code == 204
+        assert mail.outbox == []
+        assert "not linked" in json.loads(response["HX-Trigger"])["showToast"]["message"]
+
+
+def describe_guild_welcome_preview():
+    def it_renders_the_preview_without_sending(client: Client):
+        _user_with_role("wp_lead", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory(name="Preview Guild")
+        client.login(username="wp_lead", password="pass")
+        response = client.get(reverse("hub_guild_welcome_preview", args=[guild.pk]))
+        assert response.status_code == 200
+        assert b"Preview Guild" in response.content
+        assert mail.outbox == []
+
+    def it_forbids_a_regular_member(client: Client):
+        _user_with_role("wp_reg", fog_role=Member.FogRole.MEMBER)
+        guild = GuildFactory()
+        client.login(username="wp_reg", password="pass")
+        response = client.get(reverse("hub_guild_welcome_preview", args=[guild.pk]))
+        assert response.status_code == 403

--- a/tests/hub/member_directory_guilds_spec.py
+++ b/tests/hub/member_directory_guilds_spec.py
@@ -1,15 +1,17 @@
-"""Member directory: guild affiliation is fully removed (no badges, no filter).
+"""Member directory: guild affiliation badges + guild filter (revived with Join This Guild).
 
-Guild subscriptions are a notification preference, not a public affiliation — the
-directory shows no guild names, offers no guild filter, and quietly ignores stale
-bookmarked ``?guild=NN`` URLs.
+A member's joined guilds are shown as badges on their directory card, and a guild filter
+dropdown narrows the grid to one guild's members. Badges cover only active guilds, respect
+directory privacy, and are N+1 free. An unknown or stale ``?guild=`` value is ignored.
 """
 
 from __future__ import annotations
 
 import pytest
 from django.contrib.auth.models import User
+from django.db import connection
 from django.test import Client
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from membership.models import GuildMembership, Member
@@ -28,36 +30,93 @@ def _admin(username: str) -> User:
 
 @pytest.mark.django_db
 def describe_member_directory_guilds():
-    def it_shows_no_guild_badges_on_cards(client: Client):
+    def it_shows_a_guild_badge_on_a_members_card(client: Client):
         _admin("md1")
         client.login(username="md1", password="pw")
-        # Inactive guild → the sidebar never names it, so any appearance would be the badge.
-        guild = GuildFactory(name="Forge Guild", is_active=False)
+        guild = GuildFactory(name="Forge Guild", is_active=True)
         GuildMembership.objects.create(guild=guild, member=MemberFactory(full_legal_name="Ada Smith"))
         resp = client.get(reverse("hub_member_directory"))
         assert b"Ada Smith" in resp.content
-        assert b"Forge Guild" not in resp.content
-        assert b"directory-card__guilds" not in resp.content
+        assert b"Forge Guild" in resp.content
+        assert b"pl-directory-guild" in resp.content
 
-    def it_offers_no_guild_filter_dropdown(client: Client):
+    def it_links_a_badge_to_the_guild_filter(client: Client):
+        _admin("md1b")
+        client.login(username="md1b", password="pw")
+        guild = GuildFactory(name="Forge Guild", is_active=True)
+        GuildMembership.objects.create(guild=guild, member=MemberFactory(full_legal_name="Ada Smith"))
+        resp = client.get(reverse("hub_member_directory"))
+        assert f"?guild={guild.slug}".encode() in resp.content
+
+    def it_hides_badges_for_inactive_guilds(client: Client):
+        _admin("md1c")
+        client.login(username="md1c", password="pw")
+        guild = GuildFactory(name="Ghost Guild", is_active=False)
+        GuildMembership.objects.create(guild=guild, member=MemberFactory(full_legal_name="Ada Smith"))
+        resp = client.get(reverse("hub_member_directory"))
+        assert b"Ada Smith" in resp.content
+        assert b"Ghost Guild" not in resp.content
+
+    def it_offers_a_guild_filter_dropdown(client: Client):
         _admin("md2")
         client.login(username="md2", password="pw")
-        GuildFactory(name="Alpha Guild")
+        GuildFactory(name="Alpha Guild", is_active=True)
         resp = client.get(reverse("hub_member_directory"))
-        assert b'name="guild"' not in resp.content
-        assert b"All guilds" not in resp.content
-        # The view no longer supplies the filter context (the sidebar's own guild
-        # nav list is a different, page-chrome key).
-        assert "guild_filter" not in resp.context
+        assert b'name="guild"' in resp.content
+        assert b"All guilds" in resp.content
+        assert b"Alpha Guild" in resp.content
 
-    def it_ignores_a_stale_guild_query_param(client: Client):
+    def it_filters_members_to_the_selected_guild(client: Client):
         _admin("md3")
         client.login(username="md3", password="pw")
-        alpha = GuildFactory(name="Alpha Guild")
-        beta = GuildFactory(name="Beta Guild")
+        alpha = GuildFactory(name="Alpha Guild", is_active=True)
+        beta = GuildFactory(name="Beta Guild", is_active=True)
+        GuildMembership.objects.create(guild=alpha, member=MemberFactory(full_legal_name="Member InA"))
+        GuildMembership.objects.create(guild=beta, member=MemberFactory(full_legal_name="Member InB"))
+        resp = client.get(reverse("hub_member_directory"), {"guild": alpha.slug})
+        assert b"Member InA" in resp.content
+        assert b"Member InB" not in resp.content
+        assert resp.context["selected_guild"] == alpha
+
+    def it_ignores_an_unknown_guild_slug(client: Client):
+        _admin("md4")
+        client.login(username="md4", password="pw")
+        alpha = GuildFactory(name="Alpha Guild", is_active=True)
+        GuildMembership.objects.create(guild=alpha, member=MemberFactory(full_legal_name="Member InA"))
+        resp = client.get(reverse("hub_member_directory"), {"guild": "does-not-exist"})
+        assert b"Member InA" in resp.content
+        assert resp.context["selected_guild"] is None
+
+    def it_ignores_a_stale_numeric_guild_param(client: Client):
+        _admin("md5")
+        client.login(username="md5", password="pw")
+        alpha = GuildFactory(name="Alpha Guild", is_active=True)
+        beta = GuildFactory(name="Beta Guild", is_active=True)
         GuildMembership.objects.create(guild=alpha, member=MemberFactory(full_legal_name="Member InA"))
         GuildMembership.objects.create(guild=beta, member=MemberFactory(full_legal_name="Member InB"))
         resp = client.get(reverse("hub_member_directory"), {"guild": alpha.pk})
-        # The stale param filters nothing — the full directory renders.
         assert b"Member InA" in resp.content
         assert b"Member InB" in resp.content
+
+    def it_shows_the_empty_state_when_no_member_matches(client: Client):
+        _admin("md6")
+        client.login(username="md6", password="pw")
+        empty_guild = GuildFactory(name="Lonely Guild", is_active=True)
+        resp = client.get(reverse("hub_member_directory"), {"guild": empty_guild.slug})
+        assert b"No members match this filter." in resp.content
+
+    def it_renders_badges_without_n_plus_1(client: Client):
+        # The badges must come from ONE prefetch query, not one lookup per card: with 20
+        # guild-affiliated members, a per-card N+1 would fire ~20 GuildMembership selects.
+        _admin("mdn")
+        client.login(username="mdn", password="pw")
+        g1 = GuildFactory(name="G One", is_active=True)
+        g2 = GuildFactory(name="G Two", is_active=True)
+        for i in range(20):
+            member = MemberFactory(full_legal_name=f"Person {i}")
+            GuildMembership.objects.create(guild=g1, member=member)
+            GuildMembership.objects.create(guild=g2, member=member)
+        with CaptureQueriesContext(connection) as captured:
+            client.get(reverse("hub_member_directory"))
+        membership_queries = [q for q in captured.captured_queries if "guildmembership" in q["sql"].lower()]
+        assert len(membership_queries) <= 2

--- a/tests/hub/my_guilds_spec.py
+++ b/tests/hub/my_guilds_spec.py
@@ -322,10 +322,13 @@ def describe_guild_detail_subscription_touch():
         assert reverse("hub_user_settings") + "?tab=guilds" in html
         assert "Manage in Settings" in html
 
-    def it_points_a_non_subscriber_at_settings_instead_of_a_join_button(client: Client):
+    def it_shows_a_non_member_the_hero_join_button(client: Client):
+        # A linked member who has not joined this guild now gets the hero Join button
+        # (asserted by its class, since the changelog text renders "Join This Guild" into
+        # every page); the member-only updates confirmation stays hidden until they join.
         _linked_user(client)
         guild = GuildFactory()
         html = client.get(reverse("hub_guild_detail", args=[guild.slug])).content.decode()
-        assert "Join This Guild" not in html
-        assert "Want announcements from this guild?" in html
-        assert reverse("hub_user_settings") + "?tab=guilds" in html
+        assert "pl-guild-cta__join" in html
+        # The joined-state "Member" badge stays absent until they actually join.
+        assert "pl-guild-cta__badge" not in html

--- a/tests/membership/guild_welcome_spec.py
+++ b/tests/membership/guild_welcome_spec.py
@@ -1,0 +1,203 @@
+"""BDD specs for the per-guild join welcome email (send path, model copy, silent join paths)."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.core import mail
+
+from core.models import Notification, TransactionalEmailLog
+from membership import orientations
+from membership.guild_welcome_copy import STANDARD_WELCOME_BODY, standard_welcome_subject
+from membership.models import GuildMembership, GuildOrientationSettings
+from tests.membership.factories import (
+    GuildFactory,
+    GuildOrientationSettingsFactory,
+    MembershipPlanFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _member(username: str = "welcome_member") -> object:
+    MembershipPlanFactory()
+    return User.objects.create_user(username=username, email=f"{username}@example.com").member
+
+
+def describe_GuildOrientationSettings_welcome_copy():
+    def it_returns_the_lead_override_when_set():
+        guild = GuildFactory(name="Metal Guild")
+        settings_obj = GuildOrientationSettingsFactory(
+            guild=guild,
+            welcome_email_subject="Hey there!",
+            welcome_email_body="Custom note.",
+        )
+        assert settings_obj.welcome_email_subject_resolved == "Hey there!"
+        assert settings_obj.welcome_email_body_resolved == "Custom note."
+
+    def it_falls_back_to_the_standard_copy_when_blank():
+        guild = GuildFactory(name="Fiber Guild")
+        settings_obj = GuildOrientationSettingsFactory(guild=guild)
+        assert settings_obj.welcome_email_subject_resolved == standard_welcome_subject("Fiber Guild")
+        assert settings_obj.welcome_email_body_resolved == STANDARD_WELCOME_BODY
+
+    def describe_welcome_email_ready():
+        def it_tracks_the_enabled_flag():
+            on = GuildOrientationSettingsFactory(guild=GuildFactory(), welcome_email_enabled=True)
+            off = GuildOrientationSettingsFactory(guild=GuildFactory(), welcome_email_enabled=False)
+            assert on.welcome_email_ready is True
+            assert off.welcome_email_ready is False
+
+
+def describe_send_guild_welcome():
+    def it_sends_one_welcome_with_the_resolved_copy_and_banner_context():
+        guild = GuildFactory(name="Wood Guild")
+        GuildOrientationSettingsFactory(
+            guild=guild,
+            welcome_email_subject="Welcome, friend",
+            welcome_email_body="Glad you joined.",
+        )
+        member = _member()
+
+        orientations.send_guild_welcome(guild, member)
+
+        assert len(mail.outbox) == 1
+        sent = mail.outbox[0]
+        assert sent.to == [member.primary_email]
+        assert sent.subject == "Welcome, friend"
+        assert "Glad you joined." in sent.body
+        log = TransactionalEmailLog.objects.get(trigger_kind="guild_welcome")
+        assert log.to_email == member.primary_email
+
+    def it_includes_the_guild_banner_url_when_the_guild_has_a_banner():
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        # 1x1 PNG so guild.banner_image is truthy and the banner branch of the context runs.
+        png = bytes.fromhex(
+            "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+            "890000000a49444154789c6300010000050001a5f645400000000049454e44ae426082"
+        )
+        guild = GuildFactory(
+            name="Banner Guild",
+            banner_image=SimpleUploadedFile("b.png", png, content_type="image/png"),
+        )
+        ctx = orientations._guild_welcome_context(guild, "Sam", "hi")
+        assert ctx["banner_url"]
+        assert guild.banner_image.url.split("?")[0] in ctx["banner_url"]
+
+    def it_leaves_the_banner_url_blank_without_a_banner():
+        guild = GuildFactory(name="Plain Guild")
+        ctx = orientations._guild_welcome_context(guild, "Sam", "hi")
+        assert ctx["banner_url"] == ""
+
+    def it_sends_the_standard_welcome_when_no_custom_copy():
+        guild = GuildFactory(name="Print Guild")
+        GuildOrientationSettingsFactory(guild=guild)
+        member = _member()
+
+        orientations.send_guild_welcome(guild, member)
+
+        assert mail.outbox[0].subject == standard_welcome_subject("Print Guild")
+        assert STANDARD_WELCOME_BODY in mail.outbox[0].body
+
+    def it_sends_nothing_when_the_guild_has_no_settings_row():
+        guild = GuildFactory()
+        member = _member()
+
+        orientations.send_guild_welcome(guild, member)
+
+        assert mail.outbox == []
+
+    def it_sends_nothing_when_the_welcome_email_is_disabled():
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild, welcome_email_enabled=False)
+        member = _member()
+
+        orientations.send_guild_welcome(guild, member)
+
+        assert mail.outbox == []
+
+    def it_is_idempotent_per_member_and_guild_forever():
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild)
+        member = _member()
+
+        orientations.send_guild_welcome(guild, member)
+        orientations.send_guild_welcome(guild, member)  # a leave-then-rejoin re-send
+
+        assert len(mail.outbox) == 1
+
+    def it_is_reachable_from_the_member_helper():
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild)
+        member = _member()
+
+        member.send_guild_welcome(guild)
+
+        assert len(mail.outbox) == 1
+
+
+def describe_send_guild_welcome_test():
+    def it_sends_even_when_disabled_so_a_lead_can_proof_a_draft():
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild, welcome_email_enabled=False)
+        lead = _member("proof_lead")
+
+        orientations.send_guild_welcome_test(guild, lead)
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [lead.primary_email]
+
+    def it_creates_the_settings_row_when_missing():
+        guild = GuildFactory()
+        lead = _member("proof_lead2")
+
+        orientations.send_guild_welcome_test(guild, lead)
+
+        assert GuildOrientationSettings.objects.filter(guild=guild).exists()
+        assert len(mail.outbox) == 1
+
+    def it_can_send_repeated_proofs():
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild)
+        lead = _member("proof_lead3")
+
+        orientations.send_guild_welcome_test(guild, lead)
+        orientations.send_guild_welcome_test(guild, lead)
+
+        assert len(mail.outbox) == 2
+
+
+def describe_silent_join_paths():
+    def it_does_not_send_a_welcome_from_subscribe_to_guild():
+        # The Settings toggle and first-login picker both funnel through subscribe_to_guild;
+        # neither should email (only the lead "New follower" notice fires).
+        guild = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild)
+        member = _member()
+
+        member.subscribe_to_guild(guild)
+
+        assert mail.outbox == []
+        assert GuildMembership.objects.filter(guild=guild, member=member).exists()
+
+    def it_still_fires_the_lead_new_follower_notice_on_subscribe():
+        lead = _member("notice_lead")
+        guild = GuildFactory(guild_lead=lead)
+        GuildOrientationSettingsFactory(guild=guild)
+        member = _member("notice_member")
+
+        member.subscribe_to_guild(guild)
+
+        assert Notification.objects.filter(user=lead.user, trigger="guild_joined").exists()
+
+    def it_does_not_send_a_welcome_from_the_first_login_picker():
+        guild_a = GuildFactory()
+        guild_b = GuildFactory()
+        GuildOrientationSettingsFactory(guild=guild_a)
+        GuildOrientationSettingsFactory(guild=guild_b)
+        member = _member()
+
+        member.answer_guild_updates_prompt([guild_a, guild_b])
+
+        assert mail.outbox == []


### PR DESCRIPTION
Brings back a deliberate join path on every guild page and revives the per-guild welcome email as an opt-in-at-join. VERSION 1.20.0 (net-new member feature -> announces). Migration 0146 (AddField x4, no data loss risk).

Spec: `docs/superpowers/plans/2026-08-27-join-this-guild.md`.

## Join front door
- Hero **Join This Guild** button + a scroll-triggered sticky mini-CTA on the guild detail page; opens a benefit-framed modal (roster, member-directory badge, guild announcements, orientation booking). Reuses the existing `subscribe_to_guild` fat model, so roster row + Discord role + announcement audience are unchanged.
- Joined state flips to a quiet **Member** badge with **Leave guild** in an overflow menu (confirm modal).
- Members-surface only (the guest surface never shows the hero Join).

## Welcome email: opt-in at the join moment (owner decision, overriding the spec's "all paths")
- The join modal carries a **"send me the welcome packet"** checkbox, **checked by default**.
- The welcome email fires ONLY on (a) the hero Join with the box checked, or (b) the Discord `/join-guild` command. It is **silent** on the first-login interest picker, the Settings toggle, and the Discord reaction sync.
- Send lives in an idempotent `Member.send_guild_welcome` (deduped once per member+guild forever, gated on `welcome_email_enabled`), **not** inside `member_joined_guild` — so passive join paths never trigger it. The lead "New follower" in-app notice is untouched.

## Welcome email storage + editor
- Four `welcome_email_*` fields restored on `GuildOrientationSettings` (migration 0146, mirrors the thank-you email), resolved-with-default properties, a standard-copy module, and `guild_welcome.{html,txt}` (guild banner + "what you can do" section linking a new-member guide).
- New lead-editable **Welcome Email** tab on the guild editor: Save + Preview + Send a test to me.

## Member directory
- Per-guild badge on each member card + a `?guild=<slug>` filter.

## Testing
- New: `guild_join_view_spec.py`, `guild_welcome_spec.py`, `guild_welcome_editor_spec.py` — proving each trigger path (hero checked -> 1 email; hero unchecked -> 0; picker -> 0; Settings -> 0; Discord -> 1; re-join dedupe -> 0; `enabled=False` -> 0; lead notice always fires).
- Updated pre-existing specs that encoded the removed-button behavior; the changelog-collision negative assertions now target the button class (`pl-guild-cta__join`) not the bare label.
- Affected e2e run locally and green: `orientation_booking`, `mobile_no_horizontal_overflow` (new sticky FAB + directory filter cause no overflow / no overlap). ruff + mypy + manage.py check clean; no migration drift.

https://claude.ai/code/session_01NF4MEeH2icSRQ9U4RuGTmA