### PR TITLE
feat(tours): pause/resume guided tours + fix opening popover landing above the fold

### DIFF
--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -6097,6 +6097,80 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
     }
 }
 
+/* ── Paused-tour pill (§6.2) — a persistent Resume affordance that survives
+   navigation while a tour is paused, so the presenter can roam and come back ── */
+.pl-tour-resume {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.5rem 0.5rem 0.5rem 0.875rem;
+    background: var(--hub-card-bg);
+    color: var(--hub-text);
+    border: 1px solid var(--hub-border);
+    border-left: 3px solid var(--color-tuscan-yellow);
+    border-radius: 999px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28);
+    max-width: calc(100vw - 2rem);
+}
+.pl-tour-resume[hidden] { display: none; }
+
+.pl-tour-resume__label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.pl-tour-resume__end {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--hub-text-muted);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+}
+.pl-tour-resume__end:hover,
+.pl-tour-resume__end:focus {
+    background: var(--hub-border);
+    color: var(--hub-text);
+}
+
+@media (max-width: 480px) {
+    .pl-tour-resume {
+        left: 1rem;
+        right: 1rem;
+        justify-content: space-between;
+    }
+}
+
+/* The Pause control inside the Driver.js popover footer (left of Back/Next). */
+.pl-tour .pl-tour-pause-btn {
+    margin-right: auto;
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: var(--hub-text-muted);
+    font: inherit;
+    font-size: 0.8125rem;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+}
+.pl-tour .pl-tour-pause-btn:hover,
+.pl-tour .pl-tour-pause-btn:focus {
+    color: var(--color-tuscan-yellow);
+}
+
 /* ── "Show me around" entry link under a page header (§6.3) ── */
 .pl-tour-entry-link {
     margin: -0.75rem 0 1.25rem;

--- a/static/js/pl_tour.js
+++ b/static/js/pl_tour.js
@@ -433,14 +433,17 @@
                     pauseBtn.addEventListener("click", pauseTour);
                     footer.insertBefore(pauseBtn, footer.firstChild);
                 }
-                // Driver.js occasionally anchors a TARGETLESS (centered) popover
-                // off-screen on its first paint after a page load — it measures the
-                // viewport before layout settles and strands the popover above the
-                // fold (top ≈ -viewportHeight/2). The opening step of every tour is
-                // centered, so pin any targetless popover to the true viewport
-                // center ourselves; element-anchored steps keep Driver's placement.
+                // Driver.js occasionally anchors a CENTERED popover off-screen on its
+                // first paint after a page load — it measures the viewport before
+                // layout settles and strands the popover above the fold
+                // (top ≈ -viewportHeight/2). A popover is centered when the step has no
+                // target OR when driveSegment degraded a missing/hidden target to
+                // centered — same isVisible test it uses, so this matches what Driver
+                // actually did. Pin those to true viewport center; element-anchored
+                // steps keep Driver's placement (and its arrow).
                 var stepNow = current.steps[gi];
-                if (!stepNow || !stepNow.target) {
+                var targetEl = stepNow && stepNow.target ? document.querySelector(stepNow.target) : null;
+                if (!targetEl || !isVisible(targetEl)) {
                     popover.style.position = "fixed";
                     popover.style.left = "50%";
                     popover.style.top = "50%";
@@ -652,7 +655,16 @@
             function pauseTour() {
                 if (!active || !active.driverObj) return;
                 var gi = globalIndexNow();
-                var path = window.location.pathname; // the step's own page
+                // Capture the step's page WITH its query (minus our own tour/step
+                // params) so a resume lands on the exact same view. Several steps
+                // depend on a query string — e.g. ?audience=class:PK&lock=1 on the
+                // instructor compose step, ?tab=payments on the admin dashboard — and
+                // dropping it would render the target absent and strand the popover.
+                var url = new URL(window.location.href);
+                url.searchParams.delete("tour");
+                url.searchParams.delete("step");
+                var qs = url.searchParams.toString();
+                var path = url.pathname + (qs ? "?" + qs : "");
                 try {
                     window.sessionStorage.setItem(
                         RUN_KEY,
@@ -685,7 +697,11 @@
                     return;
                 }
                 hideResumePill();
-                clearRun(); // the destination re-seeds from the ?tour=&step= param
+                // Clear the paused run BEFORE navigating so the destination's init()
+                // does not short-circuit on it and instead takes the autostart path.
+                // If that navigation itself 302s (a locked area), the tour is lost and
+                // self-heals to a re-offer next visit — acceptable.
+                clearRun();
                 boostedGet(withTourParams(run.resumePath || "/", run.key, run.index));
             }
 
@@ -762,10 +778,18 @@
                 bindResumePill(); // the pill markup is present on every member page
                 var paused = readRun();
                 if (paused && paused.paused) {
-                    // A paused tour is in effect on this tab: show the pill and do NOT
+                    // An explicit ?tour= autostart on THIS page supersedes a stale
+                    // paused run: the presenter deliberately started a (possibly
+                    // different) tour from a Start link, and that must win over a hold
+                    // left from another one. Otherwise hold — show the pill and do NOT
                     // auto-resume or re-offer until the presenter clicks Resume.
-                    showResumePill();
-                    return;
+                    if (current && current.autostart) {
+                        clearRun();
+                        hideResumePill();
+                    } else {
+                        showResumePill();
+                        return;
+                    }
                 }
                 if (!current) return;
                 bindOffer();

--- a/static/js/pl_tour.js
+++ b/static/js/pl_tour.js
@@ -421,6 +421,33 @@
                         prevBtn.removeAttribute("disabled");
                     }
                 }
+                // The Pause control: lift the spotlight without ending the tour. Lives
+                // at the left of the footer so it never crowds Back/Next on the right.
+                var footer = popover.querySelector(".driver-popover-footer");
+                if (footer && !footer.querySelector(".pl-tour-pause-btn")) {
+                    var pauseBtn = document.createElement("button");
+                    pauseBtn.type = "button";
+                    pauseBtn.className = "pl-tour-pause-btn";
+                    pauseBtn.textContent = "Pause";
+                    pauseBtn.setAttribute("aria-label", "Pause the tour so you can explore on your own");
+                    pauseBtn.addEventListener("click", pauseTour);
+                    footer.insertBefore(pauseBtn, footer.firstChild);
+                }
+                // Driver.js occasionally anchors a TARGETLESS (centered) popover
+                // off-screen on its first paint after a page load — it measures the
+                // viewport before layout settles and strands the popover above the
+                // fold (top ≈ -viewportHeight/2). The opening step of every tour is
+                // centered, so pin any targetless popover to the true viewport
+                // center ourselves; element-anchored steps keep Driver's placement.
+                var stepNow = current.steps[gi];
+                if (!stepNow || !stepNow.target) {
+                    popover.style.position = "fixed";
+                    popover.style.left = "50%";
+                    popover.style.top = "50%";
+                    popover.style.right = "auto";
+                    popover.style.bottom = "auto";
+                    popover.style.transform = "translate(-50%, -50%)";
+                }
             }
 
             function handleNext() {
@@ -599,6 +626,99 @@
                 }
             }
 
+            // ── pause / resume pill ─────────────────────────────────────────
+            // A pause LIFTS the spotlight without ending the tour: it writes a
+            // "paused" run to sessionStorage (carrying the resume path, the state
+            // URL and the csrf so the pill still works on pages that emit no tour
+            // payload) and shows a persistent floating pill. Because the driver
+            // overlay is torn down, teardownForHtmx stops clearing the run, so the
+            // paused tour survives the presenter wandering to other pages. Resume
+            // reuses the ONE battle-tested resume path: a "?tour=&step=" navigation
+            // back to the paused step's page.
+            function resumePillEl() {
+                return document.getElementById("pl-tour-resume");
+            }
+
+            function showResumePill() {
+                var el = resumePillEl();
+                if (el) el.hidden = false;
+            }
+
+            function hideResumePill() {
+                var el = resumePillEl();
+                if (el) el.hidden = true;
+            }
+
+            function pauseTour() {
+                if (!active || !active.driverObj) return;
+                var gi = globalIndexNow();
+                var path = window.location.pathname; // the step's own page
+                try {
+                    window.sessionStorage.setItem(
+                        RUN_KEY,
+                        JSON.stringify({
+                            key: current.key,
+                            index: gi,
+                            total: current.steps.length,
+                            sidebarPrev: session ? session.sidebarPrev : undefined,
+                            paused: true,
+                            resumePath: path,
+                            stateUrl: current.state_url,
+                            csrf: csrf,
+                        })
+                    );
+                } catch (e) {
+                    /* no storage — pausing is best-effort; still tear the overlay down */
+                }
+                // Silent teardown that RESTORES chrome (sidebar/focus) so the presenter
+                // can roam freely, records nothing, and keeps the run in storage.
+                ending = true;
+                stripTourParams();
+                active.driverObj.destroy();
+                showResumePill();
+            }
+
+            function resumePausedTour() {
+                var run = readRun();
+                if (!run || !run.paused) {
+                    hideResumePill();
+                    return;
+                }
+                hideResumePill();
+                clearRun(); // the destination re-seeds from the ?tour=&step= param
+                boostedGet(withTourParams(run.resumePath || "/", run.key, run.index));
+            }
+
+            function endPausedTour() {
+                var run = readRun();
+                hideResumePill();
+                clearRun();
+                if (run && run.stateUrl) {
+                    // Record the dismissal from wherever the presenter ended it, using
+                    // the state URL + csrf stashed at pause time.
+                    fetch(run.stateUrl, {
+                        method: "POST",
+                        headers: {
+                            "X-CSRFToken": run.csrf || "",
+                            "Content-Type": "application/x-www-form-urlencoded",
+                        },
+                        body: "status=dismissed",
+                    }).catch(function () {
+                        /* self-healing: a lost dismiss just re-offers next visit */
+                    });
+                }
+            }
+
+            function bindResumePill() {
+                var el = resumePillEl();
+                if (!el || el.hasAttribute("data-pl-init")) return;
+                el.setAttribute("data-pl-init", "");
+                var resumeBtn = el.querySelector("[data-tour-resume]");
+                var endBtn = el.querySelector("[data-tour-resume-end]");
+                if (resumeBtn) resumeBtn.addEventListener("click", resumePausedTour);
+                if (endBtn) endBtn.addEventListener("click", endPausedTour);
+            }
+
             // ── offer card ──────────────────────────────────────────────────
             function bindOffer() {
                 var offer = document.querySelector("[data-pl-tour-offer]");
@@ -638,6 +758,14 @@
                     ["htmx:beforeHistorySave", "htmx:beforeSwap"].forEach(function (name) {
                         document.body.addEventListener(name, teardownForHtmx);
                     });
+                }
+                bindResumePill(); // the pill markup is present on every member page
+                var paused = readRun();
+                if (paused && paused.paused) {
+                    // A paused tour is in effect on this tab: show the pill and do NOT
+                    // auto-resume or re-offer until the presenter clicks Resume.
+                    showResumePill();
+                    return;
                 }
                 if (!current) return;
                 bindOffer();

--- a/templates/hub/partials/_tour.html
+++ b/templates/hub/partials/_tour.html
@@ -1,8 +1,10 @@
 {% load static %}
 {% comment %}
-Guided-tour runtime plumbing (Spec C §6.2) — included from entry pages' extra_js block only.
-Emits the json_script payload pl_tour.js consumes, the offer card when show_tour_offer is
-true, and pl_tour.js itself (~2 KB). Driver.js assets are NOT referenced here — pl_tour.js
+Guided-tour runtime plumbing (Spec C §6.2) — included on every member page via
+hub/base.html's tour_runtime block. The PAYLOAD block (root, json_script, offer card,
+advancing scrim) renders only when tour_json is present. The pause/resume pill and
+pl_tour.js itself (~2 KB) render UNCONDITIONALLY, so a paused tour can be resumed even
+on a page that carries no payload. Driver.js assets are NOT referenced here — pl_tour.js
 injects them lazily (from the data-driver-* URLs below) only when a tour actually starts.
 Boosted swaps re-execute the script; it is a guarded window.plTour IIFE, safe to re-run.
 {% endcomment %}

--- a/templates/hub/partials/_tour.html
+++ b/templates/hub/partials/_tour.html
@@ -18,5 +18,17 @@ Boosted swaps re-execute the script; it is a guarded window.plTour IIFE, safe to
     <span class="pl-tour-advancing__spinner" aria-hidden="true"></span>
     <span class="pl-tour-advancing__label">Taking you there...</span>
 </div>
-<script src="{% static 'js/pl_tour.js' %}"></script>
 {% endif %}
+{% comment %}
+The pause/resume pill lives OUTSIDE the payload gate so it renders on every member
+page. A paused tour is held in sessionStorage; pl_tour.js shows this pill from that
+run, which is what lets the presenter wander onto pages that carry no tour payload
+and still resume. The script is likewise loaded unconditionally (it is a tiny,
+inert-when-idle guarded IIFE) so the pill has a controller everywhere.
+{% endcomment %}
+<div id="pl-tour-resume" class="pl-tour-resume" role="region" aria-label="Paused tour" hidden>
+    <span class="pl-tour-resume__label">Tour paused</span>
+    <button type="button" class="pl-btn pl-btn--primary pl-btn--sm" data-tour-resume>Resume tour</button>
+    <button type="button" class="pl-tour-resume__end" data-tour-resume-end aria-label="End tour">&times;</button>
+</div>
+<script src="{% static 'js/pl_tour.js' %}"></script>

--- a/tests/e2e/guided_tour_spec.py
+++ b/tests/e2e/guided_tour_spec.py
@@ -205,6 +205,37 @@ def describe_pausing_a_tour():
         popover.wait_for(state="visible", timeout=10000)
         expect(popover).to_contain_text("Everything in One Place")
 
+    def it_preserves_the_page_query_string_on_resume(live_server, page, login_via_code):
+        # A step whose page depends on a query (?audience=..., ?tab=payments) must
+        # resume onto the SAME view. Prove a benign query survives pause -> resume.
+        email = "tour-query@example.com"
+        _seed_member_world()
+        login_via_code(email)
+        page.goto(f"{live_server.url}{reverse('hub_home')}?tour=member-welcome&step=1&demo=keepme")
+        popover = page.locator(".driver-popover.pl-tour")
+        popover.wait_for(state="visible", timeout=10000)
+        popover.locator(".pl-tour-pause-btn").click()
+        pill = page.locator("#pl-tour-resume")
+        expect(pill).to_be_visible()
+
+        pill.locator("[data-tour-resume]").click()
+        page.wait_for_url("**demo=keepme**", timeout=10000)
+        popover.wait_for(state="visible", timeout=10000)
+        assert "demo=keepme" in page.url
+
+    def it_lets_an_explicit_tour_link_win_over_a_paused_run(live_server, page, login_via_code):
+        # A stale paused run must not swallow a deliberate ?tour= start (e.g. the
+        # presenter opens a different role tour). The explicit autostart wins.
+        email = "tour-win@example.com"
+        popover = _start_mid_tour(live_server, page, login_via_code, email)
+        popover.locator(".pl-tour-pause-btn").click()
+        expect(page.locator("#pl-tour-resume")).to_be_visible()
+
+        page.goto(f"{live_server.url}{reverse('classes:public_list')}?tour=member-welcome&step=3")
+        popover.wait_for(state="visible", timeout=10000)
+        expect(popover).to_contain_text("Browse Classes")  # step index 3, on the catalog
+        expect(page.locator("#pl-tour-resume")).not_to_be_visible()
+
     def it_ends_a_paused_tour_from_the_pill(live_server, page, login_via_code):
         email = "tour-pause-end@example.com"
         popover = _start_mid_tour(live_server, page, login_via_code, email)

--- a/tests/e2e/guided_tour_spec.py
+++ b/tests/e2e/guided_tour_spec.py
@@ -150,6 +150,75 @@ def describe_member_welcome_tour():
         expect(popover).to_contain_text("Your Get Started List")  # step index 2, back on home
 
 
+def _start_mid_tour(live_server, page, login_via_code, email: str):
+    """Land directly on step 1 — an element-anchored popover on hub home.
+
+    Step 0 is a *centered* popover whose Driver.js placement is not what these
+    tests exercise; starting on the sidebar-anchored step 1 (the same reliable
+    entry the resume test uses) keeps the popover on-screen and clickable.
+    """
+    _seed_member_world()
+    login_via_code(email)
+    page.goto(f"{live_server.url}{reverse('hub_home')}?tour=member-welcome&step=1")
+    popover = page.locator(".driver-popover.pl-tour")
+    popover.wait_for(state="visible", timeout=10000)
+    expect(popover).to_contain_text("Everything in One Place")  # step index 1
+    return popover
+
+
+def describe_pausing_a_tour():
+    def it_pauses_and_resumes_on_the_same_page(live_server, page, login_via_code):
+        email = "tour-pause@example.com"
+        popover = _start_mid_tour(live_server, page, login_via_code, email)
+        progress = popover.locator(".driver-popover-progress-text").inner_text().strip()
+
+        # Pause lifts the spotlight without ending the tour: popover gone, pill shown.
+        popover.locator(".pl-tour-pause-btn").click()
+        expect(popover).not_to_be_visible()
+        pill = page.locator("#pl-tour-resume")
+        expect(pill).to_be_visible()
+
+        # Resume brings the popover back at the SAME step (progress text matches).
+        pill.locator("[data-tour-resume]").click()
+        popover.wait_for(state="visible", timeout=10000)
+        expect(popover).to_contain_text("Everything in One Place")
+        assert popover.locator(".driver-popover-progress-text").inner_text().strip() == progress
+        expect(page.locator("#pl-tour-resume")).not_to_be_visible()
+
+    def it_keeps_the_pill_while_you_wander_to_another_page(live_server, page, login_via_code):
+        email = "tour-wander@example.com"
+        popover = _start_mid_tour(live_server, page, login_via_code, email)
+        popover.locator(".pl-tour-pause-btn").click()
+        expect(page.locator("#pl-tour-resume")).to_be_visible()
+
+        # Wander to a normal member page that carries NO tour payload. The paused
+        # run lives in sessionStorage, so the pill follows the presenter there —
+        # and the page shows neither the offer nor a spotlight.
+        page.goto(f"{live_server.url}{reverse('hub_community_calendar')}")
+        expect(page.locator("#pl-tour-resume")).to_be_visible()
+        expect(page.locator(".driver-popover.pl-tour")).not_to_be_visible()
+        expect(page.locator("[data-pl-tour-offer]")).not_to_be_visible()
+
+        # Resume drives back to the paused step's page and re-spotlights it.
+        page.locator("#pl-tour-resume [data-tour-resume]").click()
+        page.wait_for_url("**/home/**", timeout=10000)
+        popover.wait_for(state="visible", timeout=10000)
+        expect(popover).to_contain_text("Everything in One Place")
+
+    def it_ends_a_paused_tour_from_the_pill(live_server, page, login_via_code):
+        email = "tour-pause-end@example.com"
+        popover = _start_mid_tour(live_server, page, login_via_code, email)
+        popover.locator(".pl-tour-pause-btn").click()
+        pill = page.locator("#pl-tour-resume")
+        expect(pill).to_be_visible()
+
+        # The pill's end button ends the tour for good: pill gone, dismissal recorded.
+        pill.locator("[data-tour-resume-end]").click()
+        expect(pill).not_to_be_visible()
+        user = _user_for(email)
+        _wait_for_status(page, user, "member-welcome", TourState.Status.DISMISSED)
+
+
 def _user_for(email: str):
     from django.contrib.auth import get_user_model
 


### PR DESCRIPTION
## What

Adds **pause / resume** to the guided tours, and fixes a pre existing bug that could strand the opening popover above the fold.

### Pause / resume
- Every tour popover gets a **Pause** control (left of Back/Next).
- Pausing lifts the spotlight **without ending the tour**: it stores a paused run in `sessionStorage` (with the resume path, the state URL and the csrf) and shows a persistent **"Tour paused"** pill.
- The presenter can click around, open things, and **navigate to other pages**; the pill follows them because the run survives navigation. It shows even on pages that carry no tour payload.
- **Resume** drives back to the paused step and re spotlights it (reusing the existing `?tour=&step=` navigation, the most tested resume path). The pill's **end** button stops the tour for good and records the dismissal.
- Pausing writes **nothing** to the DB (verified): it is a hold, not a stop, so closing the tab does not consume the tour.

### Bug fix (found while testing, demo facing)
Driver.js sometimes anchored a centered (targetless) popover **outside the viewport** on its first paint after a page load, stranding the opening step of every tour above the fold (reproduced deterministically: first landing `y=-360`, later ones `y=273`). Targetless popovers are now pinned to true viewport center. This also stabilizes the previously flaky completion e2e.

## How it renders everywhere
`_tour.html` now emits the pill markup and loads `pl_tour.js` on every member page (the payload block stays gated behind `tour_json`); the script is an inert-when-idle guarded IIFE.

## Tests
`tests/e2e/guided_tour_spec.py` (run with `-m e2e` on Postgres):
- pause and resume on the same page (progress unchanged)
- keep the pill while wandering to a no payload page, then resume back
- end a paused tour from the pill (records `dismissed`)
- existing completion lap now green across repeated runs

147 Python tour specs pass; `manage.py check` clean; ruff + mypy green via the pre-push gate.

## Versioning
`VERSION` held at `1.21.0` on purpose, matching the rest of this round, so **no Discord announce fires before the Sept 1 demo**. It ships with the batched release.

https://claude.ai/code/session_01Vfk5tQtVqopZVUqMdKu3GT
