### PR TITLE
polish(guilds): guild page CSS + join modal cleanup, Discord announce toggle, FAQ/Links tab split

### DIFF
--- a/hub/forms.py
+++ b/hub/forms.py
@@ -1660,17 +1660,24 @@ class GuildWelcomeEmailForm(forms.ModelForm):
 
 
 class GuildJoinForm(forms.Form):
-    """The join-modal opt-in: one toggle for the welcome email.
+    """The join-modal opt-ins: the welcome email plus an optional Discord announcement.
 
-    Not persisted — it only carries the member's welcome-packet choice with the join POST.
-    The toggle is checked by default (opt-out within the deliberate join, honoring "ask
-    first"). The view reads ``send_welcome`` off the POST directly.
+    Not persisted — it only carries the member's choices with the join POST. ``send_welcome``
+    is checked by default (opt-out within the deliberate join, honoring "ask first").
+    ``announce_discord`` is OFF by default (opt-in): it only posts a short celebratory message
+    to the guild's own Discord channel when the member deliberately ticks it, and the toggle is
+    only rendered for guilds that actually post to a channel. The view reads both off the POST.
     """
 
     send_welcome = forms.BooleanField(
         required=False,
         initial=True,
         label="Email me the guild welcome guide",
+    )
+    announce_discord = forms.BooleanField(
+        required=False,
+        initial=False,
+        label="Announce on the guild's Discord channel",
     )
 
 

--- a/hub/views.py
+++ b/hub/views.py
@@ -2549,6 +2549,27 @@ def _guild_cta_context(request: HttpRequest, guild: Guild, member: Member | None
     }
 
 
+def _announce_join_to_discord(guild: Guild, member: Member) -> None:
+    """Best-effort: post a short celebratory note to the guild's own Discord channel.
+
+    Mirrors the ``/join-guild`` slash command's public welcome (``guild_webhook`` +
+    ``post_embed``, `hub/discord_commands.py`): the same per-guild webhook gate (posting
+    enabled AND a non-blank webhook URL), the member named in the embed title, no @-mention.
+    Wrapped so a Discord hiccup can never fail or roll back the join — the ``GuildMembership``
+    row is the source of truth. Only the deliberate web join with the box ticked reaches here;
+    the silent paths (first-login picker, Settings toggle) never announce.
+    """
+    from core.events.channels import Message
+    from core.events.discord import guild_webhook, post_embed
+
+    try:
+        hook = guild_webhook(guild)
+        if hook:
+            post_embed(hook, Message(title=f"{member.display_name} just joined {guild.name}!", body=""))
+    except Exception:
+        logger.exception("guild_join: Discord announce failed for guild=%s member=%s", guild.pk, member.pk)
+
+
 @login_required
 @require_POST
 def guild_join(request: HttpRequest, pk: int) -> HttpResponse:
@@ -2571,6 +2592,8 @@ def guild_join(request: HttpRequest, pk: int) -> HttpResponse:
     welcomed = bool(joined and request.POST.get("send_welcome"))
     if welcomed:
         member.send_guild_welcome(guild)
+    if joined and request.POST.get("announce_discord"):
+        _announce_join_to_discord(guild, member)
     ctx = _guild_cta_context(request, guild, member)
     ctx["oob"] = True
     response = render(request, "hub/partials/_guild_join_cta.html", ctx)
@@ -3417,7 +3440,7 @@ def guild_announcement_delete(request: HttpRequest, pk: int, announcement_pk: in
 @login_required
 @require_POST
 def guild_faq_save(request: HttpRequest, pk: int) -> HttpResponse:
-    """Save the guild's FAQ rows from their own form on the FAQ & Links tab. Editor only.
+    """Save the guild's FAQ rows from their own form on the FAQ tab. Editor only.
 
     The FAQ section is its own ``<form>`` (it can't be nested in the main edit form), so it
     persists here independently and redirects back to the same tab with a Django message.
@@ -3440,7 +3463,7 @@ def guild_faq_save(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 @require_POST
 def guild_links_save(request: HttpRequest, pk: int) -> HttpResponse:
-    """Save the guild's Links rows from their own form on the FAQ & Links tab. Editor only."""
+    """Save the guild's Links rows from their own form on the Links tab. Editor only."""
     from hub.forms import GuildLinkFormSet
 
     guild = get_object_or_404(Guild, pk=pk)
@@ -3453,7 +3476,7 @@ def guild_links_save(request: HttpRequest, pk: int) -> HttpResponse:
         messages.success(request, "Links saved.")
     else:
         messages.error(request, "Couldn't save the links — check the highlighted fields.")
-    return redirect(f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=content")
+    return redirect(f"{reverse('hub_guild_edit', args=[guild.pk])}?tab=links")
 
 
 @login_required

--- a/membership/help_content.py
+++ b/membership/help_content.py
@@ -1299,7 +1299,7 @@ Wondering how far you can take the page? The [Cartographers Guild](/guilds/carto
 
 ### The Tabs {#guild-edit-page}
 
-Guild Settings is one page with tabs across the top: **Basic Information**, **Meetings**, **Studio Hours**, **Meeting Notes**, **Events**, **Orientations**, **Images**, **FAQ & Links**, **Announcements**, and **Staff**. Basic Information, Meetings, and Images share one **Save Changes** button. Every other tab has its own Save button, so save each tab before you leave it.
+Guild Settings is one page with tabs across the top: **Basic Information**, **Meetings**, **Studio Hours**, **Meeting Notes**, **Events**, **Orientations**, **Welcome Email**, **Images**, **FAQ**, **Links**, **Announcements**, and **Staff**. Basic Information, Meetings, and Images share one **Save Changes** button. Every other tab has its own Save button, so save each tab before you leave it.
 
 This guide covers the page itself. Orientations, announcements, events, studio hours, and staff each have their own guide.
 
@@ -1325,13 +1325,13 @@ The **Gallery** section on the Images tab holds up to 10 photos. They save the m
 
 ### FAQ
 
-On the **FAQ & Links** tab, click **+ Add a question**. Each answer can also embed a YouTube video and attach one document: upload a file or paste a link, not both. **Delete this question** saves the whole page right away, so nothing else you typed is lost. Click **Save FAQ** when you're done. Want the section called something other than FAQ? Rename it on the **Basic Information** tab.
+On the **FAQ** tab, click **+ Add a question**. Each answer can also embed a YouTube video and attach one document: upload a file or paste a link, not both. **Delete this question** saves the whole page right away, so nothing else you typed is lost. Click **Save FAQ** when you're done. Want the section called something other than FAQ? Rename it on the **Basic Information** tab.
 
-![The FAQ & Links tab. Each answer can carry a video and a document.](/static/help/your-guild-page/03-faq-and-links.png)
+![The FAQ tab. Each answer can carry a video and a document.](/static/help/your-guild-page/03-faq-and-links.png)
 
 ### Links
 
-Below the FAQ editor, add links with a label and a URL, then click **Save Links**. They show on your guild page.
+On the **Links** tab, add links with a label and a URL, then click **Save Links**. They show on your guild page.
 
 ### Your Automatic Email
 
@@ -1357,7 +1357,7 @@ Only leads, staff, and admins see the Guild Settings button. Everything a staff 
                 "file": "03-faq-and-links.png",
                 "page": "/guilds/1/edit/?tab=content",
                 "selector": "[x-show=\"section === 'content'\"]",
-                "caption": "The FAQ & Links tab. Each answer can carry a video and a document.",
+                "caption": "The FAQ tab. Each answer can carry a video and a document.",
                 "as_role": "guild_lead",
             },
         ],

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -7186,6 +7186,23 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
     background: var(--hub-surface);
 }
 
+/* ── Guild stat-chips row: chips on the left, Join/Member CTA on the right ──
+   Wraps on narrow viewports so the CTA drops under the chips instead of overflowing. */
+.pl-guild-statbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0 0 1rem;
+}
+.pl-guild-statbar__chips {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
 /* ── Sticky mini Join CTA (clones .pl-scroll-top placement) ──────────────── */
 .pl-guild-join-fab {
     position: fixed;
@@ -7242,6 +7259,16 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
 }
 .pl-benefit-row a {
     color: var(--color-tuscan-yellow);
+}
+
+/* ── "You get this guild's updates" note — top+bottom breathing room (8px grid) so it
+   doesn't butt against the confirmation icon above or the "Manage in Settings" button below. */
+.pl-guild-updates-note {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    padding: 0.5rem 0;
 }
 
 /* ── Member Directory guild badges ───────────────────────────────────────── */

--- a/templates/hub/guild_detail.html
+++ b/templates/hub/guild_detail.html
@@ -59,9 +59,9 @@
             <h1 class="pl-guild-hero__title" style="margin:0;">{{ guild.name }}</h1>
         </div>
         {% if guild.guild_lead %}<div class="pl-guild-hero__lead" style="margin-top:0;">Led by {{ guild.guild_lead.display_name }}</div>{% endif %}
+        {% if can_edit_this_guild %}
+        {# Editor-only hero controls. The Join/Member CTA moved out to the stat-chips row below. #}
         <div style="display:flex; gap:0.5rem; margin-top:0.75rem; flex-wrap:wrap; align-items:center;">
-            {% include "hub/partials/_guild_join_cta.html" %}
-            {% if can_edit_this_guild %}
             <a href="{% url 'hub_guild_edit' guild.pk %}" class="pl-btn pl-btn--secondary" title="Guild Settings" x-show="!isAdjusting">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:0.25rem;"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                 Guild Settings
@@ -101,16 +101,19 @@
                     Cancel
                 </button>
             {% endif %}
-            {% endif %}
         </div>
+        {% endif %}
     </div>
 </div>
 
-{# ── STAT CHIPS ── #}
-<div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin:0 0 1rem;">
-    {% include "hub/partials/_guild_member_count.html" %}
-    {% if class_count %}<span class="hub-badge">{{ class_count }} class{{ class_count|pluralize:"es" }}</span>{% endif %}
-    {% with next_meeting=guild.next_meeting_occurrence %}{% if next_meeting %}<span class="hub-badge">Next meeting {{ next_meeting.when|date:"M j" }}</span>{% endif %}{% endwith %}
+{# ── STAT CHIPS + Join/Member CTA — chips left, CTA right (wraps on mobile). ── #}
+<div class="pl-guild-statbar">
+    <div class="pl-guild-statbar__chips">
+        {% include "hub/partials/_guild_member_count.html" %}
+        {% if class_count %}<span class="hub-badge">{{ class_count }} class{{ class_count|pluralize:"es" }}</span>{% endif %}
+        {% with next_meeting=guild.next_meeting_occurrence %}{% if next_meeting %}<span class="hub-badge">Next meeting {{ next_meeting.when|date:"M j" }}</span>{% endif %}{% endwith %}
+    </div>
+    {% include "hub/partials/_guild_join_cta.html" %}
 </div>
 
 {% comment %} Legacy ?tab=notes deep links land on the renamed Meetings tab (spec §6.4); only the two known values map, so a garbage ?tab can't blank every pane. {% endcomment %}
@@ -781,10 +784,6 @@
                     <span>You get the guild's Discord role automatically.</span>
                 </div>
                 {% endif %}
-                <div class="pl-benefit-row">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                    <span>See the guild's events, meetings, and calendar.</span>
-                </div>
                 {% if gallery_images %}
                 <div class="pl-benefit-row">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
@@ -797,16 +796,16 @@
                     <span>See the guild's wishlist.</span>
                 </div>
                 {% endif %}
-                <div class="pl-benefit-row">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                    <span>You're eligible to vote on guild funding.</span>
-                </div>
             </div>
             <form hx-post="{% url 'hub_guild_join' guild.pk %}" hx-target="#guild-join-cta" hx-swap="outerHTML"
                   @htmx:after-request="if ($event.detail.successful) $dispatch('close-modal', 'join-guild')"
                   style="margin-top:1.25rem;">
                 {% csrf_token %}
                 {% include "components/toggle.html" with field=join_form.send_welcome toggle_label="Email me the "|add:guild.name|add:" welcome guide" toggle_description="A warm welcome with everything your guild page can do." %}
+                {% if guild.discord_post_enabled and guild.discord_webhook_url %}
+                {# Only shown when the guild posts to its own Discord channel (webhook set + posting on) — the same gate guild_webhook() applies before the view posts. Opt-in: off by default. #}
+                {% include "components/toggle.html" with field=join_form.announce_discord toggle_label="Announce on the "|add:guild.name|add:" Discord channel" toggle_description="Say hello in the channel that you just joined. Off unless you turn it on." %}
+                {% endif %}
                 <div class="pl-modal__actions" style="margin-top:1rem;">
                     <button type="submit" class="pl-btn pl-btn--primary" style="flex:1;" hx-disabled-elt="this">Join {{ guild.name }}</button>
                     <button type="button" class="pl-btn pl-btn--secondary" style="flex:1;" @click="$dispatch('close-modal', 'join-guild')">Not now</button>

--- a/templates/hub/guild_edit.html
+++ b/templates/hub/guild_edit.html
@@ -20,7 +20,8 @@
   <button type="button" class="vote-tab" data-help-key="guild.run-orientations" :class="section === 'orientations' ? 'vote-tab--active' : ''" @click="section = 'orientations'">Orientations</button>
   <button type="button" class="vote-tab" :class="section === 'welcome_email' ? 'vote-tab--active' : ''" @click="section = 'welcome_email'">Welcome Email</button>
   <button type="button" class="vote-tab" :class="section === 'images' ? 'vote-tab--active' : ''" @click="section = 'images'">Images</button>
-  <button type="button" class="vote-tab" :class="section === 'content' ? 'vote-tab--active' : ''" @click="section = 'content'">FAQ &amp; Links</button>
+  <button type="button" class="vote-tab" :class="section === 'content' ? 'vote-tab--active' : ''" @click="section = 'content'">FAQ</button>
+  <button type="button" class="vote-tab" :class="section === 'links' ? 'vote-tab--active' : ''" @click="section = 'links'">Links</button>
   <button type="button" class="vote-tab" data-help-key="guild.announcements" :class="section === 'announcements' ? 'vote-tab--active' : ''" @click="section = 'announcements'">Announcements</button>
   <button type="button" class="vote-tab" data-help-key="guild.manage-staff" :class="section === 'staff' ? 'vote-tab--active' : ''" @click="section = 'staff'">Staff</button>
 </div>
@@ -650,7 +651,7 @@ confirm modal carries its own POST form, and template content can't nest a form.
   {% include "components/modal.html" with modal_id="welcome-preview" modal_title="Welcome Email Preview" modal_size="lg" %}
 </div>
 
-{# ── FAQ & Links (each its own form, outside the main form — you can't nest forms) ──── #}
+{# ── FAQ (its own form + tab, outside the main form — you can't nest forms) ──── #}
 <div x-show="section === 'content'" x-cloak>
   <form method="post" action="{% url 'hub_guild_faq_save' guild.pk %}" class="hub-form" enctype="multipart/form-data">
     {% csrf_token %}
@@ -719,7 +720,10 @@ confirm modal carries its own POST form, and template content can't nest a form.
       </div>
     </div>
   </form>
+</div>
 
+{# ── Links (its own form + tab, outside the main form) ── #}
+<div x-show="section === 'links'" x-cloak>
   <form method="post" action="{% url 'hub_guild_links_save' guild.pk %}" class="hub-form">
     {% csrf_token %}
     <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;" data-help-key="guild.manage-links">

--- a/templates/hub/partials/_guild_get_involved_status.html
+++ b/templates/hub/partials/_guild_get_involved_status.html
@@ -3,7 +3,7 @@
 {# that job now). Kept in an OOB-swappable wrapper so it flips with join/leave. #}
 <div id="guild-get-involved-status"{% if oob %} hx-swap-oob="true"{% endif %}>
     {% if member and is_member_of_guild %}
-    <div class="hub-text-muted" style="display:flex; align-items:center; gap:0.4rem; font-size:0.9rem;">
+    <div class="hub-text-muted pl-guild-updates-note">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
         You get this guild's updates
     </div>

--- a/tests/hub/guild_edit_spec.py
+++ b/tests/hub/guild_edit_spec.py
@@ -395,9 +395,9 @@ def describe_guild_edit():
         assert response.status_code == 302
         assert response["Location"] == reverse("hub_guild_detail", args=[guild.slug])
 
-    def it_deletes_a_link_via_its_own_save_view_and_returns_to_the_content_tab(client: Client):
+    def it_deletes_a_link_via_its_own_save_view_and_returns_to_the_links_tab(client: Client):
         # Link deletion moved OUT of the main edit form into guild_links_save, which posts to its
-        # own action and redirects back to ?tab=content. (Was the old main-form `after=edit` flow.)
+        # own action and redirects back to ?tab=links (its own tab since the FAQ/Links split).
         _user_with_role("admin_lnk", fog_role=Member.FogRole.ADMIN)
         guild = GuildFactory(name="Forge")
         link = GuildLinkFactory(guild=guild, label="Old Discord", url="https://discord.gg/x")
@@ -416,8 +416,8 @@ def describe_guild_edit():
         }
         response = client.post(url, data=data)
         assert response.status_code == 302
-        # Lands back on the FAQ & Links tab ...
-        assert response["Location"] == reverse("hub_guild_edit", args=[guild.pk]) + "?tab=content"
+        # Lands back on the Links tab ...
+        assert response["Location"] == reverse("hub_guild_edit", args=[guild.pk]) + "?tab=links"
         # ... and the link is gone.
         assert not guild.links.filter(pk=link.pk).exists()
 
@@ -727,13 +727,15 @@ def describe_guild_edit_tabs():
             b"orientations",
             b"images",
             b"content",
+            b"links",
             b"announcements",
             b"staff",
         ):
             assert b"section = '" + tab + b"'" in response.content
-        # Calendar Integration and FAQ/Links live under tabs (using discretion).
+        # Calendar Integration lives under a tab; FAQ and Links are now two separate tabs.
         assert b"Calendar Integration" in response.content
-        assert b"FAQ &amp; Links" in response.content
+        assert b">FAQ</button>" in response.content
+        assert b">Links</button>" in response.content
         # The formerly-standalone sections now render inline on the same page.
         assert b"+ Add meeting notes" in response.content
         assert b"+ Add event" in response.content
@@ -961,7 +963,7 @@ def describe_guild_faq_save():
 def describe_guild_links_save():
     """Links now saves through its own form/view, separate from the main edit form."""
 
-    def it_adds_a_new_link_row_and_redirects_to_the_content_tab(client: Client):
+    def it_adds_a_new_link_row_and_redirects_to_the_links_tab(client: Client):
         _user_with_role("lnk_add", fog_role=Member.FogRole.ADMIN)
         guild = GuildFactory()
         client.login(username="lnk_add", password="pass")
@@ -976,7 +978,7 @@ def describe_guild_links_save():
         }
         response = client.post(reverse("hub_guild_links_save", args=[guild.pk]), data=data, follow=True)
         assert response.status_code == 200
-        assert response.redirect_chain[-1][0] == reverse("hub_guild_edit", args=[guild.pk]) + "?tab=content"
+        assert response.redirect_chain[-1][0] == reverse("hub_guild_edit", args=[guild.pk]) + "?tab=links"
         assert GuildLink.objects.filter(guild=guild, label="Discord").exists()
         assert "Links saved." in [str(m) for m in response.context["messages"]]
 
@@ -1047,7 +1049,7 @@ def describe_guild_links_save():
 
 @pytest.mark.django_db
 def describe_guild_content_tab_template():
-    """Template-level guarantees for the FAQ & Links tab after the form split."""
+    """Template-level guarantees for the FAQ and Links tabs after the form + tab split."""
 
     def it_renders_each_section_as_its_own_form_posting_to_its_save_view(client: Client):
         _user_with_role("ct_forms", fog_role=Member.FogRole.ADMIN)

--- a/tests/hub/guild_join_view_spec.py
+++ b/tests/hub/guild_join_view_spec.py
@@ -8,6 +8,7 @@ removes the subscription. Both return the flipped CTA partial plus a toast.
 from __future__ import annotations
 
 import json
+from unittest import mock
 
 import pytest
 from django.contrib.auth.models import User
@@ -24,6 +25,8 @@ from tests.membership.factories import (
 )
 
 pytestmark = pytest.mark.django_db
+
+_WEBHOOK = "https://discord.com/api/webhooks/1/token"
 
 
 def _linked_user(username: str) -> User:
@@ -140,3 +143,112 @@ def describe_guild_leave():
 
         assert response.status_code == 204
         assert _toast(response)["type"] == "error"
+
+
+def describe_guild_join_discord_announce():
+    """The opt-in 'Announce on the guild's Discord channel?' box on the web join.
+
+    Reuses the ``/join-guild`` welcome plumbing (``guild_webhook`` + ``post_embed``), so the
+    same per-guild gate (posting enabled AND a non-blank webhook) decides whether anything
+    posts. ``post_embed`` is spied; ``guild_webhook`` stays real so the gate runs for real.
+    """
+
+    @pytest.fixture
+    def post_spy(monkeypatch):
+        from core.events import discord as discord_module
+
+        spy = mock.MagicMock(name="post_embed", return_value=True)
+        monkeypatch.setattr(discord_module, "post_embed", spy)
+        return spy
+
+    def it_posts_one_channel_message_when_the_box_is_checked(client: Client, post_spy):
+        user = _linked_user("dj_on")
+        guild = GuildFactory(name="Forge", discord_webhook_url=_WEBHOOK)
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="dj_on", password="pw")
+
+        response = client.post(reverse("hub_guild_join", args=[guild.pk]), {"announce_discord": "on"})
+
+        assert response.status_code == 200
+        post_spy.assert_called_once()
+        hook, message = post_spy.call_args.args
+        assert hook == _WEBHOOK
+        assert message.title == f"{user.member.display_name} just joined Forge!"
+
+    def it_posts_nothing_when_the_box_is_unchecked(client: Client, post_spy):
+        _linked_user("dj_off")
+        guild = GuildFactory(discord_webhook_url=_WEBHOOK)
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="dj_off", password="pw")
+
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {})
+
+        post_spy.assert_not_called()
+
+    def it_posts_nothing_when_the_guild_has_no_channel(client: Client, post_spy):
+        _linked_user("dj_nochan")
+        guild = GuildFactory(discord_webhook_url="")  # no channel wired for posting
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="dj_nochan", password="pw")
+
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {"announce_discord": "on"})
+
+        post_spy.assert_not_called()
+
+    def it_does_not_announce_on_a_repeat_join(client: Client, post_spy):
+        # subscribe_to_guild returns False on a repeat join, so the announce never fires again.
+        _linked_user("dj_repeat")
+        guild = GuildFactory(discord_webhook_url=_WEBHOOK)
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="dj_repeat", password="pw")
+
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {"announce_discord": "on"})
+        client.post(reverse("hub_guild_join", args=[guild.pk]), {"announce_discord": "on"})
+
+        post_spy.assert_called_once()
+
+    def it_still_joins_when_the_discord_post_raises(client: Client, monkeypatch):
+        from core.events import discord as discord_module
+
+        boom = mock.MagicMock(name="post_embed", side_effect=RuntimeError("discord down"))
+        monkeypatch.setattr(discord_module, "post_embed", boom)
+        user = _linked_user("dj_boom")
+        guild = GuildFactory(discord_webhook_url=_WEBHOOK)
+        GuildOrientationSettingsFactory(guild=guild)
+        client.login(username="dj_boom", password="pw")
+
+        response = client.post(reverse("hub_guild_join", args=[guild.pk]), {"announce_discord": "on"})
+
+        assert response.status_code == 200
+        assert GuildMembership.objects.filter(guild=guild, member=user.member).exists()
+
+
+def describe_guild_join_modal_discord_toggle():
+    """The announce toggle only renders for guilds that actually post to a channel."""
+
+    def it_shows_the_toggle_when_the_guild_posts_to_a_channel(client: Client):
+        _linked_user("tg_on")
+        guild = GuildFactory(discord_webhook_url=_WEBHOOK)
+        client.login(username="tg_on", password="pw")
+
+        response = client.get(f"/guilds/{guild.slug}/")
+
+        assert b"announce_discord" in response.content
+
+    def it_hides_the_toggle_when_the_guild_has_no_channel(client: Client):
+        _linked_user("tg_off")
+        guild = GuildFactory(discord_webhook_url="")
+        client.login(username="tg_off", password="pw")
+
+        response = client.get(f"/guilds/{guild.slug}/")
+
+        assert b"announce_discord" not in response.content
+
+    def it_hides_the_toggle_when_posting_is_disabled(client: Client):
+        _linked_user("tg_disabled")
+        guild = GuildFactory(discord_webhook_url=_WEBHOOK, discord_post_enabled=False)
+        client.login(username="tg_disabled", password="pw")
+
+        response = client.get(f"/guilds/{guild.slug}/")
+
+        assert b"announce_discord" not in response.content


### PR DESCRIPTION
Follow-ups on the Join This Guild feature, prompted by owner review. No VERSION bump (polish + one opt-in toggle).

The owner flagged that CSS was not being reviewed against FRONTEND.md. This PR fixes the specific issues AND the reviewer is asked to audit every CSS/inline-style change against FRONTEND.md (the systemic fix).

## 1. CSS (FRONTEND.md-reviewed)
- The "You get this guild's updates" note had no vertical breathing room and clashed with neighbors. Replaced its bare inline `style="display:flex;..."` with a new `.pl-guild-updates-note` class carrying `padding:0.5rem 0` (8px grid, theme-safe) — Rule 9.
- Audited the Join feature's touched files: no Rule 12 (`display` inline on `x-show`) or Rule 13 (form-control bg/color) violations found; the `display:none`+`x-show` on modal backdrops is the intentional SSR-hidden idiom.

## 2. Move the Join/Member CTA
Out of the hero, onto the right of the member-pill/stat-chips row (new `.pl-guild-statbar`, space-between, wraps on mobile). `id="guild-join-cta"` preserved (HTMX target). Hero editor buttons stay; the empty non-editor hero row is guarded away.

## 3. Remove two false benefit lines
Dropped "See the guild's events, meetings, and calendar." and "You're eligible to vote on guild funding." from the join modal — neither requires membership.

## 4. Opt-in Discord-announce toggle (default OFF)
New `announce_discord` toggle on the join modal, shown only when the guild has `discord_webhook_url` + `discord_post_enabled`. On a deliberate web join with the box ticked, posts a best-effort celebratory note to the guild's channel (reuses the `/join-guild` welcome path: `guild_webhook` + `post_embed`, wrapped so it can never block the join). Silent on the first-login picker and Settings toggle. **Note:** gated on the webhook (the real post path), not `discord_channel_id` (slash-command auto-detect only) — verified against the model.

## 5. Split FAQ & Links editor tab
The combined "FAQ & Links" tab in Guild Settings is now two tabs: **FAQ** and **Links**. Links save redirects to `?tab=links`. Help copy updated to match (and to include the Welcome Email tab that was also missing).

## Testing
- `guild_join_view_spec.py` + `guild_edit_spec.py` (100), guild_pages/guest/my_guilds/roster (84), help drift guard + template lint green; **mobile-overflow e2e passes** (the CTA move causes no horizontal scroll). ruff + mypy + check clean; no migration (form-only field).

https://claude.ai/code/session_01NF4MEeH2icSRQ9U4RuGTmA