### PR TITLE
test(catalog): decouple _series category name from class title

### DIFF
--- a/classes/spec/views/registration_window_spec.py
+++ b/classes/spec/views/registration_window_spec.py
@@ -27,7 +27,10 @@ def _series(slug, title, *offsets_days, status=ClassOffering.Status.PUBLISHED):
     offering = ClassOfferingFactory(
         title=title,
         slug=slug,
-        category=CategoryFactory(name=title, slug=f"{slug}-cat"),
+        # Category name must differ from the class title: the catalog lists every guild
+        # type (category) even when it has no bookable class, so a title-named category
+        # would render the title into the page and trip the "title not in body" checks below.
+        category=CategoryFactory(name=f"{slug} type", slug=f"{slug}-cat"),
         instructor=InstructorFactory(),
         status=status,
         scheduling_type=ClassOffering.SchedulingType.SERIES_PACKAGE,


### PR DESCRIPTION
Unbreaks main. The full-suite CI job (the ~38-min mutation/test job that runs after the e2e+lint gate) failed on the #259 merge with one test:
`classes/spec/views/registration_window_spec.py::describe_catalog::it_hides_a_started_series_but_keeps_a_future_one`.

## Root cause
Fallout from #258 (show all guild types in the catalog). The `_series` test helper named each Category identically to its class title (`CategoryFactory(name=title)`). Before #258, a category with no bookable class was hidden, so a started series' title appeared nowhere. After #258 the catalog lists every guild type even with zero bookable classes (the intended behavior), so the started series' *category* now shows in the filter and trips the test's whole-body `"Started Forge Series" not in body` assertion.

The product is correct and intended; the test's assumption is stale.

## Fix
Name the helper's category distinctly (`f"{slug} type"`) so it can't contain the class title. The catalog assertions now reflect only the class card (hidden when started, shown when future), which is what the test means to verify.

## Verified
Reproduced the failure locally, applied the fix, and ran the full `registration_window_spec.py`: 5 passed (was 1 failed). Test-only change, no product code touched.

VERSION held at 1.21.0 (demo freeze).

https://claude.ai/code/session_01Vfk5tQtVqopZVUqMdKu3GT