### PR TITLE
feat(calendar): Subscribe to the existing Member and Public Google calendars

### DIFF
--- a/core/help_registry.py
+++ b/core/help_registry.py
@@ -75,8 +75,8 @@ HELP_KEYS: dict[str, HelpKeyEntry] = {
     "calendar.subscribe": {
         "title": "Subscribe to the calendar",
         "short_text": (
-            "Add the community calendar to your own calendar app with the .ics link. "
-            "New events show up there automatically."
+            "Subscribe to the Member or Public calendar and it stays in sync in your own "
+            "calendar app, or download a one-time .ics."
         ),
         "article_slug": "community-calendar",
         "anchor": "calendar-subscribe",

--- a/hub/calendar_entries.py
+++ b/hub/calendar_entries.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from django.utils import timezone
 
@@ -207,3 +208,18 @@ def upcoming_calendar_events() -> list[Any]:
             )
         )
     return sorted(entries, key=lambda e: e.start_dt)
+
+
+def google_calendar_subscribe_url(calendar_id: str) -> str:
+    """A ``webcal://`` subscribe URL for a Google Calendar's public iCal feed.
+
+    Members' calendar apps open a ``webcal://`` link as a live subscription (Apple
+    Calendar, Google Calendar, Outlook), so the feed stays up to date. Returns an
+    empty string when no calendar id is configured, so the template can hide the link.
+
+    Args:
+        calendar_id: The Google Calendar ID (e.g. ``"...@group.calendar.google.com"``).
+    """
+    if not calendar_id:
+        return ""
+    return f"webcal://calendar.google.com/calendar/ical/{quote(calendar_id, safe='')}/public/basic.ics"

--- a/hub/views.py
+++ b/hub/views.py
@@ -5015,7 +5015,7 @@ def community_calendar(request: HttpRequest) -> HttpResponse:
     """
     from django.core.paginator import Paginator
 
-    from hub.calendar_entries import upcoming_calendar_events
+    from hub.calendar_entries import google_calendar_subscribe_url, upcoming_calendar_events
     from membership.models import CommunityEvent
 
     ctx = _get_hub_context(request)
@@ -5043,9 +5043,14 @@ def community_calendar(request: HttpRequest) -> HttpResponse:
         else CommunityEvent.objects.none()
     )
 
-    policy = SiteConfiguration.load().member_event_policy
+    site_config = SiteConfiguration.load()
+    policy = site_config.member_event_policy
     cal_ctx["member_can_propose"] = policy != SiteConfiguration.MemberEventPolicy.DISABLED
     cal_ctx["google_sync_enabled"] = _google_sync_enabled()
+    # Subscribe links point at the makerspace's existing Member/Public Google Calendars
+    # (their public iCal feeds), so a member's calendar app stays live. Blank when unset.
+    cal_ctx["member_calendar_subscribe_url"] = google_calendar_subscribe_url(site_config.member_google_calendar_id)
+    cal_ctx["public_calendar_subscribe_url"] = google_calendar_subscribe_url(site_config.public_google_calendar_id)
 
     # Reviewer queue link + count, and the member's own in-flight proposals (Screen A′).
     scope = _reviewer_guild_scope(request)

--- a/membership/help_content.py
+++ b/membership/help_content.py
@@ -543,13 +543,13 @@ A row of colored filter chips sits above the grid — one per guild or calendar.
 
 You'll need to be signed in for this part.
 
-1. On the **Calendar** tab, click **Export Calendar** (top right).
-2. Pick **Subscribe via webcal** to keep your calendar app in sync — new events show up there automatically.
-3. Or pick **Download .ics (Apple / Outlook)** for a one-time import.
+1. On the **Calendar** tab, click **Subscribe** (top right).
+2. Pick **Subscribe to the Member calendar** for all makerspace events, or **Subscribe to the Public calendar** for the outward facing one. Your calendar app stays in sync as new events are added.
+3. Or pick **Download .ics (one time)** for a one time import of this page.
 
-![The Export Calendar button, top right of the Calendar tab.](/static/help/community-calendar/03-export-calendar.png)
+![The Subscribe button, top right of the Calendar tab.](/static/help/community-calendar/03-export-calendar.png)
 
-The export covers the full community calendar — all guild, general, and class events. To register for a class, use the class's own page instead.
+The Member and Public calendars are the makerspace's shared Google calendars. To register for a class, use the class's own page instead.
 
 Each guild also has its own calendar, on the **Guild Calendar** tab of its guild page.
 """,
@@ -572,7 +572,7 @@ Each guild also has its own calendar, on the **Guild Calendar** tab of its guild
                 "file": "03-export-calendar.png",
                 "page": "hub_community_calendar",
                 "selector": ".pl-calendar-export",
-                "caption": "The Export Calendar button, top right of the Calendar tab.",
+                "caption": "The Subscribe button, top right of the Calendar tab.",
                 "as_role": "member",
             },
         ],

--- a/templates/hub/community_calendar.html
+++ b/templates/hub/community_calendar.html
@@ -160,19 +160,25 @@
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
                     </svg>
-                    Export Calendar
+                    Subscribe
                     <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5l3 3 3-3"/></svg>
                 </button>
                 <div class="pl-calendar-export__dropdown" x-show="open" x-transition>
-                    <a href="{% url 'hub_calendar_export_ics' %}" class="pl-calendar-export__item" download>
-                        Download .ics (Apple / Outlook)
+                    {% if member_calendar_subscribe_url %}
+                    <a href="{{ member_calendar_subscribe_url }}" class="pl-calendar-export__item">
+                        Subscribe to the Member calendar
                     </a>
-                    <a href="webcal://{{ request.get_host }}{% url 'hub_calendar_export_ics' %}"
-                       class="pl-calendar-export__item">
-                        Subscribe via webcal
+                    {% endif %}
+                    {% if public_calendar_subscribe_url %}
+                    <a href="{{ public_calendar_subscribe_url }}" class="pl-calendar-export__item">
+                        Subscribe to the Public calendar
+                    </a>
+                    {% endif %}
+                    <a href="{% url 'hub_calendar_export_ics' %}" class="pl-calendar-export__item" download>
+                        Download .ics (one time)
                     </a>
                     <p class="pl-calendar-export__note">
-                        Exports the full community calendar — all guild, general, and class events. To register for a specific class, use the More Info link on that event instead.
+                        Subscribe once and your calendar app stays up to date. The Member calendar is all makerspace events; the Public calendar is the outward facing one.
                     </p>
                 </div>
             </div>

--- a/tests/hub/calendar_entries_spec.py
+++ b/tests/hub/calendar_entries_spec.py
@@ -9,8 +9,17 @@ from django.utils import timezone
 
 from classes.factories import CategoryFactory, ClassOfferingFactory, ClassSessionFactory
 from classes.models import ClassOffering
-from hub.calendar_entries import CalendarEntry
+from hub.calendar_entries import CalendarEntry, google_calendar_subscribe_url
 from tests.membership.factories import GuildFactory
+
+
+def describe_google_calendar_subscribe_url():
+    def it_builds_a_webcal_url_and_encodes_the_calendar_id():
+        url = google_calendar_subscribe_url("abc123@group.calendar.google.com")
+        assert url == "webcal://calendar.google.com/calendar/ical/abc123%40group.calendar.google.com/public/basic.ics"
+
+    def it_returns_an_empty_string_for_a_blank_id():
+        assert google_calendar_subscribe_url("") == ""
 
 
 def _entry(**kwargs) -> CalendarEntry:

--- a/tests/hub/community_events_spec.py
+++ b/tests/hub/community_events_spec.py
@@ -447,3 +447,34 @@ def describe_edit_page_delete_button():
         client.login(username="dele5", password="pass")
         html = client.get(reverse("hub_event_edit", args=[event.pk])).content.decode()
         assert "This removes the whole series." in html
+
+
+@pytest.mark.django_db
+def describe_calendar_subscribe_links():
+    def it_offers_member_and_public_subscribe_links_when_configured(client: Client):
+        _user_with_role("sub1")
+        config = SiteConfiguration.load()
+        config.member_google_calendar_id = "memid@group.calendar.google.com"
+        config.public_google_calendar_id = "pubid@group.calendar.google.com"
+        config.save()
+        client.login(username="sub1", password="pass")
+
+        body = client.get(reverse("hub_community_calendar")).content.decode()
+
+        assert "webcal://calendar.google.com/calendar/ical/memid%40group.calendar.google.com/public/basic.ics" in body
+        assert "webcal://calendar.google.com/calendar/ical/pubid%40group.calendar.google.com/public/basic.ics" in body
+        assert "Subscribe to the Member calendar" in body
+        assert "Subscribe to the Public calendar" in body
+
+    def it_hides_a_subscribe_link_when_its_calendar_is_unset(client: Client):
+        _user_with_role("sub2")
+        config = SiteConfiguration.load()
+        config.member_google_calendar_id = "memid@group.calendar.google.com"
+        config.public_google_calendar_id = ""
+        config.save()
+        client.login(username="sub2", password="pass")
+
+        body = client.get(reverse("hub_community_calendar")).content.decode()
+
+        assert "Subscribe to the Member calendar" in body
+        assert "Subscribe to the Public calendar" not in body


### PR DESCRIPTION
Item 11. The Community Calendar's "Export Calendar" dropdown had a "Subscribe via webcal" link pointing at the FOG ICS feed (`hub_calendar_export_ics`), which is `@login_required` — so an external calendar app can't authenticate and the subscription silently fails (hits the login page).

## Approach (per Josh)
Reuse the makerspace's **existing** Member and Public Google Calendars (the ones FOG already syncs from) rather than build a new feed. Every Google Calendar exposes a public iCal URL, so Subscribe just links to those.

## Change
- New helper `hub.calendar_entries.google_calendar_subscribe_url(calendar_id)` builds a `webcal://calendar.google.com/calendar/ical/<url-encoded id>/public/basic.ics` link (empty string when unset).
- `community_calendar` view passes `member_calendar_subscribe_url` / `public_calendar_subscribe_url` from `SiteConfiguration.member/public_google_calendar_id`.
- Dropdown relabeled "Export Calendar" -> "Subscribe" with "Subscribe to the Member calendar" and "Subscribe to the Public calendar" (each shown only when its calendar id is set); the one-time .ics download stays. The broken login-gated webcal link is removed.

## Verified
Both prod calendars' public iCal feeds return HTTP 200 + `BEGIN:VCALENDAR`, so the links work out of the box (no Google sharing change needed). Tests: helper URL-encoding + empty case; view renders both links when configured and hides one when its calendar is unset. 59 specs green (calendar_entries + community_events); ruff, mypy, django check, template lint clean.

VERSION held at 1.21.0 (demo freeze).

https://claude.ai/code/session_01Vfk5tQtVqopZVUqMdKu3GT