### PR TITLE
feat(tours): auto-navigating role-based guided tours (1.21.0)

### DIFF
--- a/classes/views.py
+++ b/classes/views.py
@@ -1210,13 +1210,10 @@ def teach_overview(request: HttpRequest) -> HttpResponse:
     is_guild_lead = teaching_member.is_guild_lead
     guild_lead_pending = _guild_lead_review_queue(teaching_member) if is_guild_lead else []
 
-    from core.tours import tour_offer_context
-
     return render(
         request,
         "classes/teach/overview.html",
         {
-            **tour_offer_context(request, "instructor"),
             "active_tab": "overview",
             "instructor": teaching_member,
             "drafts": drafts,

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -167,3 +167,65 @@ def persona(request: HttpRequest) -> dict[str, str | bool]:
     }
     request._persona = result  # type: ignore[attr-defined]
     return result
+
+
+def _apply_resume_step(request: HttpRequest, ctx: dict[str, Any]) -> None:
+    """Fold a clamped ``?step=`` into the payload so a driven hop resumes mid-tour."""
+    payload = ctx.get("tour_json")
+    if not payload:
+        return
+    try:
+        step = int(request.GET.get("step", "0"))
+    except ValueError:
+        step = 0
+    last = len(payload["steps"]) - 1
+    payload["resume_step"] = max(0, min(step, last)) if last >= 0 else 0
+
+
+def tour_runtime(request: HttpRequest) -> dict[str, Any]:
+    """Make a guided-tour payload available on every page a tour can land on.
+
+    The single choke-point that decides, per request, whether the page emits a
+    tour payload (so ``static/js/pl_tour.js`` can start, resume, or offer a tour):
+
+    1. A ``?tour=<key>`` for an *eligible* member -> autostart/resume payload with
+       a clamped ``resume_step`` (works on any page, which is what lets a driven
+       multi-page hop re-hydrate). No ``TourState`` write.
+    2. Otherwise, on a tour's entry page -> the usual offer/auto-offer guards
+       (first eligible GET writes the ``offered`` row).
+    3. Else nothing.
+
+    ``request.user`` / ``request.resolver_match`` are read defensively: themed
+    404s render every context processor before auth and URL resolution have run.
+    """
+    from core.tours import TOURS, tour_offer_context
+
+    empty: dict[str, Any] = {
+        "tour": None,
+        "tour_json": None,
+        "show_tour_offer": False,
+        "tour_autostart": False,
+    }
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
+        return empty
+    if getattr(request, "method", "GET") != "GET":
+        # Tours only ride GET renders — a POST re-render (e.g. a form error) must
+        # not write an ``offered`` row or emit a payload.
+        return empty
+
+    requested = request.GET.get("tour")
+    if requested in TOURS:
+        ctx = tour_offer_context(request, requested)
+        if ctx["tour_autostart"]:
+            _apply_resume_step(request, ctx)
+            return ctx
+        # Ineligible or foreign ?tour= — the param is ignored; fall through so an
+        # entry page still shows its own offer.
+
+    match = getattr(request, "resolver_match", None)
+    if match is not None:
+        for tour in TOURS.values():
+            if match.view_name == tour.entry_url_name:
+                return tour_offer_context(request, tour.key)
+    return empty

--- a/core/help_registry.py
+++ b/core/help_registry.py
@@ -621,6 +621,89 @@ HELP_KEYS: dict[str, HelpKeyEntry] = {
         "article_slug": None,
         "anchor": None,
     },
+    # ── Annotation-only keys (auto-navigating guided tours) ─────────────────
+    # Tour step targets on the demo path; article_slug=None until a section
+    # exists, so url_for degrades to /help/.
+    "catalog.filter": {
+        "title": "Filter the catalog",
+        "short_text": (
+            "Every class and workshop lives here. Filter by guild or date, then open one to see the details."
+        ),
+        "article_slug": None,
+        "anchor": None,
+    },
+    "catalog.class-card": {
+        "title": "A class card",
+        "short_text": "Each card is a class. Click it to read what you will make and to sign up.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "spaces.map": {
+        "title": "The spaces map",
+        "short_text": (
+            "Studios, storage, parking, and desks live on this map. Click any open space to ask about renting it."
+        ),
+        "article_slug": None,
+        "anchor": None,
+    },
+    "teach.class-basics": {
+        "title": "Title and description",
+        "short_text": "Give your class a clear title and describe what members will make and learn.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "teach.class-gallery": {
+        "title": "Class photos",
+        "short_text": "Add photos of the finished project and the space. Good images fill seats.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "teach.roster-table": {
+        "title": "Your class roster",
+        "short_text": "Everyone who signed up. Open a person's menu to remove them and a seat frees up.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "teach.roster-waitlist": {
+        "title": "The waitlist",
+        "short_text": "Promote someone from the waitlist and they take the open seat and get a confirmation.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "guild.welcome-email": {
+        "title": "The welcome email",
+        "short_text": (
+            "The email new members get when they join your guild. Leave the subject and body blank to send the standard welcome."
+        ),
+        "article_slug": None,
+        "anchor": None,
+    },
+    "guild.wishlist": {
+        "title": "Your guild wishlist",
+        "short_text": (
+            "List the tools and supplies your guild wants. Add a donate link and members get a Donate button too."
+        ),
+        "article_slug": None,
+        "anchor": None,
+    },
+    "admin.refunds": {
+        "title": "Payments and refunds",
+        "short_text": "Every charge is here. Open one to issue a refund; the member gets it back and a receipt.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "admin.discount-codes": {
+        "title": "Discount codes",
+        "short_text": "Create discount codes for a class or a promotion, with usage limits and an expiry date.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "admin.reconciliation": {
+        "title": "Reconciliation",
+        "short_text": "Breaks down what each guild, instructor, and orientator is owed so you can reconcile payouts.",
+        "article_slug": None,
+        "anchor": None,
+    },
 }
 
 # THE key regex — Specs B/C import this instead of restating their own.

--- a/core/tours.py
+++ b/core/tours.py
@@ -1,18 +1,28 @@
-"""The guided-tour registry — Spec C's in-code spine, sibling of :mod:`core.help_registry`.
+"""The guided-tour registry — the in-code spine, sibling of :mod:`core.help_registry`.
 
 Tour content is repo-authored (no DB model — YAGNI): frozen dataclasses plus the
 module-level ``TOURS`` dict. Step targets are ``[data-help-key="…"]`` selectors
-shared with Spec B's Info View annotations, so the template-walk drift test
+shared with the Info View annotations, so the template-walk drift test
 (``tests/hub/help_keys_spec.py``) guards tour targets for free. Per-user state
-lives in :class:`core.models.TourState`; ``tour_offer_context`` below owns every
-offer/autostart guard so entry-page views stay thin.
+lives in :class:`core.models.TourState`.
+
+Tours **drive the browser**: a :class:`TourStep` may carry action fields
+(``navigate`` to another page, ``tab_set`` to flip an Alpine tab, ``click`` a
+control) so the runtime (``static/js/pl_tour.js``) can move the operator from
+screen to screen, detect the new surface, and keep narrating. A step with none
+of those fields set behaves exactly as a plain single-page highlight — the
+backward-compatible default. :func:`tour_offer_context` owns every offer /
+autostart guard; :func:`core.context_processors.tour_runtime` makes the payload
+available on every page a tour can land on so a driven hop can re-hydrate.
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlencode, urlsplit
 
 from django.urls import reverse
 
@@ -21,23 +31,38 @@ if TYPE_CHECKING:
 
     from membership.models import Member
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class TourStep:
-    """One spotlight stop. ``target=None`` renders a centered (element-less) popover."""
+    """One spotlight stop, optionally with an action to reach it.
+
+    ``target=None`` renders a centered (element-less) popover. The action fields
+    are all optional; a step with none set is a plain highlight on the current
+    page (backward compatible). At most one *reach* action is meaningful per
+    step (``navigate`` for a page hop, ``tab_set``/``click`` for a same-page
+    hop); the runtime applies whichever is present before showing the popover.
+    """
 
     target: str | None  # CSS selector, usually '[data-help-key="…"]'; None = centered step
     title: str
-    body: str  # ELI14, 1-2 sentences
+    body: str  # ELI14, 1-2 sentences; no dashes in copy (arrow "->" allowed)
+    navigate: str | None = None  # URL name (preferred) or literal path to load before this step
+    navigate_kwargs: Callable[[Member], dict[str, Any]] | dict[str, Any] | None = None  # reverse() kwargs
+    query: Callable[[Member], dict[str, str]] | dict[str, str] | None = None  # query string appended to navigate
+    tab_set: tuple[str, str] | None = None  # (alpine_var, value) to flip an Alpine tab on the current page
+    click: str | None = None  # selector to click before this step (documented fallback for tab_set/navigate)
+    wait_for: str | None = None  # selector that must be visible before the popover shows; defaults to target
 
 
 @dataclass(frozen=True)
 class Tour:
-    """One single-page tour. Multi-page tours are consciously not built (Spec C §1)."""
+    """One role tour — a driven itinerary of :class:`TourStep` s."""
 
     key: str  # slug, e.g. "member-welcome"
     title: str  # shown on the Help card and the offer
-    entry_url_name: str  # url name of the single page the tour runs on
+    entry_url_name: str  # url name (namespaced) of the page the offer/autostart lives on
     audience: Callable[[Member], bool]
     steps: tuple[TourStep, ...]
     opens_sidebar: bool = False  # member tour: open the (mobile/collapsed) sidebar before starting
@@ -50,10 +75,8 @@ def _any_member(member: Member) -> bool:
 
 def _guild_lead_or_staff(member: Member) -> bool:
     # Admins and guild officers can edit every guild page (membership.permissions),
-    # so the guild-lead tour is theirs too — without it, the Help page's Guided
-    # Tours card never shows the tour to the people supporting guild leads. They
-    # need an active guild to run it on, though (the entry URL is a guild edit
-    # page), so an empty-guilds site simply doesn't offer them the tour.
+    # so the guild-lead tour is theirs too. They need an active guild to run it on
+    # (the entry URL is a guild edit page), so an empty-guilds site doesn't offer it.
     if member.is_guild_lead or member.is_guild_staff:
         return True
     if member.is_fog_admin or member.is_guild_officer:
@@ -64,11 +87,16 @@ def _guild_lead_or_staff(member: Member) -> bool:
 
 
 def _can_create_classes(member: Member) -> bool:
-    # Instructor-tour audience: the teaching unlock (Spec D). The rewritten
-    # ``teaching_member_required`` 302s locked members off the teach overview,
-    # so both auto-offers and manual starts must gate on the unlock or they
-    # dead-loop through the orientation redirect.
+    # Instructor-tour audience: the teaching unlock. The rewritten
+    # ``teaching_member_required`` 302s locked members off the teach overview, so
+    # both auto-offers and manual starts must gate on the unlock.
     return member.can_create_classes
+
+
+def _admin_audience(member: Member) -> bool:
+    # The admin tour reaches site-wide tools: a full FOG admin, or any member who
+    # holds even one AdminCapability (a scoped admin) is eligible.
+    return member.is_fog_admin or member.admin_capabilities.exists()
 
 
 def _first_staffed_guild_pk(member: Member) -> dict[str, Any]:
@@ -85,6 +113,54 @@ def _first_staffed_guild_pk(member: Member) -> dict[str, Any]:
     return {"pk": guild.pk}
 
 
+def _demo_guild_slug(member: Member) -> dict[str, Any]:
+    # The member tour's orientation stop: prefer an active guild that already has
+    # a future orientation slot (so the demo has something real to spotlight),
+    # else the first active guild. No active guild -> drop the step.
+    from django.utils import timezone
+
+    from membership.models import Guild
+
+    now = timezone.now()
+    guild = (
+        Guild.objects.filter(is_active=True, orientation_slots__starts_at__gte=now).order_by("name").distinct().first()
+    )
+    if guild is None:
+        guild = Guild.objects.filter(is_active=True).order_by("name").first()
+    if guild is None:
+        raise ValueError("No active guild exists for the member tour orientation stop")
+    return {"slug": guild.slug}
+
+
+def _demo_class_slug(member: Member) -> dict[str, Any]:
+    # The member tour's register stop: the soonest bookable (future, published,
+    # non-private) class. None bookable -> drop the step.
+    from classes.models import ClassOffering
+
+    offering = ClassOffering.objects.bookable().first()
+    if offering is None:
+        raise ValueError("No bookable class exists for the member tour register stop")
+    return {"slug": offering.slug}
+
+
+def _instructor_class_pk(member: Member) -> dict[str, Any]:
+    # The instructor tour's roster + waitlist stops: the instructor's newest
+    # class. Owns none -> drop those stops (the tour shortens to create+submit).
+    offering = member.classes.order_by("-created_at", "-pk").first()
+    if offering is None:
+        raise ValueError(f"Instructor {member.pk} owns no class for the roster stops")
+    return {"pk": offering.pk}
+
+
+def _instructor_class_audience(member: Member) -> dict[str, str]:
+    # The instructor tour's compose stop: pre-aim the announcement at the
+    # instructor's newest class and lock the picker. Owns none -> drop the step.
+    offering = member.classes.order_by("-created_at", "-pk").first()
+    if offering is None:
+        raise ValueError(f"Instructor {member.pk} owns no class for the compose stop")
+    return {"audience": f"class:{offering.pk}", "lock": "1"}
+
+
 TOURS: dict[str, Tour] = {
     "member-welcome": Tour(
         key="member-welcome",
@@ -97,8 +173,8 @@ TOURS: dict[str, Tour] = {
                 target=None,
                 title="Welcome to the Member Portal",
                 body=(
-                    "This is the member hub for Past Lives. Want a 30-second look around? "
-                    "Use Next — or press Esc anytime to stop."
+                    "This is your Past Lives member hub. Want a quick lap? I will drive. "
+                    "Use Next to move, or press Esc anytime to stop."
                 ),
             ),
             TourStep(
@@ -110,44 +186,81 @@ TOURS: dict[str, Tour] = {
                 ),
             ),
             TourStep(
-                target='[data-help-key="nav.guilds"]',
-                title="Guilds",
+                target='[data-help-key="home.get-started"]',
+                title="Your Get Started List",
                 body=(
-                    "Guilds are the craft groups that run each studio. Follow the ones you want "
-                    "updates from, then book an orientation to get working in the space."
+                    "A short checklist to finish setting up, including your profile, photo, and "
+                    "guild updates. It tidies itself away once you are done."
                 ),
             ),
             TourStep(
-                target='[data-help-key="nav.calendar"]',
+                target='[data-help-key="catalog.filter"]',
+                title="Browse Classes and Workshops",
+                body="Every class lives here. Filter by guild or date, then open one to see the details.",
+                navigate="classes:public_list",
+            ),
+            TourStep(
+                target='[data-help-key="catalog.class-card"]',
+                title="Each Card Is a Class",
+                body="Click a card to read what you will make and to sign up.",
+            ),
+            TourStep(
+                target='[data-help-key="calendar.filter"]',
                 title="Community Calendar",
-                body=(
-                    "Classes, guild meetups, and events all land here. Filter it, open any event, "
-                    "or subscribe from your own calendar app."
-                ),
+                body="Classes, guild meetups, and events all land here. Filter it or open any event.",
+                navigate="hub_community_calendar",
+            ),
+            TourStep(
+                target='[data-help-key="calendar.subscribe"]',
+                title="Subscribe to the Calendar",
+                body="Tap Subscribe to add the whole calendar to your own phone or laptop.",
             ),
             TourStep(
                 target='[data-help-key="voting.rank-guilds"]',
                 title="Guild Voting",
                 body=(
-                    "Each month, members rank their top 3 guilds to help decide funding. "
-                    "Your picks save automatically and you can change them anytime."
+                    "Each month you rank your top three guilds to help decide funding. "
+                    "Your picks save on their own and you can change them anytime."
                 ),
+                navigate="hub_guild_voting",
             ),
             TourStep(
-                target='[data-help-key="home.get-started"]',
-                title="Your Get Started List",
+                target='[data-help-key="spaces.map"]',
+                title="The Spaces Map",
                 body=(
-                    "A short checklist to finish setting up including your profile, photo, and "
-                    "guild updates. It disappears on its own when you're done."
+                    "Studios, storage, parking, and desks live on this map. Click any open space to "
+                    "ask about renting it and the team gets your request."
                 ),
+                navigate="hub_spaces",
+            ),
+            TourStep(
+                target='[data-help-key="orientation.book-slot"]',
+                title="Book an Orientation",
+                body=(
+                    "Before you work in a studio you book an orientation. Pick an open time here "
+                    "and the guild confirms it."
+                ),
+                navigate="hub_guild_detail",
+                navigate_kwargs=_demo_guild_slug,
+            ),
+            TourStep(
+                target='[data-help-key="class.register"]',
+                title="Register for a Class",
+                body=(
+                    "Ready to join a class? Hit Register, pick your date, and you are in. "
+                    "If it is full you can grab a waitlist spot."
+                ),
+                navigate="classes:public_class_detail",
+                navigate_kwargs=_demo_class_slug,
             ),
             TourStep(
                 target='[data-help-key="nav.help"]',
                 title="Help, Whenever",
                 body=(
                     "Stuck later? The Help page has short guides for everything you just saw. "
-                    "That's the tour — go explore."
+                    "That is the lap. Go explore."
                 ),
+                navigate="hub_help",
             ),
         ),
     ),
@@ -157,52 +270,96 @@ TOURS: dict[str, Tour] = {
         entry_url_name="hub_guild_edit",
         audience=_guild_lead_or_staff,
         entry_url_kwargs=_first_staffed_guild_pk,
-        # Steps target the tab BUTTONS (always visible) — tab panels are Alpine
-        # x-show and hidden content can't be spotlighted.
+        # A same-page lap: each step flips the Alpine `section` var to a tab and
+        # spotlights the now-visible panel. No navigation between steps, so it is
+        # very robust: a flip that finds nothing simply skips.
         steps=(
             TourStep(
                 target=None,
                 title="Your Guild's Control Room",
-                body="This page runs your guild. Each tab below covers one job — here's the quick lap.",
+                body="This page runs your guild. Every tab is one job and each saves on its own. I will flip through them.",
             ),
             TourStep(
-                target='[data-help-key="guild.edit-tabs"]',
-                title="One Tab Per Job",
-                body=(
-                    "Basic Information is your public page: banner, overview, meeting times. "
-                    "Every other tab saves on its own, so switching tabs never loses work."
-                ),
-            ),
-            TourStep(
-                target='[data-help-key="guild.manage-staff"]',
-                title="Staff — Heads Up",
-                body=(
-                    "Anyone you add here gets full guild authority: edit this page, run orientations, "
-                    "approve classes, send announcements. Every role has the same powers, so add people you trust."
-                ),
+                target='[data-help-key="guild.edit-page"]',
+                title="Your Public Page",
+                body="Basic Information is your public page: banner, overview, meeting times.",
+                tab_set=("section", "basic"),
             ),
             TourStep(
                 target='[data-help-key="guild.run-orientations"]',
                 title="Orientations",
                 body=(
-                    "Set your orientation hours and open slots here. Member bookings show up on the "
-                    "Orientations dashboard in the sidebar, where you confirm them and mark them complete."
+                    "Set your orientation hours and open slots here. Bookings show up on the "
+                    "Orientations dashboard to confirm."
                 ),
+                tab_set=("section", "orientations"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.manage-staff"]',
+                title="Staff Share Full Authority",
+                body="Anyone you add here gets full guild authority. Add people you trust.",
+                tab_set=("section", "staff"),
             ),
             TourStep(
                 target='[data-help-key="guild.announcements"]',
                 title="Announcements",
-                body=(
-                    "Write to your members with the compose wizard — draft, preview, send. Members can propose "
-                    "announcements too; they wait in your review queue until you approve them."
-                ),
+                body="Write to your members here: draft, preview, send. Member proposals wait in your review queue.",
+                tab_set=("section", "announcements"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.welcome-email"]',
+                title="The Welcome Email",
+                body="This is the welcome email new members get when they join your guild. Make it warm.",
+                tab_set=("section", "welcome_email"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.studio-hours"]',
+                title="Studio Hours",
+                body="Post when your studio is open so members know when they can drop in.",
+                tab_set=("section", "studio_hours"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.meeting-notes"]',
+                title="Meeting Notes",
+                body="Post agendas and recaps so members who miss a meeting can catch up.",
+                tab_set=("section", "meeting_notes"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.events"]',
+                title="Events",
+                body="Post one-off events like a demo night or a field trip. They land on the calendar.",
+                tab_set=("section", "events"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.photo-gallery"]',
+                title="Photo Gallery",
+                body="Add photos of your space and members' work to the gallery.",
+                tab_set=("section", "images"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.manage-faq"]',
+                title="The FAQ",
+                body="Answer common questions in the FAQ so members can help themselves.",
+                tab_set=("section", "content"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.manage-links"]',
+                title="Links",
+                body="Link out to your guides, sign-up sheets, and anything else members need.",
+                tab_set=("section", "links"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.wishlist"]',
+                title="Your Wishlist",
+                body="List the tools and supplies your guild wants. Members and donors can see it.",
+                tab_set=("section", "basic"),
             ),
             TourStep(
                 target=None,
                 title="Your Map, Whenever",
                 body=(
-                    "That's the lap. The Guild Lead Quickstart guide on the Help page lists every tool with a "
-                    "walkthrough — and the Cartographers Guild is a fully built example page to borrow ideas from."
+                    "That is the lap. The Guild Lead Quickstart on the Help page details every tool, "
+                    "and the Cartographers Guild is a full example to borrow from."
                 ),
             ),
         ),
@@ -216,38 +373,116 @@ TOURS: dict[str, Tour] = {
             TourStep(
                 target=None,
                 title="The Teaching Portal",
-                body="You're cleared to create classes here. Here's the 20-second version of how it works.",
+                body="You are cleared to teach. I will walk you from a blank draft to a published class and its roster.",
             ),
             TourStep(
                 target='[data-help-key="teach.create-class"]',
                 title="Start a Class",
-                body=(
-                    "This opens a draft: title, description, dates, price. Drafts are private — "
-                    "nothing goes public until it's been reviewed."
-                ),
-            ),
-            # Spec B already stamped the "Needs your attention" card as
-            # teach.review-pipeline — reuse it rather than minting a duplicate key.
-            TourStep(
-                target='[data-help-key="teach.review-pipeline"]',
-                title="Draft → Review → Published",
-                body=(
-                    "When you submit a draft, it goes to the guild's lead (if the category has one) and then "
-                    "an admin. Anything waiting on you, or waiting on review, shows up right here."
-                ),
+                body="Start here. This opens a private draft that nobody sees until it is reviewed.",
             ),
             TourStep(
-                target='[data-help-key="teach.roster"]',
-                title="Your Classes and Rosters",
-                body=("Click any class to see who signed up, manage the waitlist, and email your registrants."),
+                target='[data-help-key="teach.class-basics"]',
+                title="Title and Description",
+                body="Give it a clear title and describe what members will make and learn. Type your own here; I will wait.",
+                navigate="classes:teach_class_create",
+            ),
+            TourStep(
+                target='[data-help-key="teach.class-gallery"]',
+                title="Add Photos",
+                body="Drag in photos of the finished project and the space. Good images fill seats.",
+            ),
+            TourStep(
+                target='[data-help-key="teach.class-schedule"]',
+                title="Dates and Sessions",
+                body="Set the dates and times. A series just adds more sessions.",
+            ),
+            TourStep(
+                target='[data-help-key="teach.class-pricing"]',
+                title="Price and Seats",
+                body="Set the price, the number of seats, and the waitlist. This is what members see.",
+            ),
+            TourStep(
+                target='[data-help-key="teach.submit-for-review"]',
+                title="Submit for Review",
+                body="When it is ready, submit for review. It goes to the guild lead and then an admin before it publishes.",
+            ),
+            TourStep(
+                target='[data-help-key="teach.roster-table"]',
+                title="Your Roster",
+                body="Here is who signed up. Open a person's menu to remove them and a seat frees up.",
+                navigate="classes:teach_class_registrations",
+                navigate_kwargs=_instructor_class_pk,
+            ),
+            TourStep(
+                target='[data-help-key="teach.roster-waitlist"]',
+                title="The Waitlist",
+                body="Someone waiting? Promote them and they take the open seat and get a confirmation.",
+                navigate="classes:teach_class_waitlist",
+                navigate_kwargs=_instructor_class_pk,
+            ),
+            TourStep(
+                target='[data-help-key="announcements.compose"]',
+                title="Message Your Class",
+                body="Need to reach everyone in this class? Write an announcement here. It is already aimed at just this class.",
+                navigate="hub_compose",
+                query=_instructor_class_audience,
             ),
             TourStep(
                 target=None,
-                title="The Rest of the Map",
-                body=(
-                    "That's the tour. The Instructor Quickstart guide on the Help page covers everything else — "
-                    "welcome emails, announcements — and links a finished example class to study."
-                ),
+                title="That Is the Teaching Lap",
+                body="The Instructor Quickstart on the Help page covers welcome emails and more.",
+                navigate="classes:teach_overview",
+            ),
+        ),
+    ),
+    "admin": Tour(
+        key="admin",
+        title="Admin Controls",
+        entry_url_name="hub_admin_tools",
+        audience=_admin_audience,
+        steps=(
+            TourStep(
+                target=None,
+                title="The Admin Controls",
+                body="These are the admin controls. I will show the five you will reach for most.",
+            ),
+            TourStep(
+                target='[data-help-key="announcements.compose"]',
+                title="Site Wide Announcements",
+                body="Send a site wide announcement here. Pick who gets it, write once, and it can go to email, push, and Discord.",
+                navigate="hub_compose",
+            ),
+            TourStep(
+                target='[data-help-key="admin.refunds"]',
+                title="Payments and Refunds",
+                body="Every charge is here. Open one to issue a refund; the member gets it back and a receipt.",
+                navigate="billing_admin_dashboard",
+                query={"tab": "payments"},
+            ),
+            TourStep(
+                target='[data-help-key="admin.review-queue"]',
+                title="The Review Queue",
+                body="Classes waiting on you sit at the top. Review the details, then approve or send it back with a note.",
+                navigate="classes:admin_overview",
+            ),
+            TourStep(
+                target='[data-help-key="admin.discount-codes"]',
+                title="Discount Codes",
+                body="Create discount codes for a class or a promotion here, with limits and an expiry date.",
+                navigate="classes:admin_discount_codes",
+            ),
+            TourStep(
+                target='[data-help-key="admin.reconciliation"]',
+                title="Reconciliation",
+                body="This report breaks down what each guild is owed so you can reconcile payouts.",
+                navigate="billing_admin_dashboard",
+                query={"tab": "reconciliation"},
+            ),
+            TourStep(
+                target=None,
+                title="That Is the Admin Lap",
+                body="Each tool has a full guide on the Help page.",
+                navigate="hub_admin_tools",
             ),
         ),
     ),
@@ -281,32 +516,100 @@ def help_card_rows(member: Member) -> list[dict[str, Any]]:
     ]
 
 
-def _tour_payload(tour: Tour, *, autostart: bool) -> dict[str, Any]:
-    """The json_script payload pl_tour.js consumes (Spec C §6.2)."""
+def _resolve_mapping(spec: Any, member: Member) -> dict[str, Any]:
+    """Resolve a ``navigate_kwargs`` / ``query`` spec (callable, dict, or None) to a dict.
+
+    A callable is invoked with the member; it may raise ``ValueError`` to signal
+    "no eligible object" — the caller drops the step (graceful shorten).
+    """
+    if spec is None:
+        return {}
+    if callable(spec):
+        return spec(member)
+    return dict(spec)
+
+
+def _step_href(navigate: str, kwargs: dict[str, Any], query: dict[str, Any]) -> str:
+    """Resolve a step's ``navigate`` (URL name or literal path) + ``query`` to a relative href.
+
+    Raises:
+        ValueError: If the resolved href is absolute (has a scheme or host). Every
+            tour target must stay on the members apex so ``sessionStorage`` resume
+            survives the hop — a cross-origin target is a coding error, caught in
+            tests, never shipped.
+    """
+    # A namespaced URL name (e.g. "classes:public_list") carries a colon but no
+    # authority; an absolute URL carries "://". Only the latter is the coding
+    # error we guard against — a cross-origin target would break sessionStorage
+    # resume (different origin), so fail loud at build time.
+    if "://" in navigate or navigate.startswith("//"):
+        raise ValueError(f"Tour navigate {navigate!r} is a cross-origin URL; tours must stay relative")
+    path = navigate if navigate.startswith("/") else reverse(navigate, kwargs=kwargs)
+    if query:
+        path = f"{path}?{urlencode(query)}"
+    return path
+
+
+def _tour_payload(tour: Tour, member: Member, *, autostart: bool) -> dict[str, Any]:
+    """The json_script payload ``pl_tour.js`` consumes.
+
+    Resolves each step's ``navigate`` to a concrete relative href (member-resolved
+    kwargs + query), carries the current page path forward for the runtime's
+    location assertion, and **drops** any step whose ``navigate_kwargs`` / ``query``
+    resolver raises ``ValueError`` (no eligible object → a shorter, still-coherent
+    tour rather than a 500).
+    """
+    entry_kwargs = tour.entry_url_kwargs(member) if tour.entry_url_kwargs is not None else {}
+    current_path = reverse(tour.entry_url_name, kwargs=entry_kwargs)
+    steps: list[dict[str, Any]] = []
+    for step in tour.steps:
+        try:
+            nav_kwargs = _resolve_mapping(step.navigate_kwargs, member)
+            query = _resolve_mapping(step.query, member)
+        except ValueError:
+            logger.warning("tour %s: dropping step %r (resolver raised)", tour.key, step.title)
+            continue
+        href = None
+        if step.navigate is not None:
+            href = _step_href(step.navigate, nav_kwargs, query)
+            current_path = urlsplit(href).path
+        steps.append(
+            {
+                "target": step.target,
+                "title": step.title,
+                "body": step.body,
+                "navigate": href,
+                "tab_set": list(step.tab_set) if step.tab_set is not None else None,
+                "click": step.click,
+                "wait_for": step.wait_for,
+                "page_path": current_path,
+            }
+        )
     return {
         "key": tour.key,
         "title": tour.title,
-        "steps": [{"target": step.target, "title": step.title, "body": step.body} for step in tour.steps],
+        "steps": steps,
         "state_url": reverse("hub_tour_state", kwargs={"tour_key": tour.key}),
         "autostart": autostart,
         "opens_sidebar": tour.opens_sidebar,
+        "resume_step": 0,
     }
 
 
 def tour_offer_context(request: HttpRequest, tour_key: str) -> dict[str, Any]:
-    """The one helper entry-page views call — owns every offer/autostart guard.
+    """The one helper that owns every offer/autostart guard for a single tour.
 
-    Returns ``{tour, tour_json, show_tour_offer, tour_autostart}``. Guard order
-    (Spec C §5): anonymous/no member → nothing; ``?tour=`` matching this page's
-    tour for an eligible member → autostart (no ``offered`` row written, and
-    dismissed/completed never block a manual start); otherwise auto-offer only
-    when the toggle is on, the audience passes, the welcome modal isn't showing,
-    and the ``TourState`` row is absent or still ``OFFERED`` (first eligible GET
-    writes the ``offered`` row).
+    Returns ``{tour, tour_json, show_tour_offer, tour_autostart}``. Guard order:
+    anonymous/no member → nothing; ``?tour=`` matching this page's tour for an
+    eligible member → autostart (no ``offered`` row written, and dismissed/
+    completed never block a manual start); otherwise auto-offer only when the
+    toggle is on, the audience passes, the welcome modal isn't showing, and the
+    ``TourState`` row is absent or still ``OFFERED`` (first eligible GET writes
+    the ``offered`` row).
 
     Raises:
         KeyError: If ``tour_key`` isn't a registered tour (a coding error in the
-            calling view — fail loudly).
+            caller — fail loudly).
     """
     from core.models import TourState
 
@@ -322,7 +625,7 @@ def tour_offer_context(request: HttpRequest, tour_key: str) -> dict[str, Any]:
     if request.GET.get("tour") == tour_key:
         return {
             "tour": tour,
-            "tour_json": _tour_payload(tour, autostart=True),
+            "tour_json": _tour_payload(tour, member, autostart=True),
             "show_tour_offer": False,
             "tour_autostart": True,
         }
@@ -338,7 +641,7 @@ def tour_offer_context(request: HttpRequest, tour_key: str) -> dict[str, Any]:
         return empty
     return {
         "tour": tour,
-        "tour_json": _tour_payload(tour, autostart=False),
+        "tour_json": _tour_payload(tour, member, autostart=False),
         "show_tour_offer": True,
         "tour_autostart": False,
     }

--- a/docs/superpowers/plans/2026-08-27-guided-tours-autonav.md
+++ b/docs/superpowers/plans/2026-08-27-guided-tours-autonav.md
@@ -1,0 +1,416 @@
+# Auto-Navigating, Role-Based Guided Tours — Spec & Implementation Plan
+
+**Status:** Spec only — not yet approved to build.
+**Date:** 2026-08-27
+**Surface:** FOG hub (`pastlives.test` / members apex) — the whole authenticated hub, plus the classes teaching and admin surfaces that render on the apex. Runtime: `static/js/pl_tour.js`, registry `core/tours.py`, state `core.models.TourState`.
+**Related:** the original guided-tour work (Spec C, in-code in `core/tours.py` / `pl_tour.js`); `docs/HELP_AUTHORING.md` (Tours section); `core/help_registry.py` drift guard (`tests/hub/help_keys_spec.py`).
+
+---
+
+## 1. Summary
+
+Today a guided tour is a spotlight lap of **one page**: the moment you navigate, the tour is destroyed on purpose (`Tour` docstring: "Multi-page tours are consciously not built"). This spec rebuilds the runtime so a tour can **drive the browser**: it narrates a step, then moves to the next screen for you — navigating to another page or flipping a tab on the same page — detects that the new screen has loaded, and keeps narrating there. You still fill in real content yourself (typing a class description, picking an orientation time); the tour just gets you to the right place, in order, hands-free. The payoff is a live demo the owner can *click once and let run*, and a genuinely guided onboarding for new members, instructors, guild leads, and admins.
+
+We also add a **fourth role tour — Admin** — so the four are Member, Instructor, Guild Lead, and Admin.
+
+### Locked decisions (from the brief + codebase scout)
+
+| Decision | Choice |
+|---|---|
+| Central design change | Invert the "navigation = destroy" contract. Navigation now **persists and resumes** the tour instead of tearing it down. |
+| Resume carrier | `sessionStorage` (survives full reloads within an origin) **plus** a `?tour=<key>&step=<n>` URL param (survives everything, is the authoritative seed). The existing `?tour=` autostart is extended with `&step=`. |
+| Do we ever cross subdomains? | **No.** Every tour target reverses to a **relative** path on the members apex (teach + admin are member-only; catalog/detail/register also resolve on the apex). Steps must never point at an absolute `book.pastlives.test` URL — that is the one thing that would break resume (different origin, different `sessionStorage`). |
+| Same-page tab switch | Flip the Alpine tab variable directly (precedent: `sidebarOpen`), then wait for the now-visible panel. `click` on the tab button is the documented fallback. |
+| Between-page navigation | Prefer an **htmx boosted** GET (body swap + `pushState`, no white flash) with `?tour=&step=` on the pushed URL; fall back to `window.location.assign` if htmx is unavailable. |
+| Backward compatibility | A `TourStep` with none of the new action fields set behaves **exactly** as today (highlight-only, single page). The three existing tours keep working unchanged until we script them. |
+| New DB schema? | **None.** `TourStep` is an in-code frozen dataclass (no model, no migration). `TourState` is untouched and keeps recording offered / completed / dismissed. |
+| Admin tour audience | `member.is_fog_admin` **or** the member holds any `AdminCapability`. Entry page: Admin Tools (`/tools/`). |
+| Robustness posture | Optimized for the **specific demo paths**, not generality. Every step degrades gracefully (skip on missing target, abort on wrong page) and the tour can always be ended with Esc / the popover ✕. |
+
+---
+
+## 2. What already exists (reuse, don't reinvent)
+
+The build is mostly *assembly* — the tour spine, state model, offer card, settings toggle, and Help cards are all in place. This table maps each need to the existing plumbing.
+
+| Need | Existing thing | Location |
+|---|---|---|
+| Tour registry (frozen dataclasses + `TOURS` dict) | `Tour` / `TourStep`, `TOURS`, `tours_for()`, `entry_url_for()`, `help_card_rows()`, `_tour_payload()`, `tour_offer_context()` | `core/tours.py` |
+| Per-user tour state (offered/completed/dismissed) | `TourState` + `TourStateManager` (`mark_offered/completed/dismissed`, `status_for`, `statuses_for`) | `core/models.py:1154-1246` |
+| State-recording endpoint | `tour_state` view + `TourStateForm` | `hub/views.py:157`, `hub/forms.py:3095`, url `hub_tour_state` (`hub/urls.py:350`) |
+| Runtime controller (lazy Driver.js load, offer binding, sidebar flip, focus mgmt, state POST) | `window.plTour` IIFE | `static/js/pl_tour.js` |
+| Vendored Driver.js v1.3.6 + CSS (lazy-loaded) | `static/js/driver.min.js`, `static/css/driver.css` | referenced from `templates/hub/partials/_tour.html` |
+| Payload + offer template | `_tour.html`, `_tour_offer.html` | `templates/hub/partials/` |
+| Offer card CSS + popover theming (dark/light overlay already computed) | `.pl-tour-offer`, `.pl-tour` popover class | `static/css/hub.css` / `components.css`; theme handled in `runTour()` (`pl_tour.js:138-145`) |
+| Settings toggle `guided_tours_enabled` | `Member.guided_tours_enabled` field, `TourSettingsForm`, `_tour_settings.html` | `membership/models.py:557`, `hub/forms.py:3120`, `templates/hub/_tour_settings.html` |
+| Help-page "Guided tours" card rows | `help_card_rows(member)` → `hub_help` | `core/tours.py:268`, `templates/hub/help.html` |
+| Body-level Alpine state for the sidebar flip precedent | `x-data="{ sidebarOpen: … }"` on `<body hx-boost="true">` | `templates/hub/base.html:72` |
+| Guild-edit tab machinery (Alpine `section`, **also seeds from `?tab=`**) | `x-data="{ section: <?tab=…> || 'basic' }"` | `templates/hub/guild_edit.html:5` |
+| `[data-help-key]` selector convention + drift guard | help registry + template-walk test | `core/help_registry.py`, `tests/hub/help_keys_spec.py` |
+| Existing pk-resolver precedent (guild-lead entry) | `_first_staffed_guild_pk(member)` | `core/tours.py:74` |
+
+### Genuine gaps to close (kept small)
+
+1. **`TourStep` action fields** — `navigate`, `navigate_kwargs`, `tab_set`, `click`, `wait_for` (all optional). §4.
+2. **Multi-page/segment resume in `pl_tour.js`** — the inverted contract, segment grouping, wait/retry, location assertion, graceful skip, "advancing" affordance, URL-param cleanup. §5 + §6.
+3. **Site-wide payload availability** — a `core.context_processors.tour_runtime` context processor + including the bootstrap in the three base templates so any page a tour lands on can re-hydrate. §5.
+4. **Payload additions** — `_tour_payload` resolves each step's `navigate` to a concrete relative href (with member-resolved kwargs), tags each step with a stable `page_id` for segment grouping + location assertion, and drops steps whose resolver raises. §5.
+5. **A fourth tour (`admin`) + one new audience predicate + two pk/slug resolvers** (a class for the instructor tour, a guild/class for the member tour). §5 + §6.
+6. **New `[data-help-key]` hooks** on the demo-path elements that have none, each registered in `core/help_registry.py`. §6 (hooks table).
+7. **CHANGELOG + VERSION bump** (1.19.1 → 1.20.0). §8.
+
+---
+
+## 3. Where the code lives
+
+```
+core/
+  tours.py                  # extend TourStep; add TOURS["admin"]; extend member/instructor/guild-lead
+                            #   step lists; audience predicate _admin_audience; resolvers
+                            #   (_demo_guild_slug, _demo_class_slug, _instructor_class_pk);
+                            #   _tour_payload gains navigate-href resolution + page_id + skip-on-raise
+  context_processors.py     # NEW: tour_runtime(request) -> {tour_json, show_tour_offer, tour_autostart}
+  help_registry.py          # register every NEW data-help-key (and stamp the already-registered-but-unused ones)
+plfog/settings.py           # add core.context_processors.tour_runtime to context_processors list
+static/js/pl_tour.js        # the runtime rewrite (segments, resume, wait/retry, location guard, advancing UI)
+static/css/hub.css          # .pl-tour-advancing overlay/spinner (theme tokens)
+templates/hub/base.html            # include hub/partials/_tour.html in extra_js (already there on some pages -> move to base)
+templates/classes/teach/base.html  # include the tour bootstrap (teaching portal is a tour surface)
+templates/classes/base_public.html # include the tour bootstrap (catalog/detail/register are member-tour stops)
+templates/**/*.html         # add the new data-help-key attributes (hooks table in §6)
+plfog/version.py            # VERSION 1.20.0 + member-facing CHANGELOG entry
+core/spec/tours_spec.py             # registry + payload + audience + resolver tests
+core/spec/context_processors_spec.py# tour_runtime gating tests
+tests/hub/help_keys_spec.py         # extend expected-keys set for the new hooks
+tests/e2e/                          # NEW auto-nav Playwright spec (the real runtime guard)
+```
+
+No new app. `core.py`/`hub` stay inside the existing coverage + mypy scope.
+
+---
+
+## 4. Data model
+
+**No database change. No migration.** `TourState` (offered/completed/dismissed, one row per `(user, tour_key)`) is exactly right for multi-page tours: a tour is one lifecycle regardless of how many pages it spans. Completion is recorded once, on the true final step.
+
+### `TourStep` — extended in-code dataclass (`core/tours.py`)
+
+Frozen dataclass, all new fields optional with safe defaults, so today's highlight-only steps are unchanged.
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `target` | `str \| None` | *(required)* | CSS selector to spotlight; `None` = centered popover. (unchanged) |
+| `title` | `str` | *(required)* | Title Case step title. (unchanged) |
+| `body` | `str` | *(required)* | ELI14 narration, 1-2 sentences. **No dashes** in new copy (arrow `->` allowed). (unchanged) |
+| `navigate` | `str \| None` | `None` | URL **name** (preferred) or literal path to load **before** this step. Resolved to a concrete **relative** href at payload-build time. `None` = stay on the current page. |
+| `navigate_kwargs` | `Callable[[Member], dict] \| dict \| None` | `None` | kwargs for `reverse(navigate, kwargs=…)` (e.g. a guild pk, a class pk). A callable is resolved with the member at payload-build time. If it raises `ValueError`, the step is **dropped** (graceful shorten). |
+| `query` | `dict[str, str] \| None` | `None` | query string appended to the resolved href (e.g. `{"tab": "payments"}`, `{"audience": "class:42", "lock": "1"}`). |
+| `tab_set` | `tuple[str, str] \| None` | `None` | `(alpine_var, value)` to flip an Alpine tab on the current page **before** showing (e.g. `("section", "orientations")`). No navigation. |
+| `click` | `str \| None` | `None` | selector to click before this step — documented fallback for a link/tab button when `tab_set`/`navigate` do not fit. |
+| `wait_for` | `str \| None` | `None` | selector that must be present **and** visible before the popover shows; defaults to `target`. Backs the async-content / Alpine-hydration wait. |
+
+Rules kept from CLAUDE.md: frozen dataclass, `from __future__ import annotations`, full type hints, meaningful behavior documented in the docstring. No `help_text`/`__str__` — this is not a Django model.
+
+### `Tour` — one small addition
+
+`Tour` keeps `key`, `title`, `entry_url_name`, `entry_url_kwargs`, `audience`, `steps`, `opens_sidebar`. A multi-page tour's `entry_url_name` is simply **the first step's page** (where the offer/autostart lives); every later page is reached by a step's `navigate`. No structural change needed — the step list carries the itinerary.
+
+### Client payload (JSON, what `pl_tour.js` consumes)
+
+`_tour_payload` already emits `{key, title, steps[], state_url, autostart, opens_sidebar}`. Each step object gains:
+
+```jsonc
+{
+  "target": "[data-help-key=\"voting.rank-guilds\"]",
+  "title": "Guild Voting",
+  "body": "Each month you rank your top three guilds ...",
+  "navigate": "/guilds/voting/",        // concrete RELATIVE href, or null
+  "query": null,                          // already folded into navigate at build time
+  "tab_set": ["section", "orientations"], // or null
+  "click": null,                          // or null
+  "wait_for": "[data-help-key=\"voting.rank-guilds\"]", // defaults to target
+  "page_id": "hub_guild_voting"           // stable id: last navigate target carried forward; used for
+                                          //   segment grouping + location assertion
+}
+```
+
+`page_id` is computed server-side: it is the URL name of the most recent `navigate` at or before this step (the entry page for steps before any navigate). Consecutive steps with the same `page_id` **and** compatible `tab_set` form one **segment** (one Driver.js instance). A change in `page_id` = a navigation hop; a change in `tab_set` on the same `page_id` = a tab hop.
+
+---
+
+## 5. Business logic (the runtime + the registry)
+
+### 5.1 `core/tours.py` — payload resolution (thin, fail-loud, graceful-skip)
+
+`_tour_payload(tour, member, *, autostart)` (now takes `member`):
+
+- For each step: resolve `navigate` via `reverse(name, kwargs=resolve(navigate_kwargs, member))`, append `query`, and set `page_id`. If `navigate_kwargs` (or a `target`-less resolver) raises `ValueError`, **drop the step** and continue (mirrors the runtime's "missing target → drop" philosophy: a demo with no eligible class simply skips the register step rather than 500ing). Log at `warning`.
+- Never emit an absolute cross-origin href. If a resolved href is absolute and its host differs from the members apex, raise a **coding-error** `ValueError` at build time (fail loud in tests, never on stage) — steps must be relative.
+
+New resolvers (frozen-callable style, like `_first_staffed_guild_pk`):
+
+- `_admin_audience(member) -> bool` — `member.is_fog_admin or member.has_admin_capability()` (or `AdminCapability.objects.filter(member=member).exists()` if no helper exists). Fail loud only inside `_validate` paths; audience predicates return bool.
+- `_demo_guild_slug(member) -> dict` — a guild for the member tour's orientation stop: first **active** guild that currently exposes open orientation slots; else first active guild; raise `ValueError` if none (step drops).
+- `_demo_class_slug(member) -> dict` — a class for the member tour's register stop: first `ClassOffering.objects.bookable()` (future, published, seats); raise `ValueError` if none (step drops).
+- `_instructor_class_pk(member) -> dict` — the instructor's most-recent class for the roster + announcement stops: `member`'s newest `ClassOffering`; raise `ValueError` if none (both steps drop, tour shortens to create+submit).
+
+`tours_for`, `entry_url_for`, `help_card_rows`, `tour_offer_context` keep their signatures. `entry_url_for` still returns `entry_url + "?tour=<key>"` (step 0 implied).
+
+### 5.2 `core/context_processors.py::tour_runtime(request)` — site-wide payload
+
+The single choke-point that decides, on **every** request, whether this page should emit a tour payload:
+
+1. Anonymous / no member → `{}` (nothing).
+2. `?tour=<key>` present, member eligible → **autostart/resume** payload with `resume_step = int(request.GET.get("step", 0))`, clamped to a valid index. (No `TourState` write — a driven hop is not an offer.) Works on **any** page, which is what makes resume possible.
+3. Otherwise, on a tour's **entry page** (`request.resolver_match.url_name == tour.entry_url_name`) → reuse the existing offer/auto-offer guard logic from `tour_offer_context` (toggle on, audience passes, welcome modal not showing, `TourState` absent or still `OFFERED`; first eligible GET writes the `offered` row). Emits `show_tour_offer`.
+4. Else `{}`.
+
+This **replaces** the three per-view `tour_offer_context` calls (`hub_home`, `hub_guild_edit`, `classes:teach_overview`) with one processor — the offer still appears only on entry pages (guard 3), and resume now works everywhere (guard 2). The processor returns `{tour, tour_json, show_tour_offer, tour_autostart, tour_resume_step}`.
+
+`_tour.html` (payload `json_script` + offer + `pl_tour.js`) moves from per-page includes into the **three base templates** (`hub/base.html`, `classes/teach/base.html`, `classes/base_public.html`) inside their `extra_js` block, gated on `{% if tour_json %}` exactly as today. Driver.js itself stays lazy (loaded only when a tour actually runs), so ordinary pageviews pay only ~2 KB for `pl_tour.js`.
+
+### 5.3 `pl_tour.js` — the inverted contract (the heart of this spec)
+
+The controller becomes a **segment player over a persisted itinerary**. Prose first, then the loop.
+
+**Persisted running state** (`sessionStorage["plTourRun"]`): `{ key, index, total }` where `index` is the **global** step index into the full itinerary. Written on start and before every hop; cleared on completion, dismissal, or user-initiated navigation away.
+
+**Segment building.** From the payload's step list, group into segments by `(page_id, tab_set)`. `buildSegment(globalIndex)` returns the maximal run `[a..b]` containing `globalIndex` whose steps share the current page and tab context. Driver.js is built with only those steps; it starts at local offset `globalIndex - a`.
+
+**Custom Next/Back (Driver.js `onNextClick` / `onPrevClick`).** Providing these hooks stops Driver from auto-advancing, so we own the boundaries:
+- `onNextClick`: not last-in-segment → `driverObj.moveNext()`. Last-in-segment with more steps globally → `advance(+1)`. Last-in-segment and globally last → `driverObj.destroy()` → `onDestroyStarted` records **completed**.
+- `onPrevClick`: symmetric with `advance(-1)`.
+
+**`advance(delta)`** — the hop:
+1. `index += delta`; write `plTourRun`.
+2. Read `nextStep = steps[index]`.
+3. If `nextStep.page_id` differs from the current page → **navigate hop**: set `navigatingForTour = true`, then boosted GET to `nextStep.navigate` (or the current path if `navigate` is null but page_id changed — shouldn't happen) with `?tour=<key>&step=<index>` on the pushed URL. Tear down the Driver overlay silently (keep `plTourRun`). Show the **advancing** affordance. Resume runs on the new page's `init()`.
+4. Else (same page) → **tab hop**: destroy the current Driver silently, run `applyTabOrClick(nextStep)`, `await waitFor(nextStep)`, then `driveSegment(index)` on the same page.
+
+**`applyTabOrClick(step)`** — reach the panel:
+- `tab_set` → find the nearest element whose Alpine scope owns `alpine_var` (walk up from `target`, else `document.body`), set `Alpine.$data(el)[var] = value`; `requestAnimationFrame` once so the `x-show` panel paints.
+- else `click` → `document.querySelector(step.click)?.click()`.
+- Prefer `tab_set` for guild-edit (var `section`) and user-settings (var `tab`); `click` is the fallback for a link or a server `?tab=` surface that is actually a navigation.
+
+**`waitFor(step)`** — the async guard (this is what makes "detect the new page loaded" real): poll (rAF loop, ~50 ms, cap ~4 s) until `document.querySelector(step.wait_for || step.target)` exists **and** is visible (`offsetParent !== null`). Centered steps (`target == null`, no `wait_for`) resolve immediately. On timeout → **graceful skip**: `console.warn`, then `advance(+1)` (or end if last). Never hangs.
+
+**Resume on load (`init()`)** — the gate:
+1. Read `?tour` / `?step` from the URL and the payload. If a payload is present and `autostart`/resume-step applies → this is the authoritative seed: write `plTourRun = {key, index: resumeStep, total}`, load assets, `await waitFor(steps[resumeStep])`, **assert location** (`location.pathname` starts with the expected page's path; if not, clear run + stop silently — a 302 sent us somewhere unexpected), then `driveSegment(resumeStep)`.
+2. Else read `plTourRun` from `sessionStorage`. If present and the current location matches `steps[index].page_id`'s path → resume (covers an accidental same-page reload). If location does **not** match → the user navigated away on their own → clear `plTourRun`, do nothing.
+
+**Teardown split** (replaces the single `teardown()` bound to htmx events):
+- `teardownForNav()` (we set `navigatingForTour` right before our own boosted GET) → destroy the Driver overlay silently, **keep** `plTourRun`. Bound so `htmx:beforeHistorySave` / `htmx:beforeSwap` do not serialize the overlay into history.
+- User-initiated swap (`navigatingForTour` false) → destroy overlay, **clear** `plTourRun` (they abandoned), record nothing.
+
+**End-of-tour hygiene.** On completed **or** dismissed: `postState(...)` as today, clear `plTourRun`, and `history.replaceState` to strip `?tour=&step=` from the URL so a later refresh does not silently restart the tour. Esc / ✕ / overlay click still route through `onDestroyStarted` (dismissed unless truly last step) — unchanged contract, now also clears the run.
+
+**Progress text.** `showProgress` with `progressText: "{{current}} of {{total}}"` where the controller offsets local→global (`progressText` set per segment from `index`/`total`) so the popover reads "6 of 12" across the whole tour, not per page.
+
+**Reduced motion / focus / lazy assets / double-start guards** — all preserved from today (`prefers-reduced-motion`, popover focus in `onHighlighted`, `restoreFocus` in `cleanup`, cached `assetsPromise`, `window.plTour` re-declare guard, `data-pl-tour-init` bind guard).
+
+### 5.4 Failure modes and how each degrades (demo-safety)
+
+| Failure | Guard | Result on stage |
+|---|---|---|
+| A target never loads / was renamed | `waitFor` timeout (~4 s) → `advance(+1)` | Tour skips that stop and continues; `console.warn` for the operator. Never freezes. |
+| A tab panel animates (x-transition) | `waitFor` polls until the in-panel target is *visible*, not just present | Popover appears only once the panel is really there. |
+| A navigate 302-redirects (e.g. a locked area) | Location assertion after `waitFor` | Tour stops silently instead of spotlighting the wrong element (won't happen for the eligible demo user, but safe). |
+| Cross-subdomain (absolute `book.` URL) | Build-time `ValueError` in `_tour_payload` | Caught in tests, never ships; runtime never sees it. |
+| Instructor has no class / no bookable class / no active guild | Resolver raises `ValueError` → step dropped at build time | Tour is shorter, still coherent; no 500. |
+| Driver.js asset fails to load | Existing `assetsPromise` reject path | Sidebar flip reverted, tour silently does not start; retry next time. |
+| User clicks a sidebar link mid-tour (full reload, `hx-boost="false"`) | Resume gate step 2 location mismatch | `plTourRun` cleared, tour ends cleanly — no ghost popover on the new page. |
+| Lost `postState` on dismiss | Existing keepalive + self-heal | Row stays `OFFERED`, offer reappears next visit — honest. |
+
+**Pre-flight (operator) checklist** for a clean demo lives in §10 (seed a bookable class, an active guild with orientation slots, and — for the instructor tour — the demo account owning a class with a waitlisted registration).
+
+---
+
+## 6. UI / UX  (completeness checklist applied per screen)
+
+This feature adds **no new forms** — it is runtime behavior over existing screens, plus one small "advancing" affordance, a fourth tour's content, and attribute-only `data-help-key` hooks. The screens below are walked against the checklist; the list-editor items (Add/Delete/Save) do not apply (no formsets), but states, dark/light, mobile, and "no dead end" all do.
+
+### 6.1 The tour popover (Driver.js, `.pl-tour`)
+
+- **Layout & container:** existing Driver.js popover, spotlight overlay, Next / Back / Done / ✕. Progress reads global "N of M" (§5.3).
+- **States:** *loading* — while Driver.js assets load and between hops, the **advancing affordance** (below) covers the gap so the screen never flashes bare. *success* — final Done records completed and strips the URL param. *error* — a missing target skips; a wrong page ends cleanly. *empty* — a tour that resolves to <2 steps for this member does not autostart (existing guard), and a manual start shows what remains.
+- **No dead end:** Esc / ✕ / overlay click always end the tour; the URL param is stripped so refresh does not restart it.
+- **Dark + light:** overlay color already switches on `data-theme` (`pl_tour.js:138-145`); popover uses `.pl-tour` tokens. No new colors. Verify both themes.
+- **Mobile:** Driver.js repositions the popover; centered steps have no anchor so they always fit. `opens_sidebar` continues to open the collapsed sidebar before sidebar targets are spotlighted.
+
+### 6.2 The "advancing" affordance (NEW, tiny)
+
+- **Screen / partial:** a single element `#pl-tour-advancing` (added to `_tour.html`), toggled by `pl_tour.js`.
+- **Layout:** a low, non-blocking overlay with a small spinner and the label "Taking you there..." (no dashes), shown from the instant a hop is triggered until `waitFor` resolves on the destination. Prevents the "bare page for a beat" flash during a boosted swap or reload.
+- **States:** visible only during a hop; removed on arrival or on skip/timeout.
+- **Dark + light:** `static/css/hub.css`, class `.pl-tour-advancing`, theme tokens only (`--hub-bg` scrim at low opacity, `--hub-text` label, `--color-tuscan-yellow` spinner accent). No hardcoded colors; `--surface` is not a token (do not use it). Verify both themes.
+- **Mobile:** centered, `max-width:100%`, 8px-grid padding; tap-through disabled while shown (it is brief).
+- **Reduced motion:** spinner respects `prefers-reduced-motion` (static dot instead of spin).
+
+### 6.3 The offer card (`_tour_offer.html`) — unchanged behavior
+
+- Compact fixed bottom-right card, `role="status"`, "Show me around" / "No thanks". Still rendered only on entry pages (context-processor guard 3). "Show me around" starts at step 0 and the tour drives from there. No change to markup or CSS.
+
+### 6.4 Settings toggle (`_tour_settings.html`) — unchanged
+
+- `Member.guided_tours_enabled` via `components/toggle.html`. Off → no auto-offers (manual "Show me around" and the Help cards still work). Verified by existing tests; no change.
+
+### 6.5 Help-page "Guided tours" card (`help.html`) — grows to four rows
+
+- `help_card_rows(member)` already renders one row per eligible tour with a "completed" tick and a manual-start URL (`entry_url_for` → `?tour=<key>`). Adding the `admin` tour makes it appear automatically for admins. Each row's link now kicks off a full auto-nav lap.
+- **Empty state:** a member eligible for zero tours (rare) sees the card's existing empty copy. **Success:** completed tours show the existing tick. No new UI.
+
+### 6.6 New `data-help-key` hooks (attribute-only additions)
+
+Every new hook is registered in `core/help_registry.py` (the drift test `tests/hub/help_keys_spec.py` fails otherwise) and pointed at the relevant Help anchor. Keys marked **(reuse)** already exist in the registry but were never stamped on a template — stamping them is free.
+
+| Tour / stop | Template + element | `data-help-key` | New or reuse |
+|---|---|---|---|
+| Member: catalog | `classes/public/list.html` — `.cp-filter` / `#cp-filter-form` | `catalog.filter` | new |
+| Member: catalog | `classes/public/partials/_list_results.html` — first `.cls-card` | `catalog.class-card` | new |
+| Member: spaces | `hub/spaces.html` — `.pl-map` container | `spaces.map` | new |
+| Member: register | `classes/public/detail.html` — `.cp-detail__cta` | `class.register-cta` | reuse (`class.register`) |
+| Instructor: title/desc | `classes/teach/class_form.html` — wrapper around `#id_title`/`#id_description` | `teach.class-basics` | new |
+| Instructor: gallery | `classes/teach/class_form.html` — `#gallery-manager` | `teach.class-gallery` | new |
+| Instructor: roster | `classes/teach/class_registrations.html` — registrations table container | `teach.roster-table` | new |
+| Instructor: waitlist | `classes/teach/class_registrations.html` — waitlist section | `teach.roster-waitlist` | new |
+| Instructor + Admin: composer | `hub/announcement_compose.html` — `[x-ref="wizardForm"]` wrapper | `compose.wizard` | reuse (`announcements.compose`) |
+| Guild Lead: welcome msg | `hub/guild_edit.html` — `form.discord_welcome_message` wrapper (Meetings panel) | `guild.welcome-message` | new |
+| Guild Lead: meetings | `hub/guild_edit.html` — meeting-schedule block (Meetings panel) | `guild.meetings` | reuse (`guild.meeting-notes`) or new |
+| Guild Lead: studio hours | `hub/guild_edit.html` — Studio Hours panel card | `guild.studio-hours` | reuse |
+| Guild Lead: events | `hub/guild_edit.html` — Events panel card | `guild.events` | reuse |
+| Guild Lead: wishlist | `hub/guild_edit.html` — `form.wishlist` wrapper (Basic panel) | `guild.wishlist` | new |
+| Admin: review queue | `classes/admin/overview.html` — `.overview-title` section | `admin.review-queue` | reuse |
+| Admin: refunds | `billing/partials/payments_table.html` — table container | `admin.refunds` | new |
+| Admin: discount codes | `classes/admin/discount_codes.html` — `.admin-toolbar` | `admin.discount-codes` | new |
+| Admin: reconciliation | `billing/admin_reports.html` — `payout_summary` block | `admin.reconciliation` | new |
+
+Reused-but-existing panel hooks the guild-lead tour rides after a `tab_set`: `guild.edit-page` (basic), `guild.run-orientations` (orientations tab btn), `guild.manage-staff` (staff), `guild.announcements` (announcements tab btn), `guild.photo-gallery` (images), `guild.manage-faq` (content). Note `document.querySelector` is **first-match-wins** and `base.html` renders the sidebar twice — sidebar keys (`nav.calendar`, `voting.rank-guilds`, `nav.help`) resolve to the first-rendered copy, which is fine for spotlighting.
+
+**Single-line `{# #}` only** in any template edits (multi-line comments render as visible text — `tests/template_comment_lint_spec.py` guards this).
+
+### 6.7 The four tours — concrete step lists
+
+Narration is member-facing: **no dashes** (arrow `->` allowed), ELI14, 1-2 sentences. "Page" is the URL name that `navigate` reverses to (all relative, members apex). "Action" is how the runtime reaches the step.
+
+#### Member (`member-welcome`) — extends today's 7 hub-home steps into a lap
+
+| # | Page | Action | Target | Narration |
+|---|---|---|---|---|
+| 1 | hub_home | (start; `opens_sidebar`) | centered | Welcome to your Past Lives member hub. Take a quick lap and I will drive. Use Next to move, or press Esc anytime to stop. |
+| 2 | hub_home | — | `nav.sidebar` | The sidebar reaches everything: guilds, classes, the calendar, your settings. On a phone the menu button opens it. |
+| 3 | hub_home | — | `home.get-started` | Your Get Started checklist. Finish these and it tidies itself away. |
+| 4 | classes:public_list | navigate | `catalog.filter` | Every class and workshop lives here. Filter by guild or date, then open one to see the details. |
+| 5 | classes:public_list | — | `catalog.class-card` | Each card is a class. Click it to read what you will make and to sign up. |
+| 6 | hub_community_calendar | navigate | `calendar.filter` | Classes, guild meetups, and events all land on the calendar. Filter it or open any event. |
+| 7 | hub_community_calendar | — | `calendar.subscribe` | Tap Subscribe to add the whole calendar to your own phone or laptop. |
+| 8 | hub_guild_voting | navigate | `voting.rank-guilds` | Each month you rank your top three guilds to help decide funding. Your picks save on their own and you can change them anytime. |
+| 9 | hub_spaces | navigate | `spaces.map` | Studios, storage, parking, and desks live on this map. Click any open space to ask about renting it and the team gets your request. |
+| 10 | hub_guild_detail (`_demo_guild_slug`) | navigate | `orientation.book-slot` | Before you work in a studio you book an orientation. Pick an open time here and the guild confirms it. |
+| 11 | classes:public_class_detail (`_demo_class_slug`) | navigate | `class.register-cta` | Ready to join a class? Hit Register, pick your date, and you are in. If it is full you can grab a waitlist spot. |
+| 12 | hub_help | navigate | `nav.help` | Stuck later? The Help page has short guides for everything you just saw. That is the lap. Go explore. |
+
+Steps 10 and 11 drop cleanly if no eligible guild/class exists (resolver raises → step removed at build time).
+
+#### Instructor (`instructor`) — extends today's 5 steps
+
+| # | Page | Action | Target | Narration |
+|---|---|---|---|---|
+| 1 | classes:teach_overview | (start) | centered | You are cleared to teach. I will walk you from a blank draft to a published class and its roster. |
+| 2 | classes:teach_overview | — | `teach.create-class` | Start here. This opens a private draft that nobody sees until it is reviewed. |
+| 3 | classes:teach_class_create | navigate | `teach.class-basics` | Give it a clear title and describe what members will make and learn. Type your own here; I will wait. |
+| 4 | classes:teach_class_create | — | `teach.class-gallery` | Drag in photos of the finished project and the space. Good images fill seats. |
+| 5 | classes:teach_class_create | — | `teach.class-schedule` | Set the dates and times. A series just adds more sessions. |
+| 6 | classes:teach_class_create | — | `teach.class-pricing` | Set the price, the number of seats, and the waitlist. This is what members see. |
+| 7 | classes:teach_class_create | — | `teach.submit-for-review` | When it is ready, submit for review. It goes to the guild lead and then an admin before it publishes. |
+| 8 | classes:teach_class_registrations (`_instructor_class_pk`) | navigate | `teach.roster-table` | Here is who signed up. Open a person's menu to remove them and a seat frees up. |
+| 9 | classes:teach_class_registrations | — | `teach.roster-waitlist` | Someone waiting? Promote them from the waitlist and they take the open seat and get a confirmation. |
+| 10 | hub_compose (`query: audience=class:<pk>, lock=1`) | navigate | `compose.wizard` | Need to reach everyone in this class? Write an announcement here. It is already aimed at just this class. |
+| 11 | classes:teach_overview | navigate | centered | That is the teaching lap. The Instructor Quickstart on the Help page covers welcome emails and more. |
+
+Steps 8 to 10 drop if the demo instructor owns no class (resolver raises); the tour ends after step 7 + a centered close.
+
+#### Guild Lead (`guild-lead`) — extends today's tab-button lap into a full same-page lap
+
+All steps are on `hub_guild_edit` (entry kwargs = guild pk via existing `_first_staffed_guild_pk`). Each stop `tab_set`s the Alpine `section` var, then spotlights the now-visible panel element. No navigation between steps -> very robust.
+
+| # | `tab_set` | Target | Narration |
+|---|---|---|---|
+| 1 | (start) | centered | This page runs your guild. Every tab is one job and each saves on its own. I will flip through them. |
+| 2 | `section=basic` | `guild.edit-page` | Basic Information is your public page: banner, overview, meeting times. |
+| 3 | `section=orientations` | `guild.run-orientations` (tab btn) | Set your orientation hours and open slots here. Bookings show up on the Orientations dashboard to confirm. |
+| 4 | `section=staff` | `guild.manage-staff` | Anyone you add here gets full guild authority. Add people you trust. |
+| 5 | `section=announcements` | `guild.announcements` (tab btn) | Write to your members here: draft, preview, send. Member proposals wait in your review queue. |
+| 6 | `section=meetings` | `guild.welcome-message` | This is the welcome new members get when they join your guild. Make it warm. |
+| 7 | `section=studio_hours` | `guild.studio-hours` | Post when your studio is open so members know when they can drop in. |
+| 8 | `section=meetings` | `guild.meetings` | Set your regular meeting day and time so they show on your page and the calendar. |
+| 9 | `section=events` | `guild.events` | Post one-off events like a demo night or a field trip. |
+| 10 | `section=images` | `guild.photo-gallery` | Add photos of your space and members' work to the gallery. |
+| 11 | `section=content` | `guild.manage-faq` | Answer common questions in the FAQ and link out to guides and sign-up sheets. |
+| 12 | `section=basic` | `guild.wishlist` | List the tools and supplies your guild wants. Members and donors can see it. |
+| 13 | — | centered | That is the lap. The Guild Lead Quickstart on the Help page details every tool, and the Cartographers Guild is a full example to borrow from. |
+
+Note: "welcome email" in the brief maps to the guild's **welcome message** (`discord_welcome_message`) — there is no per-guild welcome *email*; the narration says "welcome message" to stay honest. Flagged in §10.
+
+#### Admin (`admin`) — NEW tour, audience `_admin_audience`, entry `hub_admin_tools`
+
+Server `?tab=` surfaces are plain navigations (relative paths), not Alpine — the runtime just hops between them.
+
+| # | Page | Action | Target | Narration |
+|---|---|---|---|---|
+| 1 | hub_admin_tools | (start) | centered | These are the admin controls. I will show the five you will reach for most. |
+| 2 | hub_compose | navigate | `compose.wizard` | Send a site wide announcement here. Pick who gets it, write once, and it can go to email, push, and Discord. |
+| 3 | billing_admin_dashboard (`query: tab=payments`) | navigate | `admin.refunds` | Every charge is here. Open one to issue a refund; the member gets it back and a receipt. |
+| 4 | classes:admin_overview | navigate | `admin.review-queue` | Classes waiting on you sit at the top. Review the details, then approve or send it back with a note. |
+| 5 | classes:admin_discount_codes | navigate | `admin.discount-codes` | Create discount codes for a class or a promotion here, with limits and an expiry date. |
+| 6 | billing_admin_reports | navigate | `admin.reconciliation` | This report breaks down what each guild is owed so you can reconcile payouts. |
+| 7 | hub_admin_tools | navigate | centered | That is the admin lap. Each tool has a full guide on the Help page. |
+
+---
+
+## 7. Notifications / emails / activity
+
+None. Tours are client-side + a `TourState` row. The only server write is the existing `hub_tour_state` POST (offered/completed/dismissed). No emails, no `SiteActivity`, no `core/triggers.py` changes.
+
+---
+
+## 8. Build order (each phase ships green: full suite + `ruff` + `mypy` + `manage.py check`)
+
+1. **Registry schema + resolvers (no behavior change yet).** Extend `TourStep` with the action fields; add `_admin_audience`, `_demo_guild_slug`, `_demo_class_slug`, `_instructor_class_pk`; extend `_tour_payload` (navigate resolution, `page_id`, skip-on-raise, cross-origin build-time guard). Keep the three tours highlight-only for now. Tests in `core/spec/tours_spec.py`. Green.
+2. **Site-wide payload + context processor.** Add `core.context_processors.tour_runtime`; wire it in settings; move `_tour.html` into the three base templates; remove the three per-view `tour_offer_context` calls. Behavior identical to today (offer on entry pages, no resume yet since no tour uses `navigate`). Tests in `core/spec/context_processors_spec.py`. Green.
+3. **Runtime rewrite in `pl_tour.js`.** Segment player, `advance`, `waitFor`, resume gate, teardown split, URL-param cleanup, global progress, `.pl-tour-advancing`. No Python change. Guarded by the new e2e (phase 6). Green (Python suite unaffected).
+4. **New `data-help-key` hooks + help registry.** Add every attribute in the §6.6 table; register new keys + Help anchors in `core/help_registry.py`; extend `tests/hub/help_keys_spec.py` expected set. Green.
+5. **Script the four tours.** Fill in the §6.7 step lists (extend member/instructor/guild-lead, add `admin`). This is where `navigate`/`tab_set` first appear. Green.
+6. **e2e (the real runtime guard).** Playwright spec in `tests/e2e/`: member tour auto-advances across >=2 pages; resume after a manual reload via `?tour=&step=`; a removed target is skipped; completion writes `TourState.completed`; Esc mid-tour strips the URL param. Green.
+7. **Housekeeping.** Bump `plfog/version.py` VERSION 1.19.1 -> **1.20.0**; add ONE member-facing CHANGELOG entry stamped `1.20.0` (curate per the changelog rule):
+   > **Guided tours that drive themselves.** Pick a tour and it walks you through the app hands free, moving from screen to screen while you follow along. There are tours for members, instructors, guild leads, and admins. Turn them on or off anytime in Settings.
+
+> Spec only — do not build until approved.
+
+## 9. Testing
+
+BDD `*_spec.py`, `describe_*`/`it_*`, factory-boy, 100% branch on touched Python, run in the `plfog-web` Docker image.
+
+**Python (`core/spec/tours_spec.py`):**
+- `TourStep` defaults: a step with no action fields serializes to today's payload shape (backward compat).
+- `_tour_payload`: `navigate` resolves to the correct relative href; `query` folds in; `navigate_kwargs` callable resolved with the member; `page_id` carries forward correctly across steps; a resolver raising `ValueError` drops exactly that step (others intact); an absolute cross-origin href raises at build time.
+- Resolvers: `_admin_audience` true for `is_fog_admin` and for a capability-holder, false otherwise; `_demo_guild_slug` / `_demo_class_slug` / `_instructor_class_pk` pick the expected object and raise `ValueError` when none exists.
+- `tours_for` includes `admin` only for admins; `help_card_rows` renders four rows for an admin, fewer for others.
+
+**Python (`core/spec/context_processors_spec.py`):**
+- Anonymous / no member -> empty. `?tour=<key>` eligible -> autostart payload with clamped `resume_step`, no `TourState` write. Entry page + toggle on + no row -> offer + `mark_offered`. Toggle off / welcome modal showing / row `dismissed` -> no offer. `?tour=` for an ineligible member -> empty (param ignored). Non-entry page without `?tour=` -> empty.
+
+**Drift guard (`tests/hub/help_keys_spec.py`):** extended expected set; every new `data-help-key` maps to a registry entry (test fails if a hook is added without registering it).
+
+**e2e (`tests/e2e/`, Playwright):** the runtime behaviors in §8 phase 6. This is the guard that the auto-nav actually works — the Python tests cannot exercise `pl_tour.js`.
+
+**Gotchas:** `_demo_class_slug` depends on a *future* bookable class (past-dated example class is not bookable) — the e2e/factory must create a future offering. Guild-lead tab hops need Alpine hydrated before `tab_set`; the e2e waits on the panel, matching `waitFor`.
+
+## 10. Open / deferred
+
+- **"Welcome email" (guild lead)** is mapped to the guild **welcome message** (`discord_welcome_message`); there is no per-guild welcome email today. If one is wanted, that is a separate feature — out of scope here.
+- **Spaces request is modal-gated** — the request form only exists inside a hotspot modal (`_space_request_form.html`), and the top-level request entry was intentionally removed. The member tour spotlights the **map** and narrates the flow rather than auto-opening a specific hotspot (which would depend on a particular space existing). Auto-opening a hotspot is deferred.
+- **Cross-subdomain tours are explicitly out of scope.** Every step stays on the members apex. If a future tour must show the *real* `book.` public site, it needs the `?tour=&step=` param carried across origins **and** the payload re-rendered on the book origin (the context processor already can, since `TOURS` is shared) — deferred until needed.
+- **Global progress text** is a nice-to-have polish (§5.3); if it proves fiddly across skipped steps, fall back to per-segment progress without blocking the release.
+- **Operator pre-flight for a clean live demo** (not code): sign in as the demo owner; ensure at least one active guild with open orientation slots and one future bookable class exist; for the instructor lap, the demo account should own a class that has a confirmed registration and a waitlisted registration so the remove/promote stops have something real to act on.
+- **Deep-link start from the Help card** already works (`?tour=<key>`); a future enhancement could let a step deep-link mid-tour (`?tour=&step=`) from a Loom or email, which this design supports for free.
+```

--- a/hub/views.py
+++ b/hub/views.py
@@ -852,12 +852,10 @@ def guild_edit(request: HttpRequest, pk: int) -> HttpResponse:
             return redirect("hub_guild_detail", slug=guild.slug)
         return render(request, "hub/guild_edit.html", _guild_edit_context(request, guild, form=form))
 
-    from core.tours import tour_offer_context
-
     return render(
         request,
         "hub/guild_edit.html",
-        {**_guild_edit_context(request, guild), **tour_offer_context(request, "guild-lead")},
+        _guild_edit_context(request, guild),
     )
 
 
@@ -4995,13 +4993,12 @@ def home(request: HttpRequest) -> HttpResponse:
     ctx = _get_hub_context(request)
     if member is None:
         return render(request, "hub/home.html", {**ctx, "member": None})
-    from core.tours import tour_offer_context
     from hub.home import build_home_context
 
     return render(
         request,
         "hub/home.html",
-        {**ctx, "member": member, **build_home_context(member), **tour_offer_context(request, "member-welcome")},
+        {**ctx, "member": member, **build_home_context(member)},
     )
 
 

--- a/plfog/settings.py
+++ b/plfog/settings.py
@@ -241,6 +241,7 @@ TEMPLATES = [
                 "billing.context_processors.tab_context",
                 "hub.context_processors.hub_sidebar",
                 "core.context_processors.notification_badge",
+                "core.context_processors.tour_runtime",
             ],
         },
     },

--- a/plfog/version.py
+++ b/plfog/version.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
-VERSION = "1.20.0"
+VERSION = "1.21.0"
 
 CHANGELOG: list[dict[str, str | list[str]]] = [
+    {
+        "version": "1.21.0",
+        "date": "2026-08-28",
+        "title": "Take a guided tour",
+        "changes": [
+            "New guided tours walk you through the member portal and drive the navigation for "
+            "you, hopping from page to page while they explain each part. There is a tour for "
+            "members, one for instructors, one for guild leads, and one for admins. Click Show "
+            "me around on your home page, or start one any time from the Help page, and you can "
+            "turn tours on or off in Settings.",
+        ],
+    },
     {
         "version": "1.20.0",
         "date": "2026-08-27",

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -6059,6 +6059,44 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
     }
 }
 
+/* ── Guided-tour "advancing" affordance: a brief scrim + spinner during a hop,
+      so a boosted swap or tab flip never flashes the destination bare. ── */
+.pl-tour-advancing {
+    position: fixed;
+    inset: 0;
+    z-index: 10001;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    background: color-mix(in srgb, var(--hub-bg) 72%, transparent);
+    backdrop-filter: blur(2px);
+    color: var(--hub-text);
+    font-size: 0.9rem;
+}
+.pl-tour-advancing[hidden] { display: none; }
+
+.pl-tour-advancing__spinner {
+    width: 28px;
+    height: 28px;
+    border: 3px solid var(--hub-border);
+    border-top-color: var(--color-tuscan-yellow);
+    border-radius: 50%;
+    animation: pl-spin 0.7s linear infinite;
+}
+
+.pl-tour-advancing__label {
+    color: var(--hub-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pl-tour-advancing__spinner {
+        animation: none;
+        border-color: var(--color-tuscan-yellow);
+    }
+}
+
 /* ── "Show me around" entry link under a page header (§6.3) ── */
 .pl-tour-entry-link {
     margin: -0.75rem 0 1.25rem;

--- a/static/js/pl_tour.js
+++ b/static/js/pl_tour.js
@@ -1,35 +1,43 @@
 /*
- * Guided tours bootstrap (Spec C §6.2). Loaded only on tour entry pages via
- * templates/hub/partials/_tour.html; Driver.js itself (static/js/driver.min.js +
- * static/css/driver.css, vendored v1.3.6) is injected lazily the moment a tour
- * starts — ordinary pageviews never pay for it.
+ * Guided tours runtime — a SEGMENT PLAYER over a persisted itinerary.
+ *
+ * A tour narrates a step, then drives the browser to the next screen for you:
+ * a page hop (a full navigation carrying the resume param) or a same-page
+ * Alpine tab flip, detects the new surface has loaded, and keeps narrating.
+ * Driver.js (static/js/driver.min.js + static/css/driver.css, vendored v1.3.6)
+ * is the spotlight lib, injected lazily the moment a tour starts.
+ *
+ * Persistence: the running tour survives navigation via BOTH sessionStorage
+ * ("plTourRun") and a "?tour=<key>&step=<n>" URL param the navigation carries,
+ * so the tour re-hydrates and resumes at the right step on the destination.
+ *
+ * Robustness posture (this runs live on a demo stage): nothing should freeze.
+ * Every hop is guarded — a waitFor cap (~4s) lets async content paint, a
+ * missing target degrades to a centered popover (never a hang), a wrong-page
+ * 302 aborts cleanly, and Esc / the ✕ / an overlay click always end the tour
+ * and strip the URL param so a refresh does not silently restart it.
  *
  * hx-boost re-executes this script on boosted navigations, so it is a guarded
  * window.plTour IIFE with no top-level const/let: the module is defined once,
- * and every execution just calls init() to re-read the page's payload and bind
- * fresh DOM (the data-pl-tour-init attribute guards event binding; the
- * window.plTour check guards re-declaration — both guards are needed).
- *
- * Recording contract (locked): all state recording lives in onDestroyStarted.
- * Driver.js 1.x suppresses its default teardown when that hook is provided, so
- * the hook MUST call driverObj.destroy() itself — destroy() bypasses the hook
- * and runs the real teardown. Esc / the popover ✕ / an overlay click all route
- * through the hook (dismissed unless on the last step); htmx history/swap
- * teardown calls destroy() directly and records nothing (navigating away is
- * not deciding). Focus management is ours, not the library's: Driver.js 1.x
- * neither focuses the popover nor restores focus on close.
+ * and every execution just calls init() to re-read the payload and resume.
  */
 (function () {
     "use strict";
 
     if (!window.plTour) {
         window.plTour = (function () {
+            var RUN_KEY = "plTourRun";
+            var WAIT_CAP_MS = 4000;
+
             var assetsPromise = null; // cached so double-start is safe
             var current = null; // this page's payload (re-read on every init)
             var csrf = "";
-            var active = null; // { driverObj, sidebarPrev, restoreFocus }
+            var active = null; // { driverObj, segStart, segEnd } for the running segment
+            var session = null; // cross-segment state: { sidebarPrev, restoreFocus }
             var htmxBound = false;
+            var ending = false; // the tour is finishing (restore sidebar/focus on destroy)
 
+            // ── payload + assets ────────────────────────────────────────────
             function readPayload() {
                 var data = document.getElementById("pl-tour-data");
                 var root = document.getElementById("pl-tour-root");
@@ -37,7 +45,12 @@
                     current = null;
                     return;
                 }
-                current = JSON.parse(data.textContent);
+                try {
+                    current = JSON.parse(data.textContent);
+                } catch (e) {
+                    current = null;
+                    return;
+                }
                 csrf = root.getAttribute("data-csrf") || "";
             }
 
@@ -45,6 +58,10 @@
                 if (assetsPromise) return assetsPromise;
                 assetsPromise = new Promise(function (resolve, reject) {
                     var root = document.getElementById("pl-tour-root");
+                    if (!root) {
+                        reject(new Error("no tour root"));
+                        return;
+                    }
                     if (!document.querySelector("link[data-pl-driver-css]")) {
                         var link = document.createElement("link");
                         link.rel = "stylesheet";
@@ -71,6 +88,12 @@
             }
 
             function postState(status) {
+                if (!current) return;
+                // A normal, normally-prioritized fetch. We do NOT use keepalive: every
+                // caller (finish on completed / Esc / the close button) fires while the
+                // page stays loaded, so there is no unload to survive — and keepalive
+                // requests are deprioritized by the browser, which delayed this POST and
+                // left the recorded state lagging.
                 fetch(current.state_url, {
                     method: "POST",
                     headers: {
@@ -78,13 +101,45 @@
                         "Content-Type": "application/x-www-form-urlencoded",
                     },
                     body: "status=" + encodeURIComponent(status),
-                    keepalive: true,
                 }).catch(function () {
                     // Worst case on a lost dismiss: the row stays OFFERED and the
                     // offer reappears next visit — honest and self-healing.
                 });
             }
 
+            // ── persisted running state ─────────────────────────────────────
+            function saveRun(index) {
+                try {
+                    var payload = {
+                        key: current.key,
+                        index: index,
+                        total: current.steps.length,
+                        sidebarPrev: session ? session.sidebarPrev : undefined,
+                    };
+                    window.sessionStorage.setItem(RUN_KEY, JSON.stringify(payload));
+                } catch (e) {
+                    /* private mode / no storage — the URL param still carries resume */
+                }
+            }
+
+            function readRun() {
+                try {
+                    var raw = window.sessionStorage.getItem(RUN_KEY);
+                    return raw ? JSON.parse(raw) : null;
+                } catch (e) {
+                    return null;
+                }
+            }
+
+            function clearRun() {
+                try {
+                    window.sessionStorage.removeItem(RUN_KEY);
+                } catch (e) {
+                    /* nothing to clear */
+                }
+            }
+
+            // ── Alpine helpers (tab flips + sidebar) ────────────────────────
             function bodyAlpineState() {
                 if (!window.Alpine || !window.Alpine.$data) return null;
                 try {
@@ -94,80 +149,380 @@
                 }
             }
 
-            function cleanup() {
-                if (!active) return;
-                var finished = active;
-                active = null;
-                if (finished.sidebarPrev !== undefined) {
-                    var bodyState = bodyAlpineState();
-                    if (bodyState) bodyState.sidebarOpen = finished.sidebarPrev;
+            function findAlpineOwner(varName) {
+                // The element whose Alpine scope owns varName (e.g. the guild
+                // editor root owns `section`; <body> owns `sidebarOpen`).
+                if (!window.Alpine || !window.Alpine.$data) return null;
+                var nodes = document.querySelectorAll("[x-data]");
+                for (var i = 0; i < nodes.length; i++) {
+                    var data = null;
+                    try {
+                        data = window.Alpine.$data(nodes[i]);
+                    } catch (e) {
+                        data = null;
+                    }
+                    if (data && varName in data) return data;
                 }
-                if (finished.restoreFocus && document.contains(finished.restoreFocus)) {
-                    finished.restoreFocus.focus({ preventScroll: true });
+                return null;
+            }
+
+            function applyTabOrClick(step) {
+                if (step.tab_set) {
+                    var owner = findAlpineOwner(step.tab_set[0]);
+                    if (owner) {
+                        try {
+                            owner[step.tab_set[0]] = step.tab_set[1];
+                        } catch (e) {
+                            /* scope went away — the target simply won't show; waitFor handles it */
+                        }
+                    }
+                } else if (step.click) {
+                    var el = document.querySelector(step.click);
+                    if (el) el.click();
                 }
             }
 
-            function buildSteps() {
-                // Missing/hidden targets are dropped BEFORE the driver is built, so
-                // progress numbering stays contiguous — a renamed element degrades
-                // to a shorter tour, never a broken one. Element-less (centered)
-                // steps always survive.
-                var steps = [];
-                current.steps.forEach(function (step) {
-                    if (!step.target) {
-                        steps.push({ popover: { title: step.title, description: step.body } });
+            // ── the async guard ─────────────────────────────────────────────
+            function isVisible(el) {
+                return !!(el && el.offsetParent !== null);
+            }
+
+            function waitFor(step) {
+                return new Promise(function (resolve) {
+                    var selector = step.wait_for || step.target;
+                    if (!selector) {
+                        resolve(true); // centered step — nothing to wait on
                         return;
                     }
-                    var el = document.querySelector(step.target);
-                    if (el && el.offsetParent !== null) {
-                        steps.push({ element: step.target, popover: { title: step.title, description: step.body } });
-                    }
+                    var startedAt = Date.now();
+                    (function poll() {
+                        if (isVisible(document.querySelector(selector))) {
+                            resolve(true);
+                            return;
+                        }
+                        if (Date.now() - startedAt > WAIT_CAP_MS) {
+                            resolve(false); // never hang — the step degrades to centered
+                            return;
+                        }
+                        requestAnimationFrame(poll);
+                    })();
                 });
-                return steps;
             }
 
-            function runTour(auto, sidebarPrev, restoreFocus) {
-                var steps = buildSteps();
-                // <2 surviving steps aborts an auto-offered start silently (records
-                // nothing); a manual start still shows what remains.
-                if (steps.length === 0 || (auto && steps.length < 2)) {
-                    active = { sidebarPrev: sidebarPrev, restoreFocus: null };
-                    cleanup();
+            // ── the advancing affordance ────────────────────────────────────
+            function advancingEl() {
+                return document.getElementById("pl-tour-advancing");
+            }
+
+            function showAdvancing() {
+                var el = advancingEl();
+                if (el) el.hidden = false;
+            }
+
+            function hideAdvancing() {
+                var el = advancingEl();
+                if (el) el.hidden = true;
+            }
+
+            // ── segments ────────────────────────────────────────────────────
+            function stepStartsSegment(i) {
+                if (i === 0) return true;
+                var s = current.steps[i];
+                return !!(s.navigate || s.tab_set || s.click);
+            }
+
+            function segmentBounds(globalIndex) {
+                var start = globalIndex;
+                while (start > 0 && !stepStartsSegment(start)) start--;
+                var end = start;
+                while (end + 1 < current.steps.length && !stepStartsSegment(end + 1)) end++;
+                return { start: start, end: end };
+            }
+
+            function clampIndex(index) {
+                var last = current.steps.length - 1;
+                if (last < 0) return 0;
+                if (index < 0) return 0;
+                if (index > last) return last;
+                return index;
+            }
+
+            // ── URL param plumbing ──────────────────────────────────────────
+            function withTourParams(href, key, step) {
+                var sep = href.indexOf("?") === -1 ? "?" : "&";
+                return href + sep + "tour=" + encodeURIComponent(key) + "&step=" + step;
+            }
+
+            function stripTourParams() {
+                try {
+                    var url = new URL(window.location.href);
+                    url.searchParams.delete("tour");
+                    url.searchParams.delete("step");
+                    var qs = url.searchParams.toString();
+                    var clean = url.pathname + (qs ? "?" + qs : "") + url.hash;
+                    window.history.replaceState(window.history.state, "", clean);
+                } catch (e) {
+                    /* best effort — leaving the param only risks a re-offer, not a break */
+                }
+            }
+
+            function boostedGet(url) {
+                // A full navigation is the reliable hop between tour pages. The runtime
+                // is built to survive it: the destination reloads pl_tour.js and resumes
+                // from the "?tour=&step=" param (and sessionStorage). We deliberately do
+                // NOT drive tour hops through an hx-boost swap — a synthetic boosted <a>
+                // click does not reliably trigger htmx's boosted navigation, which strands
+                // the tour on the origin page (the popover tears down but nothing loads).
+                window.location.assign(url);
+            }
+
+            // ── teardown / restore ──────────────────────────────────────────
+            function restoreSession() {
+                if (!session) return;
+                if (session.sidebarPrev !== undefined) {
+                    var bodyState = bodyAlpineState();
+                    if (bodyState) bodyState.sidebarOpen = session.sidebarPrev;
+                }
+                if (session.restoreFocus && document.contains(session.restoreFocus)) {
+                    try {
+                        session.restoreFocus.focus({ preventScroll: true });
+                    } catch (e) {
+                        /* element unfocusable — harmless */
+                    }
+                }
+            }
+
+            function onSegmentDestroyed() {
+                active = null;
+                if (ending) {
+                    ending = false;
+                    restoreSession();
+                    session = null;
+                }
+            }
+
+            function finish(status) {
+                if (!active && !session) return;
+                ending = true;
+                postState(status);
+                clearRun();
+                stripTourParams();
+                if (active && active.driverObj) {
+                    active.driverObj.destroy();
+                } else {
+                    ending = false;
+                    restoreSession();
+                    session = null;
+                }
+            }
+
+            // ── driving a segment ───────────────────────────────────────────
+            function popoverFor(step) {
+                return { title: step.title, description: step.body };
+            }
+
+            function driveSegment(globalIndex) {
+                if (!current) return;
+                var bounds = segmentBounds(globalIndex);
+                var driverSteps = [];
+                for (var i = bounds.start; i <= bounds.end; i++) {
+                    var s = current.steps[i];
+                    if (s.target && isVisible(document.querySelector(s.target))) {
+                        driverSteps.push({ element: s.target, popover: popoverFor(s) });
+                    } else {
+                        driverSteps.push({ popover: popoverFor(s) }); // missing target -> centered, never a hang
+                    }
+                }
+                if (driverSteps.length === 0) {
+                    finishSilently();
                     return;
                 }
                 var theme = document.documentElement.getAttribute("data-theme") || window.__plTheme || "dark";
+                var localOffset = clampIndex(globalIndex) - bounds.start;
+                // Driver.js labels the LAST step of each per-page instance with doneBtnText.
+                // A segment that is NOT the final one hops to the next page, so its last
+                // step must read "Next", not "Done" — set that at config time so the button
+                // is correct the instant it renders (decoratePopover's later override would
+                // otherwise leave a race window where a single-step segment briefly shows
+                // "Done"). Only the final segment's last step gets the real "Done".
+                var isFinalSegment = bounds.end >= current.steps.length - 1;
                 var driverObj = window.driver.js.driver({
-                    steps: steps,
+                    steps: driverSteps,
                     popoverClass: "pl-tour",
                     showProgress: true,
+                    showButtons: ["next", "previous", "close"],
                     allowClose: true,
                     animate: !window.matchMedia("(prefers-reduced-motion: reduce)").matches,
                     overlayColor: theme === "light" ? "rgba(29, 30, 30, 0.45)" : "rgba(4, 5, 8, 0.72)",
                     overlayOpacity: 1,
                     nextBtnText: "Next",
                     prevBtnText: "Back",
-                    doneBtnText: "Done",
+                    doneBtnText: isFinalSegment ? "Done" : "Next",
                     onHighlighted: function () {
-                        var popover = document.querySelector(".driver-popover");
-                        if (popover) {
-                            popover.setAttribute("tabindex", "-1");
-                            popover.focus({ preventScroll: true });
-                        }
+                        decoratePopover();
+                    },
+                    onNextClick: function () {
+                        handleNext();
+                    },
+                    onPrevClick: function () {
+                        handlePrev();
+                    },
+                    onCloseClick: function () {
+                        finish("dismissed"); // the ✕ — an explicit stop
                     },
                     onDestroyStarted: function () {
-                        // Providing this hook suppresses Driver's default teardown —
-                        // record, then destroy ourselves (destroy() bypasses the hook).
-                        postState(driverObj.isLastStep() ? "completed" : "dismissed");
-                        driverObj.destroy();
+                        // Esc / overlay click. Providing this hook suppresses Driver's
+                        // default teardown, so finish() must call destroy() itself
+                        // (which then bypasses this hook — no re-entry).
+                        finish("dismissed");
                     },
-                    onDestroyed: cleanup,
+                    onDestroyed: onSegmentDestroyed,
                 });
-                active = { driverObj: driverObj, sidebarPrev: sidebarPrev, restoreFocus: restoreFocus };
-                driverObj.drive();
+                active = { driverObj: driverObj, segStart: bounds.start, segEnd: bounds.end };
+                driverObj.drive(localOffset);
             }
 
-            function start(auto) {
-                if (!current || active) return;
+            function globalIndexNow() {
+                if (!active || !active.driverObj) return 0;
+                var local = 0;
+                try {
+                    local = active.driverObj.getActiveIndex() || 0;
+                } catch (e) {
+                    local = 0;
+                }
+                return active.segStart + local;
+            }
+
+            function decoratePopover() {
+                var popover = document.querySelector(".driver-popover");
+                if (!popover) return;
+                popover.setAttribute("tabindex", "-1");
+                try {
+                    popover.focus({ preventScroll: true });
+                } catch (e) {
+                    /* ignore */
+                }
+                var total = current.steps.length;
+                var gi = globalIndexNow();
+                var progress = popover.querySelector(".driver-popover-progress-text");
+                if (progress) progress.textContent = gi + 1 + " of " + total;
+                var nextBtn = popover.querySelector(".driver-popover-next-btn");
+                if (nextBtn) nextBtn.textContent = gi >= total - 1 ? "Done" : "Next";
+                var prevBtn = popover.querySelector(".driver-popover-prev-btn");
+                if (prevBtn) {
+                    if (gi <= 0) {
+                        prevBtn.style.display = "none";
+                    } else {
+                        prevBtn.style.display = "";
+                        // Driver.js disables the prev button on the first step of each
+                        // per-page instance via "driver-popover-btn-disabled"; a segment
+                        // that is not the first still has a global Back, so re-enable it.
+                        prevBtn.classList.remove("driver-popover-btn-disabled");
+                        prevBtn.removeAttribute("disabled");
+                    }
+                }
+            }
+
+            function handleNext() {
+                if (!active || !active.driverObj) return;
+                var local = active.driverObj.getActiveIndex() || 0;
+                var segLen = active.segEnd - active.segStart + 1;
+                if (local < segLen - 1) {
+                    active.driverObj.moveNext(); // within the segment
+                    return;
+                }
+                var gi = active.segStart + local;
+                if (gi >= current.steps.length - 1) {
+                    finish("completed");
+                } else {
+                    hopTo(gi + 1);
+                }
+            }
+
+            function handlePrev() {
+                if (!active || !active.driverObj) return;
+                var local = active.driverObj.getActiveIndex() || 0;
+                if (local > 0) {
+                    active.driverObj.movePrevious(); // within the segment
+                    return;
+                }
+                var gi = active.segStart + local;
+                if (gi <= 0) return; // already at the very first step
+                hopTo(gi - 1);
+            }
+
+            // ── hopping between segments ────────────────────────────────────
+            function hopTo(targetIndex) {
+                var bounds = segmentBounds(targetIndex);
+                var leader = current.steps[bounds.start];
+                ending = false;
+                var d = active && active.driverObj;
+                // A hop NAVIGATES when the target segment lives on another page: a forward
+                // step carries a resolved `navigate` href; a BACKWARD hop into the entry-page
+                // segment has no `navigate` (its page was reached by the initial load, not an
+                // action) yet still sits on a different pathname. Both full-navigate carrying
+                // `?tour=&step=` so the destination re-hydrates and resumes. Only a truly
+                // same-page leader (a tab flip / click) stays put.
+                var destPath = leader.navigate || leader.page_path;
+                var needsNav =
+                    !!leader.navigate ||
+                    (!!leader.page_path && leader.page_path !== window.location.pathname);
+                if (needsNav && destPath) {
+                    saveRun(targetIndex);
+                    if (d) d.destroy(); // silent (bypasses onDestroyStarted); onSegmentDestroyed keeps session
+                    showAdvancing();
+                    boostedGet(withTourParams(destPath, current.key, targetIndex));
+                } else {
+                    saveRun(targetIndex);
+                    if (d) d.destroy();
+                    applyTabOrClick(leader);
+                    requestAnimationFrame(function () {
+                        waitFor(current.steps[targetIndex]).then(function () {
+                            driveSegment(targetIndex);
+                        });
+                    });
+                }
+            }
+
+            function finishSilently() {
+                // No drivable steps at all (a resolver stripped everything): end
+                // without recording, restore any sidebar/focus, clear the run.
+                ending = false;
+                clearRun();
+                stripTourParams();
+                restoreSession();
+                session = null;
+                active = null;
+                hideAdvancing();
+            }
+
+            // ── resume / start ──────────────────────────────────────────────
+            function resumeAt(globalIndex) {
+                if (!current) return;
+                var idx = clampIndex(globalIndex);
+                var bounds = segmentBounds(idx);
+                var leader = current.steps[bounds.start];
+                // Location assertion: a 302 (e.g. a locked area) must not leave us
+                // spotlighting the wrong page. page_path is the pathname the step
+                // belongs to; if we are not there, stop cleanly.
+                if (leader.page_path && window.location.pathname.indexOf(leader.page_path) !== 0) {
+                    clearRun();
+                    session = null;
+                    hideAdvancing();
+                    return;
+                }
+                var navigated = !!leader.navigate;
+                if (!leader.navigate) applyTabOrClick(leader); // same-page leader on a fresh load
+                if (navigated) showAdvancing();
+                requestAnimationFrame(function () {
+                    waitFor(current.steps[idx]).then(function () {
+                        hideAdvancing();
+                        driveSegment(idx);
+                    });
+                });
+            }
+
+            function beginSession(auto) {
                 var sidebarPrev; // undefined = nothing to restore
                 if (current.opens_sidebar) {
                     var bodyState = bodyAlpineState();
@@ -176,13 +531,19 @@
                         bodyState.sidebarOpen = true;
                     }
                 }
-                var restoreFocus = document.activeElement;
+                session = { sidebarPrev: sidebarPrev, restoreFocus: document.activeElement };
+                return sidebarPrev;
+            }
+
+            function start(auto) {
+                if (!current || active) return;
+                if (current.steps.length === 0 || (auto && current.steps.length < 2)) return;
+                var sidebarPrev = beginSession(auto);
+                saveRun(0);
                 loadAssets().then(
                     function () {
-                        // One frame so the sidebar flip has painted before the
-                        // visibility filter runs (sidebar targets must count as visible).
                         requestAnimationFrame(function () {
-                            runTour(auto, sidebarPrev, restoreFocus);
+                            resumeAt(0);
                         });
                     },
                     function () {
@@ -190,30 +551,84 @@
                             var bodyState = bodyAlpineState();
                             if (bodyState) bodyState.sidebarOpen = sidebarPrev;
                         }
+                        session = null;
+                        clearRun();
                     }
                 );
             }
 
-            function teardown() {
-                // htmx history snapshot / swap: kill the tour without recording —
-                // the member navigated, they didn't decide. destroy() bypasses
-                // onDestroyStarted; onDestroyed still runs cleanup().
-                if (active && active.driverObj) active.driverObj.destroy();
+            function resumeFromContext() {
+                // 1. Authoritative seed: an autostart payload (?tour= present) —
+                //    resume at the server-clamped resume_step on THIS page.
+                if (current.autostart) {
+                    var seed = clampIndex(current.resume_step || 0);
+                    if (current.steps.length === 0) return;
+                    beginSession(false);
+                    saveRun(seed);
+                    loadAssets().then(
+                        function () {
+                            resumeAt(seed);
+                        },
+                        function () {
+                            session = null;
+                            clearRun();
+                        }
+                    );
+                    return;
+                }
+                // 2. A running tour continued onto this page via sessionStorage
+                //    (covers an accidental same-page reload without the URL param).
+                var run = readRun();
+                if (run && run.key === current.key) {
+                    var idx = clampIndex(run.index);
+                    var bounds = segmentBounds(idx);
+                    var leader = current.steps[bounds.start];
+                    if (leader.page_path && window.location.pathname.indexOf(leader.page_path) !== 0) {
+                        clearRun(); // the user navigated away on their own — end cleanly
+                        return;
+                    }
+                    session = { sidebarPrev: run.sidebarPrev, restoreFocus: document.activeElement };
+                    loadAssets().then(
+                        function () {
+                            resumeAt(idx);
+                        },
+                        function () {
+                            session = null;
+                        }
+                    );
+                }
             }
 
+            // ── offer card ──────────────────────────────────────────────────
             function bindOffer() {
                 var offer = document.querySelector("[data-pl-tour-offer]");
                 if (!offer || offer.hasAttribute("data-pl-tour-init")) return;
                 offer.setAttribute("data-pl-tour-init", "");
-                offer.querySelector("[data-tour-accept]").addEventListener("click", function () {
-                    offer.remove();
-                    start(true);
-                });
-                offer.querySelector("[data-tour-decline]").addEventListener("click", function () {
-                    // Remove immediately — don't wait on the response. Quiet: no toast.
-                    postState("dismissed");
-                    offer.remove();
-                });
+                var accept = offer.querySelector("[data-tour-accept]");
+                var decline = offer.querySelector("[data-tour-decline]");
+                if (accept) {
+                    accept.addEventListener("click", function () {
+                        offer.remove();
+                        start(true);
+                    });
+                }
+                if (decline) {
+                    decline.addEventListener("click", function () {
+                        postState("dismissed");
+                        offer.remove();
+                    });
+                }
+            }
+
+            // ── htmx teardown split ─────────────────────────────────────────
+            function teardownForHtmx() {
+                if (!active || !active.driverObj) return;
+                // Tour hops are full navigations, not htmx swaps, so this only fires when the
+                // user themselves boosts away mid-tour (a link click) — abandon the tour.
+                ending = false;
+                clearRun();
+                active.driverObj.destroy();
+                session = null;
             }
 
             function init() {
@@ -221,15 +636,16 @@
                 if (!htmxBound) {
                     htmxBound = true;
                     ["htmx:beforeHistorySave", "htmx:beforeSwap"].forEach(function (name) {
-                        document.body.addEventListener(name, teardown);
+                        document.body.addEventListener(name, teardownForHtmx);
                     });
                 }
                 if (!current) return;
                 bindOffer();
-                if (current.autostart) start(false); // ?tour= manual start
+                if (active) return; // already running (e.g. a mid-tab-hop re-init)
+                resumeFromContext();
             }
 
-            return { init: init, start: start, teardown: teardown };
+            return { init: init, start: start };
         })();
     }
 

--- a/templates/billing/admin_dashboard.html
+++ b/templates/billing/admin_dashboard.html
@@ -320,6 +320,7 @@
   </div>
 
   <div class="pl-table-scroll"
+       data-help-key="admin.refunds"
        hx-get="{% url 'billing_admin_payments_table' %}?{{ payments_query }}"
        hx-trigger="refund-done from:body"
        hx-swap="innerHTML">
@@ -340,7 +341,7 @@
   {# ================================================================ #}
   {% if active_tab == "reconciliation" %}
 
-  <div>
+  <div data-help-key="admin.reconciliation">
     <h2 class="pl-card__title" style="font-size:1.35rem">Reconciliation</h2>
     <p class="pl-text-muted">How much to disburse to each guild, instructor, orientator, and Past Lives for the selected month.</p>
   </div>

--- a/templates/classes/_components/image_formset.html
+++ b/templates/classes/_components/image_formset.html
@@ -110,6 +110,7 @@ On create (no pk): multi-file input that submits with the form, with local previ
 
 {% if offering and offering.pk %}
 <div id="gallery-manager"
+     data-help-key="teach.class-gallery"
      data-upload-url="{% url 'classes:admin_class_image_upload' pk=offering.pk %}"
      data-reorder-url="{% url 'classes:admin_class_image_reorder' pk=offering.pk %}"
      data-csrf="{{ csrf_token }}">

--- a/templates/classes/admin/discount_codes.html
+++ b/templates/classes/admin/discount_codes.html
@@ -1,7 +1,7 @@
 {% extends "classes/admin/base.html" %}
 {% load classes_tags %}
 {% block tab_content %}
-<div class="admin-toolbar">
+<div class="admin-toolbar" data-help-key="admin.discount-codes">
     {% include "components/table_search.html" with q=q placeholder="Search codes…" %}
     <a class="hub-btn hub-btn--primary hub-btn--sm" href="{% url 'classes:admin_discount_code_create' %}">+ New Code</a>
 </div>

--- a/templates/classes/admin/overview.html
+++ b/templates/classes/admin/overview.html
@@ -6,7 +6,7 @@
 
   {# ① Classes awaiting approval — full width #}
   <section class="hub-card" style="margin:0;">
-    <h2 class="overview-title">Needs your attention <span class="overview-title__count">({{ stats.pending }})</span></h2>
+    <h2 class="overview-title" data-help-key="admin.review-queue">Needs your attention <span class="overview-title__count">({{ stats.pending }})</span></h2>
     {% for c in pending_classes %}
       <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--hub-border);">
         <a href="{% url 'classes:admin_class_detail' pk=c.pk %}">{{ c.title }}</a>

--- a/templates/classes/public/_list_results.html
+++ b/templates/classes/public/_list_results.html
@@ -37,7 +37,7 @@ list.html for the initial full-page response.{% endcomment %}
 <div class="cls-grid">
   {% for group in page_obj %}
     {% with offering=group.representative %}
-    <div class="cls-card">
+    <div class="cls-card"{% if forloop.first %} data-help-key="catalog.class-card"{% endif %}>
       <a class="cls-media" href="{% url 'classes:public_class_detail' slug=offering.slug %}" aria-label="View {{ offering.title|strip_date_suffix }}">
         {% if offering.image %}
           <img class="cls-img" src="{{ offering.image.url }}" alt="" loading="lazy"

--- a/templates/classes/public/detail.html
+++ b/templates/classes/public/detail.html
@@ -394,7 +394,7 @@
             {% endif %}
           </div>
           {% if spots_remaining > 0 %}
-            <a class="cp-detail__cta" href="{% url 'classes:register' slug=offering.slug %}">
+            <a class="cp-detail__cta" data-help-key="class.register" href="{% url 'classes:register' slug=offering.slug %}">
               {% if offering.price_cents == 0 %}Register — Free{% else %}Register now{% endif %}
             </a>
           {% else %}

--- a/templates/classes/public/list.html
+++ b/templates/classes/public/list.html
@@ -28,6 +28,7 @@
 {# ── Filter bar: category dropdown + Filter popover button ── #}
 <form id="cp-filter-form"
       class="cp-filter"
+      data-help-key="catalog.filter"
       method="get"
       action="{% url 'classes:public_list' %}"
       hx-get="{% url 'classes:public_list' %}"

--- a/templates/classes/teach/class_form.html
+++ b/templates/classes/teach/class_form.html
@@ -11,7 +11,7 @@
     {% csrf_token %}
     {# Identity fields (left) + the Share & Print card (right), 6/6 on desktop, stacked on mobile. #}
     <div class="pl-edit-split">
-        <div class="pl-edit-split__main">
+        <div class="pl-edit-split__main" data-help-key="teach.class-basics">
             {% for field in form %}
                 {% if field.name == 'title' or field.name == 'category' %}
                     {% include "components/form_field.html" with field=field %}

--- a/templates/classes/teach/class_registrations.html
+++ b/templates/classes/teach/class_registrations.html
@@ -2,7 +2,8 @@
 {% load classes_tags %}
 {% block detail_content %}
 <div>
-    <div hx-get="{% url 'classes:teach_class_registrations_table' offering.pk %}"
+    <div data-help-key="teach.roster-table"
+         hx-get="{% url 'classes:teach_class_registrations_table' offering.pk %}"
          hx-trigger="refund-done from:body"
          hx-swap="innerHTML">
         {% include "classes/teach/partials/class_registrations_table.html" %}

--- a/templates/classes/teach/class_waitlist.html
+++ b/templates/classes/teach/class_waitlist.html
@@ -1,7 +1,7 @@
 {% extends "classes/teach/class_detail_base.html" %}
 {% block detail_content %}
 {% if waitlist_registrations %}
-<div class="admin-table-wrap">
+<div class="admin-table-wrap" data-help-key="teach.roster-waitlist">
 <table>
     <thead>
         <tr>

--- a/templates/classes/teach/overview.html
+++ b/templates/classes/teach/overview.html
@@ -133,5 +133,3 @@ the instructor tour's step-2 target.{% endcomment %}
   </div>
 {% endif %}
 {% endblock %}
-
-{% block extra_js %}{% include "hub/partials/_tour.html" %}{% endblock %}

--- a/templates/hub/announcement_compose.html
+++ b/templates/hub/announcement_compose.html
@@ -44,7 +44,7 @@
             :class="{ 'pl-phase-tab--active': phase === 2 }" @click="goPreview()">2. Preview &amp; send</button>
   </div>
 
-  <form method="post" action="{% url 'hub_compose_send' %}" x-ref="wizardForm">
+  <form method="post" action="{% url 'hub_compose_send' %}" x-ref="wizardForm" data-help-key="announcements.compose">
     {% csrf_token %}
     <input type="hidden" id="compose-draft-pk" name="draft_pk" value="{{ draft.pk|default:'' }}">
 

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -566,5 +566,6 @@
     {% block extra_js %}{% endblock %}
     <script src="{% static 'js/hero_placement.js' %}?v=1.1"></script>
     <script src="{% static 'js/session_calendar.js' %}"></script>
+    {% block tour_runtime %}{% include "hub/partials/_tour.html" %}{% endblock %}
 </body>
 </html>

--- a/templates/hub/guild_edit.html
+++ b/templates/hub/guild_edit.html
@@ -49,7 +49,7 @@
       {% include "components/form_field.html" with field=form.show_members %}
     </div>
 
-    <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;">
+    <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;" data-help-key="guild.wishlist">
       <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Wishlist</h2>
       <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">Tools, materials, or equipment the guild is hoping to receive as donations. Shown on a Wishlist tab on your guild page. Add a donate link and members get a Donate button too.</p>
       {% include "components/form_field.html" with field=form.wishlist %}
@@ -126,7 +126,7 @@
 <div x-show="section === 'studio_hours'" x-cloak>
   <form method="post" action="{% url 'hub_guild_studio_hours_save' guild.pk %}" class="hub-form">
     {% csrf_token %}
-    <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;">
+    <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;" data-help-key="guild.studio-hours">
       <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Studio Hours</h2>
       <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">Weekly windows when you're around for members to drop by — shown on your guild page. Add one row per window (e.g. Tuesdays and Saturdays are two rows).</p>
       {{ studio_hours_formset.management_form }}
@@ -264,7 +264,7 @@ confirm modal carries its own POST form, and template content can't nest a form.
 
 {# ── Meeting Notes (list only; per-record add/edit live on their own small pages) ──── #}
 <div x-show="section === 'meeting_notes'" x-cloak>
-  <div class="hub-card" style="padding:1.5rem;">
+  <div class="hub-card" style="padding:1.5rem;" data-help-key="guild.meeting-notes">
     <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Meeting Notes</h2>
     <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">
       Post your meeting agendas and recaps so members can catch up — with a date, a write-up, and any files or links.
@@ -303,7 +303,7 @@ confirm modal carries its own POST form, and template content can't nest a form.
 
 {# ── Events (list only; per-record add/edit live on their own small pages) ──── #}
 <div x-show="section === 'events'" x-cloak>
-  <div class="hub-card" style="padding:1.5rem;">
+  <div class="hub-card" style="padding:1.5rem;" data-help-key="guild.events">
     <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Events</h2>
     <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">
       Schedule your guild's meetings and events. They show on the Community Calendar and the guild's own calendar, and members get a heads-up when a new one goes up.
@@ -624,7 +624,7 @@ confirm modal carries its own POST form, and template content can't nest a form.
 {# Immediate-effect controls (Preview + Send test) sit ABOVE the batch Save form so Save is the #}
 {# last thing on the tab with nothing under it (Rule 21). #}
 <div x-show="section === 'welcome_email'" x-cloak>
-  <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;">
+  <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;" data-help-key="guild.welcome-email">
     <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Welcome Email</h2>
     <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">Sent to a member when they deliberately join this guild (the Join This Guild button, or the Discord /join-guild command). On by default; leave the subject and body blank to send the standard welcome.</p>
     <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
@@ -1002,5 +1002,3 @@ confirm modal carries its own POST form, and template content can't nest a form.
 
 </div>{# /x-data #}
 {% endblock %}
-
-{% block extra_js %}{% include "hub/partials/_tour.html" %}{% endblock %}

--- a/templates/hub/home.html
+++ b/templates/hub/home.html
@@ -167,5 +167,3 @@
 </div>
 {% endif %}
 {% endblock %}
-
-{% block extra_js %}{% include "hub/partials/_tour.html" %}{% endblock %}

--- a/templates/hub/partials/_tour.html
+++ b/templates/hub/partials/_tour.html
@@ -13,5 +13,10 @@ Boosted swaps re-execute the script; it is a guarded window.plTour IIFE, safe to
      data-driver-js="{% static 'js/driver.min.js' %}"></div>
 {{ tour_json|json_script:"pl-tour-data" }}
 {% if show_tour_offer %}{% include "hub/partials/_tour_offer.html" %}{% endif %}
+{% comment %} The advancing affordance: a brief scrim + spinner shown by pl_tour.js during a hop so the destination never flashes bare. {% endcomment %}
+<div id="pl-tour-advancing" class="pl-tour-advancing" role="status" aria-live="polite" hidden>
+    <span class="pl-tour-advancing__spinner" aria-hidden="true"></span>
+    <span class="pl-tour-advancing__label">Taking you there...</span>
+</div>
 <script src="{% static 'js/pl_tour.js' %}"></script>
 {% endif %}

--- a/templates/hub/spaces.html
+++ b/templates/hub/spaces.html
@@ -27,7 +27,7 @@ exist (see hub_space_request_review_queue) but the entry point here is intention
 Requests now notify the makerspace admins directly by email and in the bell.{% endcomment %}
 
 {% if floorplans %}
-<div class="pl-map" x-data="plMap({{ floorplans.0.pk }}, '{{ active_tab }}')">
+<div class="pl-map" data-help-key="spaces.map" x-data="plMap({{ floorplans.0.pk }}, '{{ active_tab }}')">
 
     <nav class="pl-space-tabs" role="tablist" aria-label="Spaces views" x-cloak>
         <button type="button" role="tab" class="vote-tab"

--- a/tests/core/context_processors_spec.py
+++ b/tests/core/context_processors_spec.py
@@ -1,10 +1,22 @@
 """BDD-style tests for core.context_processors."""
 
 import pytest
+from django.contrib.auth.models import AnonymousUser, User
 from django.test import RequestFactory
+from django.urls import resolve, reverse
+from django.utils import timezone
 
-from core.context_processors import app_version, feature_flags, google_analytics, registration_mode, surface, theme
-from core.models import SiteConfiguration
+from core.context_processors import (
+    app_version,
+    feature_flags,
+    google_analytics,
+    registration_mode,
+    surface,
+    theme,
+    tour_runtime,
+)
+from core.models import SiteConfiguration, TourState
+from membership.models import Member
 from plfog.version import CHANGELOG, VERSION
 
 pytestmark = pytest.mark.django_db
@@ -267,3 +279,78 @@ def describe_notification_badge():
         request = RequestFactory().get("/")
         request.user = AnonymousUser()
         assert notification_badge(request)["unread_notification_count"] == 0
+
+
+def _tour_member(name, **fields):
+    user = User.objects.create_user(username=name, email=f"{name}@example.com")
+    member = Member.objects.get(user=user)  # auto-provisioned by ensure_user_has_member
+    fields.setdefault("welcome_dismissed_at", timezone.now())
+    for key, value in fields.items():
+        setattr(member, key, value)
+    member.save()
+    return member
+
+
+def _tour_request(path, user, *, method="GET", with_resolver=True):
+    factory = RequestFactory()
+    request = factory.get(path) if method == "GET" else factory.post(path)
+    request.user = user
+    if with_resolver:
+        request.resolver_match = resolve(path.split("?")[0])
+    return request
+
+
+def describe_tour_runtime():
+    def it_returns_empty_for_an_anonymous_visitor():
+        request = _tour_request(reverse("hub_home"), AnonymousUser())
+        ctx = tour_runtime(request)
+        assert ctx["tour_json"] is None
+        assert ctx["show_tour_offer"] is False
+
+    def it_returns_empty_for_a_user_without_a_member():
+        user = User.objects.create_user(username="tr-nomember", email="tr-nomember@example.com")
+        Member.objects.filter(user=user).delete()
+        assert tour_runtime(_tour_request(reverse("hub_home"), user))["tour_json"] is None
+
+    def it_offers_on_an_entry_page_and_writes_the_offered_row():
+        member = _tour_member("tr-entry")
+        ctx = tour_runtime(_tour_request(reverse("hub_home"), member.user))
+        assert ctx["show_tour_offer"] is True
+        assert ctx["tour_json"]["key"] == "member-welcome"
+        assert TourState.objects.status_for(member.user, "member-welcome") == TourState.Status.OFFERED
+
+    def it_returns_empty_on_a_non_entry_page_without_a_tour_param():
+        member = _tour_member("tr-nonentry")
+        assert tour_runtime(_tour_request(reverse("hub_help"), member.user))["tour_json"] is None
+
+    def it_autostarts_and_clamps_the_resume_step_on_any_page_without_writing_a_row():
+        member = _tour_member("tr-resume")
+        request = _tour_request(f"{reverse('hub_help')}?tour=member-welcome&step=99", member.user)
+        ctx = tour_runtime(request)
+        assert ctx["tour_autostart"] is True
+        assert ctx["tour_json"]["resume_step"] == len(ctx["tour_json"]["steps"]) - 1
+        assert TourState.objects.count() == 0
+
+    def it_defaults_the_resume_step_to_zero_for_a_non_integer():
+        member = _tour_member("tr-badstep")
+        request = _tour_request(f"{reverse('hub_home')}?tour=member-welcome&step=abc", member.user)
+        assert tour_runtime(request)["tour_json"]["resume_step"] == 0
+
+    def it_ignores_a_foreign_tour_param_but_still_offers_the_entry_tour():
+        member = _tour_member("tr-foreign")  # not a guild lead
+        request = _tour_request(f"{reverse('hub_home')}?tour=guild-lead", member.user)
+        ctx = tour_runtime(request)
+        assert ctx["tour_autostart"] is False
+        assert ctx["tour_json"]["key"] == "member-welcome"
+        assert ctx["show_tour_offer"] is True
+
+    def it_returns_empty_on_a_non_get_request():
+        member = _tour_member("tr-post")
+        request = _tour_request(reverse("hub_home"), member.user, method="POST")
+        assert tour_runtime(request)["tour_json"] is None
+        assert TourState.objects.count() == 0
+
+    def it_handles_a_request_without_a_resolver_match():
+        member = _tour_member("tr-noresolve")
+        request = _tour_request("/anything/", member.user, with_resolver=False)
+        assert tour_runtime(request)["tour_json"] is None

--- a/tests/core/tours_spec.py
+++ b/tests/core/tours_spec.py
@@ -1,6 +1,7 @@
 """BDD-style tests for the guided-tour registry + offer context (Spec C §5)."""
 
 import re
+from datetime import timedelta
 
 import pytest
 from django.contrib.auth.models import AnonymousUser, User
@@ -10,7 +11,20 @@ from django.utils import timezone
 
 from core.help_registry import HELP_KEYS
 from core.models import TourState
-from core.tours import TOURS, entry_url_for, help_card_rows, tour_offer_context, tours_for
+from core.tours import (
+    TOURS,
+    Tour,
+    TourStep,
+    _admin_audience,
+    _demo_class_slug,
+    _demo_guild_slug,
+    _instructor_class_pk,
+    _tour_payload,
+    entry_url_for,
+    help_card_rows,
+    tour_offer_context,
+    tours_for,
+)
 from membership.models import Member
 from tests.membership.factories import GuildFactory
 
@@ -45,8 +59,8 @@ def _get(url: str, member: Member):
 
 
 def describe_TOURS():
-    def it_registers_the_three_launch_tours():
-        assert set(TOURS) == {"member-welcome", "guild-lead", "instructor"}
+    def it_registers_the_four_role_tours():
+        assert set(TOURS) == {"member-welcome", "guild-lead", "instructor", "admin"}
 
     def it_keys_match_their_tour_and_the_slug_format():
         for key, tour in TOURS.items():
@@ -89,12 +103,13 @@ def describe_TOURS():
         assert TOURS["member-welcome"].title == "The Member Hub"
         assert TOURS["guild-lead"].title == "Guild Lead Tools"
         assert TOURS["instructor"].title == "The Teaching Portal"
+        assert TOURS["admin"].title == "Admin Controls"
         member_step_titles = {step.title for step in TOURS["member-welcome"].steps}
         assert "Everything in One Place" in member_step_titles
         assert "Community Calendar" in member_step_titles
         lead_step_titles = {step.title for step in TOURS["guild-lead"].steps}
         assert "Your Guild's Control Room" in lead_step_titles
-        assert "One Tab Per Job" in lead_step_titles
+        assert "Your Wishlist" in lead_step_titles
 
     def describe_guild_lead_url_fallback_for_admins_and_officers():
         def it_falls_back_to_the_first_active_guild_ordered_by_name_for_an_admin():
@@ -190,10 +205,10 @@ def describe_tours_for():
         lead.save(update_fields=["instructor_oriented_at"])
         assert [t.key for t in tours_for(lead)] == ["member-welcome", "guild-lead", "instructor"]
 
-    def it_includes_the_lead_tour_for_admins_who_staff_no_guild():
+    def it_includes_the_lead_and_admin_tours_for_admins_who_staff_no_guild():
         GuildFactory(name="Rows Active Guild", is_active=True)
         admin = _member("tf-admin", fog_role=Member.FogRole.ADMIN)
-        assert [t.key for t in tours_for(admin)] == ["member-welcome", "guild-lead"]
+        assert [t.key for t in tours_for(admin)] == ["member-welcome", "guild-lead", "admin"]
 
     def it_includes_the_lead_tour_for_guild_officers_who_staff_no_guild():
         GuildFactory(name="Rows Officer Guild", is_active=True)
@@ -325,3 +340,158 @@ def describe_tour_offer_context():
             ctx = tour_offer_context(_get("/x/?tour=guild-lead", member), "guild-lead")
             assert ctx["tour_autostart"] is False
             assert ctx["tour_json"] is None
+
+
+def describe_admin_tour():
+    def it_admits_a_full_fog_admin():
+        admin = _member("adm-full", fog_role=Member.FogRole.ADMIN)
+        assert _admin_audience(admin) is True
+        assert TOURS["admin"].audience(admin) is True
+
+    def it_admits_a_member_holding_any_admin_capability():
+        from membership.models import AdminCapability
+
+        scoped = _member("adm-scoped")
+        AdminCapability.objects.create(member=scoped, capability=AdminCapability.Capability.REFUNDS)
+        assert _admin_audience(scoped) is True
+        assert TOURS["admin"].audience(scoped) is True
+
+    def it_excludes_a_plain_member():
+        plain = _member("adm-none")
+        assert _admin_audience(plain) is False
+        assert TOURS["admin"].audience(plain) is False
+
+    def it_lists_the_admin_tour_on_the_help_card_for_an_admin():
+        admin = _member("adm-rows", fog_role=Member.FogRole.ADMIN)
+        assert "admin" in [row["tour"].key for row in help_card_rows(admin)]
+
+    def it_reverses_the_admin_entry_url():
+        admin = _member("adm-url", fog_role=Member.FogRole.ADMIN)
+        assert entry_url_for(TOURS["admin"], admin) == f"{reverse('hub_admin_tools')}?tour=admin"
+
+
+def describe_member_tour_resolvers():
+    def describe__demo_guild_slug():
+        def it_prefers_an_active_guild_with_a_future_orientation_slot():
+            from tests.membership.factories import OrientationSlotFactory
+
+            member = _member("dg-slot")
+            GuildFactory(name="Aaa No Slot Guild", is_active=True)  # alphabetically first, but no slot
+            with_slot = GuildFactory(name="Zzz Slotted Guild", is_active=True)
+            OrientationSlotFactory(guild=with_slot)
+            assert _demo_guild_slug(member) == {"slug": with_slot.slug}
+
+        def it_falls_back_to_the_first_active_guild_by_name_when_none_have_slots():
+            member = _member("dg-fallback")
+            GuildFactory(name="Zzz Active Guild", is_active=True)
+            first = GuildFactory(name="Aaa Active Guild", is_active=True)
+            assert _demo_guild_slug(member) == {"slug": first.slug}
+
+        def it_raises_when_no_active_guild_exists():
+            member = _member("dg-none")
+            GuildFactory(name="Only Inactive Guild", is_active=False)
+            with pytest.raises(ValueError, match="No active guild"):
+                _demo_guild_slug(member)
+
+    def describe__demo_class_slug():
+        def it_returns_the_soonest_bookable_class_slug():
+            from classes.factories import ClassOfferingFactory, ClassSessionFactory
+            from classes.models import ClassOffering
+
+            member = _member("dc-1")
+            offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED, is_private=False)
+            ClassSessionFactory(
+                class_offering=offering,
+                starts_at=timezone.now() + timedelta(days=7),
+                ends_at=timezone.now() + timedelta(days=7, hours=2),
+            )
+            assert _demo_class_slug(member) == {"slug": offering.slug}
+
+        def it_raises_when_no_bookable_class_exists():
+            member = _member("dc-none")
+            with pytest.raises(ValueError, match="No bookable class"):
+                _demo_class_slug(member)
+
+    def describe__instructor_class_pk():
+        def it_returns_the_members_newest_class_pk():
+            from classes.factories import ClassOfferingFactory
+
+            member = _member("ic-1")
+            ClassOfferingFactory(instructor=member)
+            newest = ClassOfferingFactory(instructor=member)
+            assert _instructor_class_pk(member) == {"pk": newest.pk}
+
+        def it_raises_when_the_member_owns_no_class():
+            member = _member("ic-none")
+            with pytest.raises(ValueError, match="owns no class"):
+                _instructor_class_pk(member)
+
+
+def describe__tour_payload():
+    def it_keeps_a_plain_highlight_step_backward_compatible():
+        member = _member("pl-plain")
+        payload = _tour_payload(TOURS["member-welcome"], member, autostart=False)
+        first = payload["steps"][0]
+        assert first["navigate"] is None
+        assert first["tab_set"] is None
+        assert first["click"] is None
+        assert first["wait_for"] is None
+        assert first["page_path"] == reverse("hub_home")
+        assert payload["resume_step"] == 0
+        assert payload["autostart"] is False
+
+    def it_resolves_navigate_to_a_relative_href_and_carries_page_path_forward():
+        member = _member("pl-nav")
+        steps = _tour_payload(TOURS["member-welcome"], member, autostart=True)["steps"]
+        catalog = next(s for s in steps if s["target"] == '[data-help-key="catalog.filter"]')
+        assert catalog["navigate"] == reverse("classes:public_list")
+        assert catalog["page_path"] == reverse("classes:public_list")
+        card = next(s for s in steps if s["target"] == '[data-help-key="catalog.class-card"]')
+        assert card["navigate"] is None  # inherits the catalog page
+        assert card["page_path"] == reverse("classes:public_list")
+
+    def it_folds_a_static_query_into_the_navigate_href():
+        admin = _member("pl-q", fog_role=Member.FogRole.ADMIN)
+        steps = _tour_payload(TOURS["admin"], admin, autostart=False)["steps"]
+        refunds = next(s for s in steps if s["target"] == '[data-help-key="admin.refunds"]')
+        assert refunds["navigate"] == reverse("billing_admin_dashboard") + "?tab=payments"
+        recon = next(s for s in steps if s["target"] == '[data-help-key="admin.reconciliation"]')
+        assert recon["navigate"] == reverse("billing_admin_dashboard") + "?tab=reconciliation"
+
+    def it_resolves_a_callable_query_with_the_member():
+        from classes.factories import ClassOfferingFactory
+
+        member = _member("pl-cq")
+        offering = ClassOfferingFactory(instructor=member)
+        steps = _tour_payload(TOURS["instructor"], member, autostart=False)["steps"]
+        compose = next(s for s in steps if s["target"] == '[data-help-key="announcements.compose"]')
+        assert compose["navigate"] == reverse("hub_compose") + f"?audience=class%3A{offering.pk}&lock=1"
+
+    def it_serializes_tab_set_as_a_list():
+        lead = _lead("pl-tab")
+        steps = _tour_payload(TOURS["guild-lead"], lead, autostart=False)["steps"]
+        orient = next(s for s in steps if s["target"] == '[data-help-key="guild.run-orientations"]')
+        assert orient["tab_set"] == ["section", "orientations"]
+        assert orient["navigate"] is None
+
+    def it_drops_steps_whose_resolver_raises_and_keeps_the_rest():
+        # An instructor who owns no class: the roster, waitlist, and compose stops
+        # (each with a class resolver) drop; create + submit survive.
+        member = _member("pl-drop")
+        targets = [s["target"] for s in _tour_payload(TOURS["instructor"], member, autostart=False)["steps"]]
+        assert '[data-help-key="teach.roster-table"]' not in targets
+        assert '[data-help-key="teach.roster-waitlist"]' not in targets
+        assert '[data-help-key="announcements.compose"]' not in targets
+        assert '[data-help-key="teach.submit-for-review"]' in targets
+
+    def it_raises_on_a_cross_origin_navigate_at_build_time():
+        member = _member("pl-x")
+        bad = Tour(
+            key="member-welcome",  # a registered key so state_url reverses
+            title="Bad",
+            entry_url_name="hub_home",
+            audience=lambda m: True,
+            steps=(TourStep(target=None, title="X", body="x", navigate="https://book.example.com/classes/"),),
+        )
+        with pytest.raises(ValueError, match="cross-origin"):
+            _tour_payload(bad, member, autostart=False)

--- a/tests/e2e/guided_tour_spec.py
+++ b/tests/e2e/guided_tour_spec.py
@@ -1,17 +1,23 @@
-"""End-to-end: the member-welcome guided tour (Spec C).
+"""End-to-end: the member-welcome guided tour, now an auto-navigating lap.
 
-Drives the real offer → Driver.js run → state-recording loop in a browser:
-offer card on hub home, "Show me around" spotlights the page, Next through to
-Done records ``completed``, and the offer never returns. The Esc scenario pins
-the review-hardened JS contract that only a browser can prove — providing
-``onDestroyStarted`` suppresses Driver's default teardown, so our hook must
-call ``destroy()`` itself or Esc/✕/overlay stop closing the tour at all.
+Drives the real offer -> Driver.js segment player -> state-recording loop in a
+browser. The tour narrates on hub home, then DRIVES itself to the next screen
+(catalog, calendar, voting, spaces, a guild, a class, help) via boosted
+navigation, re-hydrating on each page from the "?tour=&step=" param it pushes,
+until Done records ``completed`` and strips the param. Two more scenarios pin
+the contract: Esc mid-tour records ``dismissed``, and landing directly on
+``?tour=member-welcome&step=N`` resumes mid-lap.
+
+The Python suite cannot exercise ``pl_tour.js``; this is the real runtime guard.
 Run with ``pytest -m e2e``.
 """
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from django.urls import reverse
+from django.utils import timezone
 from playwright.sync_api import expect
 
 from core.models import TourState
@@ -19,9 +25,23 @@ from tests.membership.factories import GuildFactory, MembershipPlanFactory
 
 
 def _seed_member_world() -> None:
-    """A plan (so login auto-creates the member) and a guild for the sidebar."""
+    """A plan (so login auto-creates the member), a guild, and a bookable class.
+
+    The guild backs the tour's orientation stop and the future-dated bookable
+    class backs its register stop, so the full multi-page lap has real
+    navigation targets rather than dropping those steps.
+    """
+    from classes.factories import ClassOfferingFactory, ClassSessionFactory
+    from classes.models import ClassOffering
+
     MembershipPlanFactory()
     GuildFactory(name="Fiber Arts Guild")
+    offering = ClassOfferingFactory(status=ClassOffering.Status.PUBLISHED, is_private=False)
+    ClassSessionFactory(
+        class_offering=offering,
+        starts_at=timezone.now() + timedelta(days=7),
+        ends_at=timezone.now() + timedelta(days=7, hours=2),
+    )
 
 
 def _open_home_with_offer(live_server, page, login_via_code, email: str):
@@ -34,8 +54,36 @@ def _open_home_with_offer(live_server, page, login_via_code, email: str):
     return offer
 
 
+def _drive_to_completion(page) -> None:
+    """Click Next through every step, following each cross-page hop.
+
+    Progress reads a global "N of M"; after a Next that is not the final Done we
+    wait until that text changes (a same-page move) or the popover detaches (a
+    boosted navigation), so the loop is resilient to the tour driving the browser.
+    """
+    for _ in range(40):
+        # A hop is a full navigation; let the destination finish loading (and its
+        # tour bootstrap run) before we look for the popover.
+        page.wait_for_load_state("load")
+        popover = page.locator(".driver-popover.pl-tour")
+        popover.wait_for(state="visible", timeout=10000)
+        progress = popover.locator(".driver-popover-progress-text").inner_text().strip()
+        next_btn = popover.locator(".driver-popover-next-btn")
+        label = next_btn.inner_text().strip()
+        next_btn.click()
+        if label == "Done":
+            return
+        page.wait_for_function(
+            "(prev) => { const el = document.querySelector('.driver-popover-progress-text');"
+            " return !el || el.textContent.trim() !== prev; }",
+            arg=progress,
+            timeout=10000,
+        )
+    raise AssertionError("guided tour never reached its Done step")
+
+
 def describe_member_welcome_tour():
-    def it_runs_the_offered_tour_to_completion(live_server, page, login_via_code):
+    def it_runs_the_offered_tour_across_pages_to_completion(live_server, page, login_via_code):
         email = "tour-complete@example.com"
         offer = _open_home_with_offer(live_server, page, login_via_code, email)
 
@@ -47,22 +95,26 @@ def describe_member_welcome_tour():
         expect(popover).to_be_visible()
         expect(popover).to_contain_text("Welcome to the Member Portal")
 
-        # Next through every surviving step until the last one shows Done.
-        # (Hard cap of 12 — surviving steps vary with page state, never exceed 7.)
-        next_btn = popover.locator(".driver-popover-next-btn")
-        for _ in range(12):
-            if next_btn.inner_text().strip() == "Done":
-                break
-            next_btn.click()
-        expect(next_btn).to_have_text("Done")
-        next_btn.click()
-        expect(popover).not_to_be_visible()
+        _drive_to_completion(page)
 
-        # Completion recorded; the offer never returns.
+        # Completion recorded; the offer never returns and the ?tour= param is
+        # stripped so a refresh does not silently restart the tour.
         user = _user_for(email)
         _wait_for_status(page, user, "member-welcome", TourState.Status.COMPLETED)
+        assert "tour=" not in page.url
         page.goto(f"{live_server.url}{reverse('hub_home')}")
         expect(page.locator("[data-pl-tour-offer]")).not_to_be_visible()
+
+    def it_resumes_mid_tour_from_the_url_param(live_server, page, login_via_code):
+        email = "tour-resume@example.com"
+        _seed_member_world()
+        login_via_code(email)
+
+        # Land directly on a later step; the tour re-hydrates there.
+        page.goto(f"{live_server.url}{reverse('hub_home')}?tour=member-welcome&step=1")
+        popover = page.locator(".driver-popover.pl-tour")
+        expect(popover).to_be_visible()
+        expect(popover).to_contain_text("Everything in One Place")  # step index 1
 
     def it_escapes_mid_tour_and_records_a_dismissal(live_server, page, login_via_code):
         email = "tour-escape@example.com"
@@ -79,6 +131,24 @@ def describe_member_welcome_tour():
         user = _user_for(email)
         _wait_for_status(page, user, "member-welcome", TourState.Status.DISMISSED)
 
+    def it_steps_back_across_a_page_hop(live_server, page, login_via_code):
+        # Back from the first step of the second segment (on the catalog) must NAVIGATE
+        # home to the entry-page segment, not strand the user on the catalog with a
+        # centered popover — the entry-page leader has no `navigate`, so hopTo must fall
+        # back to its page_path.
+        email = "tour-back@example.com"
+        _seed_member_world()
+        login_via_code(email)
+        page.goto(f"{live_server.url}{reverse('classes:public_list')}?tour=member-welcome&step=3")
+        popover = page.locator(".driver-popover.pl-tour")
+        popover.wait_for(state="visible", timeout=10000)
+        expect(popover).to_contain_text("Browse Classes")  # step index 3, on the catalog
+
+        popover.locator(".driver-popover-prev-btn").click()
+        page.wait_for_url("**/home/**", timeout=10000)
+        popover.wait_for(state="visible", timeout=10000)
+        expect(popover).to_contain_text("Your Get Started List")  # step index 2, back on home
+
 
 def _user_for(email: str):
     from django.contrib.auth import get_user_model
@@ -87,11 +157,17 @@ def _user_for(email: str):
 
 
 def _wait_for_status(page, user, tour_key: str, expected: str) -> None:
-    """Poll the DB briefly — the state POST is fired from the browser."""
-    for _ in range(40):
+    """Poll the DB — the state POST is fired from the browser and lands async.
+
+    Patient by design: the POST returns 204 promptly against a real server, but
+    under the machine-speed e2e (a heavy final page, the service worker, no human
+    pause) the browser can deprioritize it for several seconds. A human finishing
+    the tour never notices; the poll just needs to outlast the test-infra latency.
+    """
+    for _ in range(60):
         if TourState.objects.status_for(user, tour_key) == expected:
             return
-        page.wait_for_timeout(250)
+        page.wait_for_timeout(500)
     raise AssertionError(
         f"TourState for {tour_key} never became {expected!r}; got {TourState.objects.status_for(user, tour_key)!r}"
     )


### PR DESCRIPTION
The guided tour becomes a **segment player** that drives the browser: narrate a step, hop to the next screen (full navigation or a same-page Alpine tab flip), detect the new surface, keep narrating — persisting the running tour across navigation via a `?tour=&step=` URL param + sessionStorage so it re-hydrates and resumes. Four role tours: **Member (12), Instructor (11), Guild Lead (14), Admin (7, new)** ending on the Reconciliation tab. 12 new `data-help-key` hooks stamped + registered (drift guard green). Offer card, Settings toggle, Help cards, and TourState recording all preserved. VERSION 1.21.0 (member-facing -> announces). No migration (TourState untouched).

Spec: `docs/superpowers/plans/2026-08-27-guided-tours-autonav.md`.

## Three runtime bugs I found + fixed by driving the real browser e2e (pl_tour.js is not pytest-testable)
1. **Label at render time** (`driveSegment`): a non-final page segment now reads "Next" not "Done" — set in the Driver.js config (`doneBtnText: isFinalSegment ? "Done" : "Next"`) instead of a post-render override, closing a race where a single-step page ended the tour early.
2. **Reliable hops** (`boostedGet`): tour navigation is now a plain full navigation (`window.location.assign`). The synthetic hx-boost anchor click did not reliably fire htmx navigation and stranded the tour on the origin page (popover torn down, nothing loaded). The persistence design already survives a full load.
3. **Prompt state recording** (`postState`): dropped `keepalive: true`, which the browser deprioritized and left the recorded state lagging past the poll. Every caller fires while the page stays loaded, so keepalive isn't needed.

## Testing
- Python: `tours_spec`, `context_processors_spec`, `help_keys_spec`, `template_comment_lint` etc. — 124 passed; changelog-collision sweep (`tests/plfog/` + home/tours) 396 passed. ruff + mypy + check clean; no migration drift.
- **e2e (`guided_tour_spec.py`) drives the full member lap across all 8 pages to completion, plus resume + Esc-dismiss. IMPORTANT: run it on Postgres (the CI DB) — `DATABASE_URL=postgres://plfog:plfog@localhost:5433/plfog pytest -m e2e tests/e2e/guided_tour_spec.py`. It is 100% stable on Postgres (6/6). On local SQLite it flakes ~35% purely from SQLite's single-writer table lock (`database table is locked: core_tourstate`) when the browser's state POST races the test's DB read — a SQLite-only artifact that cannot occur on Postgres/MVCC.** I bumped the test's status-poll patience to 30s and added a post-nav load-state wait as belt-and-suspenders.

https://claude.ai/code/session_01NF4MEeH2icSRQ9U4RuGTmA