### PR TITLE
polish(guild+tour): tooltip crop, Member button Leave menu, Pause pill

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -1091,10 +1091,12 @@
 [data-theme="light"] .pl-btn--secondary {
     background: #f3f4f6;
     color: #1f2937;
+    border-color: #cbd0d6;
 }
 
 [data-theme="light"] .pl-btn--secondary:hover {
     background: #e5e7eb;
+    border-color: #9ca3af;
 }
 
 [data-theme="light"] .pl-cart {

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -6153,22 +6153,36 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
     }
 }
 
-/* The Pause control inside the Driver.js popover footer (left of Back/Next). */
+/* Driver's footer packs its three children (pause, "N of M", nav buttons) with no
+   gap, so the pause control ends up jammed against the step counter. Give the row a
+   gap so nothing touches. */
+.pl-tour .driver-popover-footer {
+    gap: 0.5rem;
+}
+
+/* The Pause control inside the Driver.js popover footer (a subtle ghost pill sitting
+   left of the "N of M" counter and Back/Next). Styled as a real button so it reads as
+   a control and never visually merges with the counter text. */
 .pl-tour .pl-tour-pause-btn {
-    margin-right: auto;
-    padding: 0;
+    padding: 0.25rem 0.6rem;
     background: transparent;
-    border: none;
+    border: 1px solid var(--hub-border);
+    border-radius: 8px;
     color: var(--hub-text-muted);
     font: inherit;
     font-size: 0.8125rem;
-    text-decoration: underline;
-    text-underline-offset: 2px;
+    font-weight: 500;
+    line-height: 1.3;
+    text-decoration: none;
+    text-shadow: none; /* driver's default footer-button white text-shadow must be reset */
     cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
 }
 .pl-tour .pl-tour-pause-btn:hover,
 .pl-tour .pl-tour-pause-btn:focus {
+    background: transparent; /* override driver's default #f7f7f7 hover fill */
     color: var(--color-tuscan-yellow);
+    border-color: var(--color-tuscan-yellow);
 }
 
 /* ── "Show me around" entry link under a page header (§6.3) ── */
@@ -7260,15 +7274,14 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    cursor: default;
+    cursor: pointer;
 }
-.pl-guild-cta__overflow {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    padding: 0;
+.pl-guild-cta__caret {
+    margin-left: 0.1rem;
+    transition: transform 0.15s ease;
+}
+.pl-guild-cta__caret--open {
+    transform: rotate(180deg);
 }
 .pl-guild-cta__menu {
     position: absolute;

--- a/templates/hub/guild_detail.html
+++ b/templates/hub/guild_detail.html
@@ -254,7 +254,7 @@
         <div class="hub-card">
             <div style="display:flex; align-items:center; gap:0.4rem;">
                 <h3 class="hub-detail-label" style="margin-bottom:0;">Studio Hours</h3>
-                <span class="pl-help" tabindex="0" aria-label="What are studio hours?">
+                <span class="pl-help pl-help--right" tabindex="0" aria-label="What are studio hours?">
                     <span class="pl-help__icon" aria-hidden="true">?</span>
                     <span class="pl-help__bubble" role="tooltip">Come chat with the Guild Lead during these times.</span>
                 </span>

--- a/templates/hub/partials/_guild_join_cta.html
+++ b/templates/hub/partials/_guild_join_cta.html
@@ -6,7 +6,7 @@
     {% if member and not is_guilds_surface %}
         {% if is_member_of_guild %}
         <div class="pl-guild-cta__member" x-data="{ menu: false }">
-            <button type="button" class="pl-btn pl-btn--secondary pl-guild-cta__badge" @click="menu = !menu" @click.outside="menu = false" aria-haspopup="true" :aria-expanded="menu" aria-label="Guild membership options">
+            <button type="button" class="pl-btn pl-btn--secondary pl-guild-cta__badge" @click="menu = !menu" @click.outside="menu = false" aria-haspopup="true" :aria-expanded="menu" aria-label="Member, guild membership options">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
                 Member
                 <svg class="pl-guild-cta__caret" :class="{ 'pl-guild-cta__caret--open': menu }" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>

--- a/templates/hub/partials/_guild_join_cta.html
+++ b/templates/hub/partials/_guild_join_cta.html
@@ -6,12 +6,10 @@
     {% if member and not is_guilds_surface %}
         {% if is_member_of_guild %}
         <div class="pl-guild-cta__member" x-data="{ menu: false }">
-            <span class="pl-btn pl-btn--secondary pl-guild-cta__badge">
+            <button type="button" class="pl-btn pl-btn--secondary pl-guild-cta__badge" @click="menu = !menu" @click.outside="menu = false" aria-haspopup="true" :aria-expanded="menu" aria-label="Guild membership options">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
                 Member
-            </span>
-            <button type="button" class="pl-btn pl-btn--secondary pl-guild-cta__overflow" @click="menu = !menu" @click.outside="menu = false" aria-haspopup="true" :aria-expanded="menu" aria-label="Guild membership options">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg>
+                <svg class="pl-guild-cta__caret" :class="{ 'pl-guild-cta__caret--open': menu }" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
             </button>
             <div class="pl-guild-cta__menu" x-show="menu" x-cloak @click="menu = false">
                 <button type="button" class="pl-guild-cta__menu-item" @click="$dispatch('open-confirm', 'leave-guild')">Leave guild</button>


### PR DESCRIPTION
Member-facing UI polish batch for the Sept 1 demo. CSS/template only, no Python changes.

## What changed
1. **Studio Hours tooltip crop** (item 1). Added the documented `pl-help--right` variant to the Studio Hours help tooltip on the guild page so the bubble anchors inside the narrow 340px right aside instead of overflowing the content column's `overflow-x: clip`. Verified in browser: bubble ends at x=1054 in a 1280 viewport, no clipping.
2. **Member button self-triggers Leave** (item 2). The "Member" status control is now a `<button>` that toggles the Leave menu itself; the separate kebab toggle is removed and a caret (rotates when open) indicates the dropdown. Verified: clicking opens the menu, `aria-expanded` flips, "Leave guild" shows.
3. **Light-mode secondary button border** (item 2). `.pl-btn--secondary` was nearly borderless in light mode. Added a visible border (base `#cbd0d6`, hover `#9ca3af`). This is site-wide but **zero layout shift**: `.pl-btn` already reserves a `1px solid transparent` border, so only the color changes. Verified across several secondary buttons.
4. **Tour Pause button** (item 12). The Pause control collided with the "N of M" step counter and read as bare underlined text. Restyled as a bordered ghost pill and added a footer gap so it sits cleanly left of the counter. Verified live in the member-welcome tour.

## Notes for review
- **VERSION intentionally held at 1.21.0** (no bump, no changelog entry). This round is staged for the Sept 1 demo and we are deliberately not firing the Discord release announcement before then. Multiple PRs land at 1.21.0 by design.
- No test targets the removed kebab (`pl-guild-cta__overflow`); template comment lint passes.

https://claude.ai/code/session_01Vfk5tQtVqopZVUqMdKu3GT