### PR TITLE
feat(tours): broad expand all four role tours + demo showcase class

### DIFF
--- a/core/help_registry.py
+++ b/core/help_registry.py
@@ -704,6 +704,50 @@ HELP_KEYS: dict[str, HelpKeyEntry] = {
         "article_slug": None,
         "anchor": None,
     },
+    "teach.class-overview": {
+        "title": "Your class home base",
+        "short_text": (
+            "Everything about one class in one place: who is instructing, the price, seats filled, and every session date."
+        ),
+        "article_slug": None,
+        "anchor": None,
+    },
+    "teach.class-qr": {
+        "title": "Flyer and QR code",
+        "short_text": "Open a printable one page flyer or download a QR code that links straight to your class sign up page.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "guild.thankyou-email": {
+        "title": "Orientation thank you email",
+        "short_text": "The note that goes out after someone finishes their orientation. Turn it on and make it your own.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "guild.qr-codes": {
+        "title": "Guild flyer and QR",
+        "short_text": "Print a flyer or download a QR code that points people at your guild page. Great for the studio wall.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "admin.event-review": {
+        "title": "Event approvals",
+        "short_text": "Member proposed events wait here. Review the details, then approve to publish or send it back with a note.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "admin.activity": {
+        "title": "Site activity",
+        "short_text": "A running feed of what is happening across the site: sign ups, bookings, approvals, and more.",
+        "article_slug": None,
+        "anchor": None,
+    },
+    "admin.quickstart-guides": {
+        "title": "Quickstart guides",
+        "short_text": "Short role guides for guild leads and instructors. Point new staff here so they can get going fast.",
+        "article_slug": None,
+        "anchor": None,
+    },
 }
 
 # THE key regex — Specs B/C import this instead of restating their own.

--- a/core/management/commands/demo_data.py
+++ b/core/management/commands/demo_data.py
@@ -83,8 +83,27 @@ STUDENT_FUTURE_ORDER_NUMBER = "PL-DMF2-26"
 # (spots_remaining == 0); the WAITLISTED rows sit genuinely beyond capacity. It is
 # prod-safe like the rest (demo- slug + @pastlives.demo emails, direct ORM, no
 # Stripe/email), so it lives outside the DEBUG-gated local-dev extras.
-FULL_WAITLIST_CAPACITY = 4
-FULL_WAITLIST_WAITLISTED = 3
+#
+# This is the "fully fleshed out" showcase class the instructor tour points at, so
+# it carries a real title, a rich description, believable rosters, and a hero photo.
+# It is themed woodworking to match a repo-committed image (see SHOWCASE_HERO_REL_PATH)
+# that is present on every deploy — unlike the gitignored demo_seed dir — so the card
+# looks real even on a prod seed, where the image saves through R2.
+SHOWCASE_TITLE = "Woodshop Fundamentals: Build a Cutting Board"
+SHOWCASE_DESCRIPTION = (
+    "A hands on introduction to the Past Lives woodshop. In one focused session you will learn to "
+    "safely set up and use the table saw, planer, and random orbit sander, then mill and glue up a "
+    "hardwood cutting board you sand, finish, and take home the same day. All tools, hardwood, and a "
+    "food safe finish are provided, and we keep the group small so everyone gets real bench time. No "
+    "experience needed. Please wear closed toe shoes and clothes you can get a little sawdust on."
+)
+SHOWCASE_HERO_REL_PATH = "assets/images/woodshop+portland+oregon+makerspace+past+lives.webp"
+# Realistic rosters so the showcase reads like a real class on the roster + waitlist
+# screens. Emails stay `wl-…@pastlives.demo` so teardown's demo-email sweep catches them.
+FULL_WAITLIST_CONFIRMED_NAMES = [("Maya", "Thompson"), ("Leo", "Garcia"), ("Priya", "Shah"), ("Sam", "Okafor")]
+FULL_WAITLIST_WAITING_NAMES = [("Jordan", "Kim"), ("Tessa", "Alvarez"), ("Marcus", "Bell")]
+FULL_WAITLIST_CAPACITY = len(FULL_WAITLIST_CONFIRMED_NAMES)
+FULL_WAITLIST_WAITLISTED = len(FULL_WAITLIST_WAITING_NAMES)
 
 # --- Local-dev-only personas + data (gated on settings.DEBUG) ----------------
 # The blocks below create ACTIVE demo Members, push orientation config onto real
@@ -150,7 +169,7 @@ class Command(BaseCommand):
         self._ensure_student_registrations(student, past_class, future_paid_class)
         self._ensure_instructor_class_rosters(past_class, current_free_class, future_paid_class)
         self._ensure_guest_registration(current_free_class)
-        full_waitlist_class = self._ensure_full_waitlist_class(category, instructor)
+        full_waitlist_class = self._ensure_full_waitlist_class(self._ensure_showcase_category(), instructor)
         self._ensure_discount_codes()
 
         # Everything below is local-dev only. Registration questions are global
@@ -203,6 +222,19 @@ class Command(BaseCommand):
         category, _ = Category.objects.get_or_create(
             slug=f"{DEMO_SLUG_PREFIX}lamp-working",
             defaults={"name": "[DEMO] Lamp Working", "sort_order": 999},
+        )
+        return category
+
+    def _ensure_showcase_category(self) -> Category:
+        """A standalone category for the fully fleshed out showcase class.
+
+        Named without a ``[DEMO]`` prefix so the showcase card reads like a real
+        catalog entry (the class is the demo centerpiece the instructor tour points
+        at), but slug stays ``demo-`` prefixed so ``--remove`` still tears it down.
+        """
+        category, _ = Category.objects.get_or_create(
+            slug=f"{DEMO_SLUG_PREFIX}woodworking",
+            defaults={"name": "Woodworking", "sort_order": 998},
         )
         return category
 
@@ -350,6 +382,7 @@ class Command(BaseCommand):
         capacity: int,
         session_start,
         member_discount_pct: int = 10,
+        description: str = "Seeded demo class. Safe to delete via `manage.py demo_data --remove`.",
     ) -> ClassOffering:
         offering, _ = ClassOffering.objects.update_or_create(
             slug=slug,
@@ -357,7 +390,7 @@ class Command(BaseCommand):
                 "title": title,
                 "category": category,
                 "instructor": instructor,
-                "description": "Seeded demo class. Safe to delete via `manage.py demo_data --remove`.",
+                "description": description,
                 "price_cents": price_cents,
                 "member_discount_pct": member_discount_pct,
                 "capacity": capacity,
@@ -467,34 +500,38 @@ class Command(BaseCommand):
         now = timezone.now()
         offering = self._upsert_class(
             slug=f"{DEMO_SLUG_PREFIX}full-waitlist",
-            title="[DEMO] Screen Printing Intensive (Full + Waitlist)",
+            title=SHOWCASE_TITLE,
             category=category,
             instructor=instructor,
             price_cents=9000,
             capacity=FULL_WAITLIST_CAPACITY,
             session_start=now + timedelta(days=10),
+            description=SHOWCASE_DESCRIPTION,
         )
+        # A hero photo so the showcase card looks real. Sourced from a repo-committed
+        # asset (present on every deploy) so it also lands on a prod seed via R2.
+        self._attach_committed_hero(offering, SHOWCASE_HERO_REL_PATH)
         # Fill to capacity with CONFIRMED, paid registrants → spots_remaining == 0.
-        for i in range(1, offering.capacity + 1):
+        for i, (first, last) in enumerate(FULL_WAITLIST_CONFIRMED_NAMES, start=1):
             self._upsert_registration(
                 offering=offering,
                 order_number=f"PL-DMW{i + 1}-26",
                 email=f"wl-confirmed{i}@{DEMO_EMAIL_DOMAIN}",
-                first_name="Waitlist",
-                last_name=f"Confirmed{i}",
+                first_name=first,
+                last_name=last,
                 status=Registration.Status.CONFIRMED,
                 confirmed_at=now - timedelta(days=1),
                 amount_paid_cents=offering.price_cents,
             )
         # A genuine waitlist beyond capacity: unpaid, unconfirmed, and never notified
         # (waitlist_notified_at defaults to None and _upsert_registration never sets it).
-        for i in range(1, FULL_WAITLIST_WAITLISTED + 1):
+        for i, (first, last) in enumerate(FULL_WAITLIST_WAITING_NAMES, start=1):
             self._upsert_registration(
                 offering=offering,
                 order_number=f"PL-DMX{i + 1}-26",
                 email=f"wl-waiting{i}@{DEMO_EMAIL_DOMAIN}",
-                first_name="Waitlist",
-                last_name=f"Waiting{i}",
+                first_name=first,
+                last_name=last,
                 status=Registration.Status.WAITLISTED,
                 confirmed_at=None,
                 amount_paid_cents=0,
@@ -676,6 +713,25 @@ class Command(BaseCommand):
         offering.approvals.all().delete()
         ClassApproval.objects.create(class_offering=offering, role=ClassApproval.Role.ADMIN)
         return offering
+
+    def _attach_committed_hero(self, offering: ClassOffering, rel_path: str) -> None:
+        """Attach a repo-committed image as the class hero if it has none.
+
+        Reads from a path under ``BASE_DIR`` (committed to the repo, so present on
+        every environment including Render) and saves through the active storage
+        backend — local FileSystemStorage in dev, Cloudflare R2 in prod. This is how
+        the showcase class gets a real hero even on a prod seed, where the gitignored
+        ``demo_seed`` dir does not exist. Skips silently if the source is missing or a
+        hero is already set, so re-seeding never duplicates and a checkout without the
+        asset still seeds cleanly.
+        """
+        if offering.image:
+            return
+        source = Path(settings.BASE_DIR) / rel_path
+        if not source.is_file():
+            return
+        with source.open("rb") as fh:
+            offering.image.save(Path(rel_path).name, File(fh), save=True)
 
     def _demo_image_dir(self) -> Path | None:
         image_dir = Path(settings.MEDIA_ROOT) / DEMO_IMAGE_DIRNAME

--- a/core/management/commands/demo_data.py
+++ b/core/management/commands/demo_data.py
@@ -98,6 +98,28 @@ SHOWCASE_DESCRIPTION = (
     "experience needed. Please wear closed toe shoes and clothes you can get a little sawdust on."
 )
 SHOWCASE_HERO_REL_PATH = "assets/images/woodshop+portland+oregon+makerspace+past+lives.webp"
+# Believable descriptions for the other demo classes so the prod catalog does not show
+# placeholder jargon next to real classes during a demo. They keep their [DEMO] titles
+# (they exist to demo management flows) but read like real listings.
+DESC_FREE_INTRO = (
+    "A relaxed, free hour in the studio to see the space, meet a few makers, and find out what you "
+    "can make here. Drop in, look around, and ask anything. Perfect if you are brand new and just "
+    "want a feel for the place before you commit."
+)
+DESC_ADVANCED = (
+    "Take your glass work further. This session digs into layering color, striking, and encasing so "
+    "your pieces read the way you picture them. Bring a few basics under your belt and we will build "
+    "from there. Glass and studio time are included."
+)
+DESC_PAST = (
+    "The core skills every lampworker needs: lighting and tuning the torch, gathering and shaping "
+    "molten glass, and making your first solid bead start to finish. All glass and tools provided."
+)
+DESC_PENDING = (
+    "A gentle first taste of working glass at the torch. You will shape your first bead and leave "
+    "knowing the safety basics and whether lampworking is for you. No experience needed and "
+    "everything is provided."
+)
 # Realistic rosters so the showcase reads like a real class on the roster + waitlist
 # screens. Emails stay `wl-…@pastlives.demo` so teardown's demo-email sweep catches them.
 FULL_WAITLIST_CONFIRMED_NAMES = [("Maya", "Thompson"), ("Leo", "Garcia"), ("Priya", "Shah"), ("Sam", "Okafor")]
@@ -169,7 +191,6 @@ class Command(BaseCommand):
         self._ensure_student_registrations(student, past_class, future_paid_class)
         self._ensure_instructor_class_rosters(past_class, current_free_class, future_paid_class)
         self._ensure_guest_registration(current_free_class)
-        full_waitlist_class = self._ensure_full_waitlist_class(self._ensure_showcase_category(), instructor)
         self._ensure_discount_codes()
 
         # Everything below is local-dev only. Registration questions are global
@@ -197,6 +218,12 @@ class Command(BaseCommand):
                     "class images, pending-approval class, orientations."
                 )
             )
+
+        # Create the showcase full+waitlist class LAST so it is the demo instructor's
+        # newest class on every environment. The instructor tour targets the newest
+        # class, and on local dev (DEBUG on) the pending-approval class above would
+        # otherwise win and strand the tour on an empty roster.
+        full_waitlist_class = self._ensure_full_waitlist_class(self._ensure_showcase_category(), instructor)
 
         self.stdout.write(self.style.SUCCESS("\nDemo data ready. Log in details:"))
         self.stdout.write(f"  Student (non-member): {PERSONA_STUDENT_EMAIL}  /  password: {password}")
@@ -349,6 +376,7 @@ class Command(BaseCommand):
             price_cents=8000,
             capacity=6,
             session_start=now - timedelta(days=14),
+            description=DESC_PAST,
         )
         current_free = self._upsert_class(
             slug=f"{DEMO_SLUG_PREFIX}free-intro",
@@ -359,6 +387,7 @@ class Command(BaseCommand):
             member_discount_pct=0,
             capacity=8,
             session_start=now + timedelta(days=3),
+            description=DESC_FREE_INTRO,
         )
         future_paid = self._upsert_class(
             slug=f"{DEMO_SLUG_PREFIX}future-advanced",
@@ -368,6 +397,7 @@ class Command(BaseCommand):
             price_cents=15000,
             capacity=4,
             session_start=now + timedelta(days=21),
+            description=DESC_ADVANCED,
         )
         return past, current_free, future_paid
 
@@ -699,7 +729,7 @@ class Command(BaseCommand):
                 "category": category,
                 "instructor": instructor,
                 "created_by": instructor,
-                "description": "Seeded demo class awaiting admin approval. Safe to delete via `demo_data --remove`.",
+                "description": DESC_PENDING,
                 "price_cents": 6500,
                 "member_discount_pct": 10,
                 "capacity": 6,

--- a/core/tours.py
+++ b/core/tours.py
@@ -450,8 +450,8 @@ TOURS: dict[str, Tour] = {
                 target='[data-help-key="teach.roster-waitlist"]',
                 title="The Waitlist",
                 body=(
-                    "A seat opened up? Promote someone here. They take the spot, and for a paid class they "
-                    "get a payment link to check out. No card is charged for them."
+                    "A seat opened up? Promote someone here. They take the spot, and for a paid class you can "
+                    "send them a payment link to check out. No card is charged for them."
                 ),
                 navigate="classes:teach_class_waitlist",
                 navigate_kwargs=_instructor_class_pk,

--- a/core/tours.py
+++ b/core/tours.py
@@ -216,6 +216,14 @@ TOURS: dict[str, Tour] = {
                 body="Tap Subscribe to add the whole calendar to your own phone or laptop.",
             ),
             TourStep(
+                target=None,
+                title="It All Syncs to Discord",
+                body=(
+                    "Classes, events, and guild meetups post to our Discord automatically, so the "
+                    "calendar and Discord always match. Nothing extra for you to do."
+                ),
+            ),
+            TourStep(
                 target='[data-help-key="voting.rank-guilds"]',
                 title="Guild Voting",
                 body=(
@@ -286,11 +294,26 @@ TOURS: dict[str, Tour] = {
                 tab_set=("section", "basic"),
             ),
             TourStep(
+                target='[data-help-key="guild.qr-codes"]',
+                title="Share and Print",
+                body="Print a flyer or grab a QR code for your guild page. Perfect for the shop wall or a table at an event.",
+                tab_set=("section", "basic"),
+            ),
+            TourStep(
                 target='[data-help-key="guild.run-orientations"]',
                 title="Orientations",
                 body=(
                     "Set your orientation hours and open slots here. Bookings show up on the "
                     "Orientations dashboard to confirm."
+                ),
+                tab_set=("section", "orientations"),
+            ),
+            TourStep(
+                target='[data-help-key="guild.thankyou-email"]',
+                title="The Thank You Email",
+                body=(
+                    "After someone finishes their orientation, this note goes out automatically. "
+                    "Turn it on and make it yours."
                 ),
                 tab_set=("section", "orientations"),
             ),
@@ -407,6 +430,16 @@ TOURS: dict[str, Tour] = {
                 body="When it is ready, submit for review. It goes to the guild lead and then an admin before it publishes.",
             ),
             TourStep(
+                target='[data-help-key="teach.class-overview"]',
+                title="Your Class Home Base",
+                body=(
+                    "This is one class in one place: who is teaching, the price, how many seats are filled, "
+                    "and every session date. Everything below hangs off here."
+                ),
+                navigate="classes:teach_class_detail",
+                navigate_kwargs=_instructor_class_pk,
+            ),
+            TourStep(
                 target='[data-help-key="teach.roster-table"]',
                 title="Your Roster",
                 body="Here is who signed up. Open a person's menu to remove them and a seat frees up.",
@@ -416,8 +449,21 @@ TOURS: dict[str, Tour] = {
             TourStep(
                 target='[data-help-key="teach.roster-waitlist"]',
                 title="The Waitlist",
-                body="Someone waiting? Promote them and they take the open seat and get a confirmation.",
+                body=(
+                    "A seat opened up? Promote someone here. They take the spot, and for a paid class they "
+                    "get a payment link to check out. No card is charged for them."
+                ),
                 navigate="classes:teach_class_waitlist",
+                navigate_kwargs=_instructor_class_pk,
+            ),
+            TourStep(
+                target='[data-help-key="teach.class-qr"]',
+                title="Print a Flyer or QR",
+                body=(
+                    "Open a one page flyer or grab a QR code that links right to your sign up page. "
+                    "Print it, post it, hand it out."
+                ),
+                navigate="classes:teach_class_edit",
                 navigate_kwargs=_instructor_class_pk,
             ),
             TourStep(
@@ -444,13 +490,31 @@ TOURS: dict[str, Tour] = {
             TourStep(
                 target=None,
                 title="The Admin Controls",
-                body="These are the admin controls. I will show the five you will reach for most.",
+                body="These are the admin controls. I will walk you through the tools you will reach for most.",
             ),
             TourStep(
                 target='[data-help-key="announcements.compose"]',
                 title="Site Wide Announcements",
                 body="Send a site wide announcement here. Pick who gets it, write once, and it can go to email, push, and Discord.",
                 navigate="hub_compose",
+            ),
+            TourStep(
+                target='[data-help-key="admin.review-queue"]',
+                title="Class Approvals",
+                body="Classes waiting on you sit at the top. Review the details, then approve or send it back with a note.",
+                navigate="classes:admin_overview",
+            ),
+            TourStep(
+                target='[data-help-key="announcements.review-proposals"]',
+                title="Announcement Approvals",
+                body="Member proposed announcements wait here. Approve one to post it, or send it back with a note.",
+                navigate="hub_guild_announcement_review_queue",
+            ),
+            TourStep(
+                target='[data-help-key="admin.event-review"]',
+                title="Event Approvals",
+                body="Member proposed events wait here too. Approving one publishes it to the calendar and posts to Discord.",
+                navigate="hub_event_review_queue",
             ),
             TourStep(
                 target='[data-help-key="admin.refunds"]',
@@ -460,10 +524,14 @@ TOURS: dict[str, Tour] = {
                 query={"tab": "payments"},
             ),
             TourStep(
-                target='[data-help-key="admin.review-queue"]',
-                title="The Review Queue",
-                body="Classes waiting on you sit at the top. Review the details, then approve or send it back with a note.",
-                navigate="classes:admin_overview",
+                target='[data-help-key="admin.reconciliation"]',
+                title="Reconciliation",
+                body=(
+                    "This report breaks down exactly what each guild, instructor, and orientator is owed, "
+                    "so you can tell the treasurer precisely what to transfer."
+                ),
+                navigate="billing_admin_dashboard",
+                query={"tab": "reconciliation"},
             ),
             TourStep(
                 target='[data-help-key="admin.discount-codes"]',
@@ -472,16 +540,30 @@ TOURS: dict[str, Tour] = {
                 navigate="classes:admin_discount_codes",
             ),
             TourStep(
-                target='[data-help-key="admin.reconciliation"]',
-                title="Reconciliation",
-                body="This report breaks down what each guild is owed so you can reconcile payouts.",
-                navigate="billing_admin_dashboard",
-                query={"tab": "reconciliation"},
+                target='[data-help-key="orientation.dashboard"]',
+                title="Orientations Dashboard",
+                body="Every guild's orientation requests and completions live here so you can see who is booked and who is oriented.",
+                navigate="hub_orientations_dashboard",
             ),
             TourStep(
-                target=None,
-                title="That Is the Admin Lap",
-                body="Each tool has a full guide on the Help page.",
+                target='[data-help-key="admin.invite-member"]',
+                title="Manage Members",
+                body="See everyone, open a member to edit them, or invite someone new right here.",
+                navigate="hub_admin_members",
+            ),
+            TourStep(
+                target='[data-help-key="admin.activity"]',
+                title="Site Activity",
+                body="A running feed of sign ups, bookings, approvals, and emails, so you can see what just happened.",
+                navigate="manage_activity",
+            ),
+            TourStep(
+                target='[data-help-key="admin.quickstart-guides"]',
+                title="Your Admin Home",
+                body=(
+                    "Every tool lives on this page, and the Guild Lead and Instructor Quickstart guides at the "
+                    "bottom spell out each role. That is the lap."
+                ),
                 navigate="hub_admin_tools",
             ),
         ),

--- a/docs/superpowers/plans/2026-08-28-guided-tour-broad-expansion.md
+++ b/docs/superpowers/plans/2026-08-28-guided-tour-broad-expansion.md
@@ -1,0 +1,88 @@
+# Guided Tour Broad Expansion + Demo Class Enrichment
+
+**Date:** 2026-08-28
+**Goal:** Flesh out all four role tours to cover the full Tuesday demo script, enrich the
+fictional full class so it is a believable showcase, and seed the whole thing on production.
+
+## Context
+
+The four auto-navigating tours (`core/tours.py`) shipped in v1.21.0 and work well. For the
+Sept 1 demo the presenter wants each tour to walk the *complete* role workflow, not just the
+core stops. The demo runs on **production** (`members.pastlives.space`), seeded with the
+prod-safe `demo_data` command. The fictional "full class + waitlist" (already seeded by
+`_ensure_full_waitlist_class`) is thin (generic description, no images) and only appears
+where `demo_data` has been run.
+
+## Decisions (locked with the requester)
+
+| Question | Decision |
+|---|---|
+| Demo environment | **Production.** Seed `demo_data` on prod (prod-safe: `@pastlives.demo` emails, `demo-` slugs, no Stripe/email). Verify DB host before/after. |
+| Tour scope | **Broad expansion** — a guided stop for (nearly) every bullet in the demo workflow lists. |
+| Full class | **Enrich but keep standalone** — real title, rich description, hero + gallery images, kept in its own demo category (not tied to Cartographers). Keep 4-confirmed + 3-waitlist state. |
+
+## Tour expansion (target stops per role)
+
+Every new step targets a `[data-help-key="…"]` that must exist in `core/help_registry.py`
+**and** in a template (drift guard: `tests/hub/help_keys_spec.py`). New keys get a template
+hook in the same PR. Element-less (`target=None`) steps need no hook.
+
+### Member (`member-welcome`)
+Existing lap is complete except one gap:
+- **Discord sync** — after the calendar-subscribe stop, an element-less note: classes, events,
+  and guild meetups mirror to the Past Lives Discord automatically. No new hook (centered step).
+
+### Instructor (`instructor`)
+- **Class detail / management landing** (`classes:teach_class_detail`, newest class = the full
+  showcase class) — overview stop. New hook `teach.class-overview`.
+- **QR flyer** — the printable flyer / QR download control on the class detail page
+  (`classes:class_flyer` / `classes:class_qr`). New hook `teach.class-qr`.
+- Reword the waitlist stop to name the re-charge-on-promote behaviour for paid classes.
+
+### Guild lead (`guild-lead`)
+- **Thank-you email** — the post-orientation thank-you editor
+  (`GuildOrientationSettings.thankyou_email_*`). Hook to be placed where it is edited.
+- **QR codes** — the guild printable flyer / QR (`hub_guild_flyer` / `hub_guild_qr`). New hook.
+
+### Admin (`admin`)
+Broaden from 5 to the fuller admin surface:
+- Keep: site-wide announcements, refunds, review queue, discount codes, reconciliation.
+- Add: **Orientations Dashboard** (`hub_orientations_dashboard`, key `orientation.dashboard`),
+  **event + announcement approvals** (`announcements.review-proposals` and/or the events queue),
+  **manage members**, **activity pane**, and **quickstart guides** — each only if a real anchor
+  and route exist (drop gracefully otherwise, per the resolver-raises-`ValueError` pattern).
+
+Exact anchors are being mapped read-only before implementation; any stop whose page/anchor does
+not exist is dropped rather than faked.
+
+## Demo class enrichment (`_ensure_full_waitlist_class`)
+
+- Believable title (drop the `[DEMO]` display prefix; teardown stays keyed on the `demo-` slug
+  and `@pastlives.demo` emails, not the title).
+- Rich, real-sounding description (what you make, what is provided, skill level).
+- Hero + gallery images that also attach on a **prod** seed (R2 storage). Because the current
+  `demo_seed` dir is local + gitignored + DEBUG-gated, the showcase image(s) come from a small
+  committed asset set so a prod seed (DEBUG off on Render) can attach them through R2.
+- Keep capacity = confirmed count (full) with 3 genuine waitlist rows.
+
+## Prod seeding
+
+Seed via a **Render one-off job** (`python manage.py demo_data`) so DEBUG is off and the
+dangerous local-dev extras (global registration questions, ACTIVE demo member, orientation
+config pushed onto real guilds) are skipped. Only the prod-safe block runs: personas, classes,
+the enriched full class, discount codes. Verify with `demo_data --status` and by loading the
+catalog. `demo_data --remove` cleans it all up after the demo.
+
+## Tests
+
+- `tests/hub/help_keys_spec.py` — new keys must round-trip (registry ↔ template).
+- `core/spec/tours_spec.py` (or equivalent) — payload builds, resolvers drop gracefully.
+- `tests/e2e/guided_tour_spec.py` — the member lap still drives to completion with the added step.
+- `tests/template_comment_lint_spec.py` — single-line `{# #}` only.
+
+## Out of scope
+
+- No changes to the tour runtime (`static/js/pl_tour.js`) beyond what new step shapes require.
+- No new DB models (tours are repo-authored dataclasses).
+- General-info items the presenter narrates live (Discord command list, app-store links) are not
+  in-app tour stops unless a natural anchor already exists.

--- a/templates/classes/_components/class_qr_share.html
+++ b/templates/classes/_components/class_qr_share.html
@@ -14,4 +14,4 @@ card as a single string, since the shared card takes one pre-computed hint.
   {% include "components/qr_share_card.html" with title="Share & Print" hint="This QR opens the class's public page once it's published. You can print it now — the link stays the same." qr_svg=offering.qr_svg share_url=offering.qr_url svg_url=class_qr_svg_url png_url=class_qr_png_url %}
 {% endif %}
 {# A print-ready one-page flyer (hero photo + QR) — opens in its own tab for browser Print → Save as PDF. #}
-<a class="hub-btn hub-btn--sm hub-btn--primary pl-qr-share__flyer" href="{% url 'classes:class_flyer' offering.pk %}" target="_blank" rel="noopener">Open printable flyer</a>
+<a class="hub-btn hub-btn--sm hub-btn--primary pl-qr-share__flyer" data-help-key="teach.class-qr" href="{% url 'classes:class_flyer' offering.pk %}" target="_blank" rel="noopener">Open printable flyer</a>

--- a/templates/classes/teach/class_overview.html
+++ b/templates/classes/teach/class_overview.html
@@ -1,7 +1,7 @@
 {% extends "classes/teach/class_detail_base.html" %}
 {% load classes_tags %}
 {% block detail_content %}
-<div class="admin-table-wrap" style="margin-bottom:1rem;">
+<div class="admin-table-wrap" data-help-key="teach.class-overview" style="margin-bottom:1rem;">
 <table>
     <tbody>
         <tr>

--- a/templates/hub/admin/activity.html
+++ b/templates/hub/admin/activity.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div x-data="{ tab: '{{ active_tab|default:"feed" }}' }">
-  <h1 class="hub-page-title">Site Activity</h1>
+  <h1 class="hub-page-title" data-help-key="admin.activity">Site Activity</h1>
 
   <div style="display:flex;border-bottom:1px solid var(--hub-border);gap:0;margin-bottom:1.25rem;flex-wrap:wrap;">
     <button type="button" @click="tab = 'feed'"

--- a/templates/hub/admin/members.html
+++ b/templates/hub/admin/members.html
@@ -58,7 +58,7 @@
     <h2 class="hub-detail-label" style="margin:0;">Members &amp; invites</h2>
     <div class="pl-invite-card__actions">
       <button type="button" class="hub-btn hub-btn--sm hub-btn--primary" @click="showAdd = !showAdd; showInvite = false">+ Add member</button>
-      <button type="button" class="hub-btn hub-btn--sm" @click="showInvite = !showInvite; showAdd = false">+ Invite a member</button>
+      <button type="button" class="hub-btn hub-btn--sm" data-help-key="admin.invite-member" @click="showInvite = !showInvite; showAdd = false">+ Invite a member</button>
     </div>
   </div>
 

--- a/templates/hub/admin_tools.html
+++ b/templates/hub/admin_tools.html
@@ -4,7 +4,7 @@
 <h1 class="hub-page-title">Admin Tools</h1>
 <p class="pl-wizard-lead">Staff and leadership tools, in one place.</p>
 
-<div class="pl-tools-grid">
+<div class="pl-tools-grid" data-help-key="admin.quickstart-guides">
   {% if tool_announcements %}
   <a class="hub-card pl-tool-card" href="{% url 'hub_compose' %}">
     <span class="pl-tool-card__icon">

--- a/templates/hub/event_review_queue.html
+++ b/templates/hub/event_review_queue.html
@@ -6,7 +6,7 @@
   <p style="margin-bottom:0.75rem;">
     <a href="{% url 'hub_community_calendar' %}?tab=events" class="hub-btn hub-btn--sm hub-btn--ghost">← Back to the Community Calendar</a>
   </p>
-  <h1 class="hub-page-title">Events Awaiting Review</h1>
+  <h1 class="hub-page-title" data-help-key="admin.event-review">Events Awaiting Review</h1>
   <p class="hub-text-muted" style="margin:-0.25rem 0 1.5rem; max-width:65ch;">
     Member-proposed events waiting on a decision. Approving one publishes it to the calendar (and posts to Discord).
   </p>

--- a/templates/hub/guild_announcement_review_queue.html
+++ b/templates/hub/guild_announcement_review_queue.html
@@ -6,7 +6,7 @@
   <p style="margin-bottom:0.75rem;">
     <a href="{% url 'hub_home' %}" class="hub-btn hub-btn--sm hub-btn--ghost">← Back to your hub</a>
   </p>
-  <h1 class="hub-page-title">Announcements Awaiting Review</h1>
+  <h1 class="hub-page-title" data-help-key="announcements.review-proposals">Announcements Awaiting Review</h1>
   <p class="hub-text-muted" style="margin:-0.25rem 0 1.5rem; max-width:65ch;">
     Member-proposed announcements waiting on a decision. Approving one posts it to the guild page — and, if you
     leave the boxes ticked, emails the guild's members and posts to its Discord.

--- a/templates/hub/guild_edit.html
+++ b/templates/hub/guild_edit.html
@@ -199,7 +199,7 @@
 </div>
 
 {# ── Share & Print (Basic tab) — vanity URL, printable flyer, QR downloads ──── #}
-<div x-show="section === 'basic'" x-cloak class="hub-card" style="padding:1.5rem; margin-top:2.5rem; margin-bottom:1.5rem;">
+<div x-show="section === 'basic'" x-cloak class="hub-card" data-help-key="guild.qr-codes" style="padding:1.5rem; margin-top:2.5rem; margin-bottom:1.5rem;">
   <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Share &amp; Print</h2>
   <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem; max-width:46rem;">
     Every guild has a short public web page. Print the flyer for the shop wall, hand out the QR code, or read the link aloud.
@@ -423,7 +423,7 @@ confirm modal carries its own POST form, and template content can't nest a form.
   <form method="post" action="{% url 'hub_guild_emails_save' guild.pk %}" class="hub-form">
     {% csrf_token %}
     <input type="hidden" name="form_id" value="thankyou_email">
-    <div class="hub-card" style="padding:1.5rem; margin-bottom:1.5rem;">
+    <div class="hub-card" data-help-key="guild.thankyou-email" style="padding:1.5rem; margin-bottom:1.5rem;">
       <h2 class="hub-detail-label" style="margin-top:0; margin-bottom:0.25rem;">Thank-you Email</h2>
       <p class="hub-text-muted" style="font-size:0.8125rem; margin-bottom:1rem;">Sent to the member once their orientation is marked complete.</p>
       {% include "components/form_field.html" with field=thankyou_email_form.thankyou_email_enabled %}

--- a/templates/hub/orientations_dashboard.html
+++ b/templates/hub/orientations_dashboard.html
@@ -3,7 +3,9 @@
 {% block title %}Orientations{% endblock %}
 {% block content %}
 <div x-data="{}">
-  {% include "components/page_header.html" with title="Orientations" description="Track and manage orientation requests and completions for the guilds you lead or staff. Members request an orientation from each guild's own page — this is where leads and staff respond to, schedule, and record them." %}
+  <div data-help-key="orientation.dashboard">
+    {% include "components/page_header.html" with title="Orientations" description="Track and manage orientation requests and completions for the guilds you lead or staff. Members request an orientation from each guild's own page — this is where leads and staff respond to, schedule, and record them." %}
+  </div>
 
   {% if hours_nudge_guilds %}
   <div class="hub-card pl-hours-nudge">
@@ -19,7 +21,7 @@
   {% endif %}
 
   {% if upcoming %}
-  <div class="hub-card" data-help-key="orientation.dashboard" style="padding:1.25rem 1.5rem; margin-bottom:1.5rem;">
+  <div class="hub-card" style="padding:1.25rem 1.5rem; margin-bottom:1.5rem;">
     <h2 class="hub-detail-label" style="margin:0 0 0.75rem;">Upcoming</h2>
     <ul style="list-style:none; padding:0; margin:0;">
       {% for b in upcoming %}

--- a/templates/hub/orientations_dashboard.html
+++ b/templates/hub/orientations_dashboard.html
@@ -19,7 +19,7 @@
   {% endif %}
 
   {% if upcoming %}
-  <div class="hub-card" style="padding:1.25rem 1.5rem; margin-bottom:1.5rem;">
+  <div class="hub-card" data-help-key="orientation.dashboard" style="padding:1.25rem 1.5rem; margin-bottom:1.5rem;">
     <h2 class="hub-detail-label" style="margin:0 0 0.75rem;">Upcoming</h2>
     <ul style="list-style:none; padding:0; margin:0;">
       {% for b in upcoming %}

--- a/tests/core/management/demo_data_spec.py
+++ b/tests/core/management/demo_data_spec.py
@@ -40,6 +40,18 @@ def _write_demo_image(path) -> None:
     path.write_bytes(buf.getvalue())
 
 
+@pytest.fixture(autouse=True)
+def _isolate_media(settings, tmp_path):
+    """Point MEDIA_ROOT at a throwaway dir for every demo_data spec.
+
+    The seed now attaches a repo-committed hero to the showcase class on every run
+    (the prod-image path), which writes through the storage backend. Without this,
+    those writes would land in the real ``media/`` tree and accumulate. Tests that
+    need their own media dir (the image spec) reassign MEDIA_ROOT in their body.
+    """
+    settings.MEDIA_ROOT = str(tmp_path / "media")
+
+
 def describe_demo_data_seed():
     def it_creates_student_instructor_and_guest_registrations():
         call_command("demo_data")
@@ -137,6 +149,49 @@ def describe_demo_data_full_waitlist_class():
         status_out = io.StringIO()
         call_command("demo_data", "--status", stdout=status_out)
         assert f"{DEMO_SLUG_PREFIX}full-waitlist" in status_out.getvalue()
+
+
+def describe_demo_data_showcase_class():
+    def it_makes_the_full_class_a_believable_standalone_showcase(settings):
+        # DEBUG off = the prod path: the committed hero must still attach.
+        settings.DEBUG = False
+        call_command("demo_data")
+
+        offering = ClassOffering.objects.get(slug=f"{DEMO_SLUG_PREFIX}full-waitlist")
+        # A real, prefix-free title in its own standalone (non lamp-working) category.
+        assert "[DEMO]" not in offering.title
+        assert offering.category.slug == f"{DEMO_SLUG_PREFIX}woodworking"
+        assert "[DEMO]" not in offering.category.name
+        # A rich description, not the generic seed placeholder.
+        assert "Seeded demo class" not in offering.description
+        assert len(offering.description) > 200
+        # A hero attached from the committed asset even with DEBUG off (the prod path).
+        assert offering.image
+        # Real-looking roster names, not "Waitlist ConfirmedN".
+        names = {(r.first_name, r.last_name) for r in offering.registrations.all()}
+        assert ("Maya", "Thompson") in names  # a confirmed seat holder
+        assert ("Jordan", "Kim") in names  # first in line on the waitlist
+
+    def it_leaves_the_hero_in_place_on_reseed(settings):
+        settings.DEBUG = False
+        call_command("demo_data")
+        offering = ClassOffering.objects.get(slug=f"{DEMO_SLUG_PREFIX}full-waitlist")
+        first = offering.image.name
+
+        call_command("demo_data")
+        offering.refresh_from_db()
+        # Idempotent: the existing hero is kept, not re-saved under a new name.
+        assert offering.image.name == first
+
+    def it_removes_the_showcase_category_on_remove(settings):
+        from classes.models import Category
+
+        settings.DEBUG = False
+        call_command("demo_data")
+        assert Category.objects.filter(slug=f"{DEMO_SLUG_PREFIX}woodworking").exists()
+
+        call_command("demo_data", "--remove")
+        assert not Category.objects.filter(slug=f"{DEMO_SLUG_PREFIX}woodworking").exists()
 
 
 def describe_demo_data_registration_questions():

--- a/tests/core/management/demo_data_spec.py
+++ b/tests/core/management/demo_data_spec.py
@@ -172,6 +172,19 @@ def describe_demo_data_showcase_class():
         assert ("Maya", "Thompson") in names  # a confirmed seat holder
         assert ("Jordan", "Kim") in names  # first in line on the waitlist
 
+    def it_makes_the_showcase_the_instructors_newest_class(settings):
+        from membership.models import Member
+
+        # The instructor tour targets the instructor's NEWEST class. The showcase must
+        # win even on local dev (DEBUG on), where a pending-approval class is also
+        # created; otherwise the tour strands on that empty class's roster.
+        settings.DEBUG = True
+        call_command("demo_data")
+        instructor = Member.objects.get(user__email=PERSONA_INSTRUCTOR_EMAIL)
+        newest = instructor.classes.order_by("-created_at", "-pk").first()
+        assert newest is not None
+        assert newest.slug == f"{DEMO_SLUG_PREFIX}full-waitlist"
+
     def it_leaves_the_hero_in_place_on_reseed(settings):
         settings.DEBUG = False
         call_command("demo_data")

--- a/tests/core/tours_spec.py
+++ b/tests/core/tours_spec.py
@@ -2,6 +2,7 @@
 
 import re
 from datetime import timedelta
+from pathlib import Path
 
 import pytest
 from django.contrib.auth.models import AnonymousUser, User
@@ -32,6 +33,20 @@ pytestmark = pytest.mark.django_db
 
 TOUR_KEY_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 HELP_KEY_TARGET_RE = re.compile(r'^\[data-help-key="([^"]+)"\]$')
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
+_STAMPED_KEY_RE = re.compile(r'data-help-key="([^"{}]*)"')
+_STAMPED_PARAM_RE = re.compile(r'action_help_key="([^"{}]*)"')
+
+
+def _keys_stamped_in_templates() -> set[str]:
+    """Every help key actually stamped as an element attribute under templates/."""
+    keys: set[str] = set()
+    for path in TEMPLATES_DIR.rglob("*.html"):
+        text = path.read_text(encoding="utf-8")
+        keys.update(_STAMPED_KEY_RE.findall(text))
+        keys.update(_STAMPED_PARAM_RE.findall(text))
+    return keys
 
 
 def _member(name: str = "tour-member", **kwargs) -> Member:
@@ -84,6 +99,23 @@ def describe_TOURS():
                 match = HELP_KEY_TARGET_RE.match(step.target)
                 assert match, f"{tour.key}: non-help-key target {step.target!r}"
                 assert match.group(1) in HELP_KEYS, f"{tour.key}: unregistered key {match.group(1)!r}"
+
+    def it_targets_only_keys_stamped_in_a_template():
+        # The template->registry drift guard (tests/hub/help_keys_spec) does NOT
+        # enforce the reverse: a key can be registered yet stamped in zero
+        # templates, so a tour step aimed at it would spotlight nothing on the
+        # page. Guard the tour direction explicitly.
+        stamped = _keys_stamped_in_templates()
+        unstamped = sorted(
+            {
+                match.group(1)
+                for tour in TOURS.values()
+                for step in tour.steps
+                if step.target is not None and (match := HELP_KEY_TARGET_RE.match(step.target))
+                if match.group(1) not in stamped
+            }
+        )
+        assert not unstamped, "tour targets not stamped in any template:\n  " + "\n  ".join(unstamped)
 
     def it_reverses_every_entry_url(db):
         member = _lead("urls")


### PR DESCRIPTION
## What this ships

Broad expansion of all four guided tours for the Sept 1 demo, plus a believable demo showcase class.

Spec: `docs/superpowers/plans/2026-08-28-guided-tour-broad-expansion.md`

### Tours (`core/tours.py`)
* **Member** (13 stops): adds a "syncs to Discord" stop after the calendar.
* **Instructor** (13 stops): adds a class home base stop (`teach_class_detail`) and a flyer/QR stop (`teach_class_edit`), and corrects the waitlist copy: promoting a paid waitlister emails them a payment link, it does not charge a card.
* **Guild lead** (16 stops): adds a Share and Print (QR) stop and an orientation thank you email stop, both same page tab flips.
* **Admin** (12 stops): broadens to class + announcement + event approvals, refunds, reconciliation, discount codes, orientations dashboard, manage members, site activity, and the quickstart guides. Reconciliation copy now names guild + instructor + orientator payouts.

### Hooks + drift guard
* 7 new `HELP_KEYS` entries and 10 new `data-help-key` stamps (3 reuse already registered but previously unstamped keys: `orientation.dashboard`, `announcements.review-proposals`, `admin.invite-member`).
* New `tests/core/tours_spec.py::it_targets_only_keys_stamped_in_a_template` closes a real gap: the existing template->registry guard did not enforce that a tour target is actually stamped in a template.

### Demo showcase class (`core/management/commands/demo_data.py`)
* The full + waitlist class becomes a believable standalone showcase: real woodworking title + rich description, a repo committed hero photo that also lands on a **prod** seed via R2 (the gitignored `demo_seed` dir is not on Render), realistic confirmed + waitlist rosters.
* Teardown stays keyed on the `demo-` slug and `@pastlives.demo` emails, so `--remove` still cleans everything. New `demo-woodworking` category is torn down too.

## Version
No `VERSION` bump on purpose. The tours were already announced at 1.21.0; this refines that same feature and adds demo only data, so no member Discord announce should fire on merge. Say the word if you want it announced and I will bump + curate an entry.

## Tests
* `tests/core/tours_spec.py` and `tests/hub/help_keys_spec.py` and `tests/hub/tours_spec.py` and `tests/membership/member_tours_spec.py`: 104 passed.
* `tests/core/management/demo_data_spec.py`: 26 passed (adds showcase + prod hero coverage; autouse tmp `MEDIA_ROOT` so seeds do not pollute the tree).
* `ruff check` + `ruff format` + `mypy` (187 files) + `manage.py check`: clean.
* The member lap e2e is unchanged in shape (existing indices preserved; the new Discord stop is an element less mid tour step the driver already handles). Relying on the CI e2e lane (Postgres).

https://claude.ai/code/session_01Vfk5tQtVqopZVUqMdKu3GT
