### PR TITLE
fix(demo): [DEMO]-prefix the showcase category to avoid a unique-name clash

### DIFF
--- a/core/management/commands/demo_data.py
+++ b/core/management/commands/demo_data.py
@@ -253,15 +253,17 @@ class Command(BaseCommand):
         return category
 
     def _ensure_showcase_category(self) -> Category:
-        """A standalone category for the fully fleshed out showcase class.
+        """A standalone ``[DEMO]``-prefixed category for the showcase class.
 
-        Named without a ``[DEMO]`` prefix so the showcase card reads like a real
-        catalog entry (the class is the demo centerpiece the instructor tour points
-        at), but slug stays ``demo-`` prefixed so ``--remove`` still tears it down.
+        The ``[DEMO]`` prefix is deliberate: ``Category.name`` is unique, and a real
+        makerspace category (e.g. "Woodworking") may already own the bare name on
+        production. Prefixing keeps this dedicated demo category collision-proof and
+        consistent with the sibling "[DEMO] Lamp Working". Slug stays ``demo-``
+        prefixed so ``--remove`` still tears it down.
         """
         category, _ = Category.objects.get_or_create(
             slug=f"{DEMO_SLUG_PREFIX}woodworking",
-            defaults={"name": "Woodworking", "sort_order": 998},
+            defaults={"name": "[DEMO] Woodworking", "sort_order": 998},
         )
         return category
 

--- a/tests/core/management/demo_data_spec.py
+++ b/tests/core/management/demo_data_spec.py
@@ -159,9 +159,11 @@ def describe_demo_data_showcase_class():
 
         offering = ClassOffering.objects.get(slug=f"{DEMO_SLUG_PREFIX}full-waitlist")
         # A real, prefix-free title in its own standalone (non lamp-working) category.
+        # The category name keeps a [DEMO] prefix because Category.name is unique and a
+        # real "Woodworking" category may already own the bare name on production.
         assert "[DEMO]" not in offering.title
         assert offering.category.slug == f"{DEMO_SLUG_PREFIX}woodworking"
-        assert "[DEMO]" not in offering.category.name
+        assert offering.category.name == "[DEMO] Woodworking"
         # A rich description, not the generic seed placeholder.
         assert "Seeded demo class" not in offering.description
         assert len(offering.description) > 200


### PR DESCRIPTION
The prod seed of `demo_data` failed with `IntegrityError: duplicate key value violates unique constraint classes_category_name_key (Key (name)=(Woodworking) already exists)` because a real Woodworking category owns that unique name. This prefixes the dedicated demo category to `[DEMO] Woodworking` (slug stays `demo-woodworking`), collision-proof and consistent with the sibling `[DEMO] Lamp Working`.

The seed is `@transaction.atomic`, so the failed run rolled back cleanly (verified prod: still 3 demo classes, no demo-woodworking category).

Test `it_makes_the_full_class_a_believable_standalone_showcase` updated to assert the new name. demo_data spec: 27 passed; ruff clean.

https://claude.ai/code/session_01Vfk5tQtVqopZVUqMdKu3GT