### PR TITLE
feat(view-as): admin self-service capability toggles in the dropdown

### DIFF
--- a/hub/context_processors.py
+++ b/hub/context_processors.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from django.http import HttpRequest
 
-from membership.models import Guild, Member
+from membership.models import AdminCapability, Guild, Member
 
 
 def hub_sidebar(request: HttpRequest) -> dict[str, Any]:
@@ -41,7 +41,26 @@ def hub_sidebar(request: HttpRequest) -> dict[str, Any]:
         "user_initials": initials,
         "user_profile_photo_url": photo_url,
         "can_use_admin_tools": _can_use_admin_tools(request, member),
+        "view_as_capabilities": _admin_capability_rows(request, member),
     }
+
+
+def _admin_capability_rows(request: HttpRequest, member: Member | None) -> list[dict[str, Any]]:
+    """Rows for the "View As" dropdown's self-service admin-duty toggles.
+
+    Returns one ``{value, label, checked}`` dict per :class:`AdminCapability` for an
+    ACTUAL admin (``request.view_as.actual_is_admin`` — a view-as preview can't unlock
+    it), and an empty list otherwise. ``checked`` reflects the current member's own held
+    capabilities so the toggles start in the right state.
+    """
+    view_as = getattr(request, "view_as", None)
+    if member is None or view_as is None or not view_as.actual_is_admin:
+        return []
+    held = set(member.admin_capabilities.values_list("capability", flat=True))
+    return [
+        {"value": value, "label": label, "checked": value in held}
+        for value, label in AdminCapability.Capability.choices
+    ]
 
 
 def _can_use_admin_tools(request: HttpRequest, member: Member | None) -> bool:

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -405,6 +405,7 @@ urlpatterns = [
     path("events/<int:pk>/event.ics", views.event_ics, name="hub_event_ics"),
     path("events/<int:pk>/qr.<str:fmt>/", views.event_qr, name="hub_event_qr"),
     path("view-as/set/", views.view_as_set, name="hub_view_as_set"),
+    path("view-as/capability/set/", views.view_as_capability_set, name="hub_view_as_capability_set"),
     path("manage/voting/", views.voting_overview, name="hub_admin_voting_overview"),
     path("manage/voting/history/", views.voting_history, name="hub_admin_voting_history"),
     path("manage/voting/history/<int:pk>/", views.voting_history_detail, name="hub_admin_voting_history_detail"),

--- a/hub/views.py
+++ b/hub/views.py
@@ -32,7 +32,7 @@ from billing.exceptions import NoPaymentMethodError, TabLimitExceededError, TabL
 from billing.models import BillingSettings, Tab, TabCharge
 from classes.models import Category, ClassOffering
 from core.models import HeroCropMixin, SiteConfiguration
-from hub.view_as import ALL_ROLES, ROLE_GUEST, ROLE_MEMBER, SESSION_ROLE_KEY, fog_admin_required
+from hub.view_as import ALL_ROLES, ROLE_ADMIN, ROLE_GUEST, ROLE_MEMBER, SESSION_ROLE_KEY, fog_admin_required
 from hub.forms import (
     BetaFeedbackForm,
     CalendarFeedFormSet,
@@ -5294,6 +5294,60 @@ def view_as_set(request: HttpRequest) -> JsonResponse:
     request.session[SESSION_ROLE_KEY] = role
 
     return JsonResponse({"role": role})
+
+
+def _coerce_enabled(raw: object) -> bool:
+    """Coerce a posted ``enabled`` value into a bool, accepting JSON bools, ints, and strings.
+
+    The dropdown posts a real JSON boolean, but tolerate ``1``/``"true"``/``"on"`` etc.
+    so a hand-crafted client can't slip through with a truthy string that Python would
+    otherwise treat as always-``True``.
+    """
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return bool(raw)
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
+@require_POST
+@login_required
+def view_as_capability_set(request: HttpRequest) -> JsonResponse:
+    """Grant or revoke one of the CURRENT admin's OWN admin capabilities.
+
+    Body: ``{"capability": "billing_approver", "enabled": true}``. Lets a full admin
+    self-grant or self-revoke a scoped duty (e.g. Billing Administrator) straight from
+    the "View As" dropdown without visiting their member-edit page. This is a REAL grant,
+    not a preview — a full ``fog_role=admin`` must still opt into each capability to
+    receive its notifications and actions, so self-granting is meaningful.
+
+    SECURITY: gated on the caller's ACTUAL admin role (``view_as.has_actual(ROLE_ADMIN)``),
+    never the view-as *effective* role — a session view-as preview can neither grant this
+    access nor let a non-admin through (a non-admin, or an admin previewing down, gets 403).
+    The capability is validated against ``AdminCapability.Capability.values`` (else 400) and
+    only ever applied to the caller's OWN linked member; no target member id is accepted.
+    """
+    view_as = getattr(request, "view_as", None)
+    if view_as is None or not view_as.has_actual(ROLE_ADMIN):
+        return JsonResponse({"error": "Admin access required."}, status=403)
+
+    try:
+        payload = json.loads(request.body or b"{}")
+        capability = payload["capability"]
+        enabled = _coerce_enabled(payload["enabled"])
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return JsonResponse({"error": "Invalid request"}, status=400)
+
+    if capability not in AdminCapability.Capability.values:
+        return JsonResponse({"error": f"Unknown capability '{capability}'"}, status=400)
+
+    member = _get_member(request)
+    if member is None:
+        return JsonResponse({"error": "No member on this account."}, status=403)
+
+    member.set_admin_capability(capability, enabled, granted_by=cast(User, request.user))
+
+    return JsonResponse({"ok": True, "capability": capability, "enabled": enabled})
 
 
 @fog_admin_required

--- a/membership/models.py
+++ b/membership/models.py
@@ -1062,7 +1062,12 @@ class Member(models.Model):
                 (idempotent: revoking an absent grant is a no-op).
             granted_by: The user performing the grant, recorded for audit. Applied
                 only when a new grant row is created.
+
+        Raises:
+            ValueError: If ``capability`` is not a known ``AdminCapability.Capability``.
         """
+        if capability not in AdminCapability.Capability.values:
+            raise ValueError(f"Unknown admin capability: {capability!r}")
         if enabled:
             self.admin_capabilities.get_or_create(capability=capability, defaults={"granted_by": granted_by})
         else:

--- a/membership/models.py
+++ b/membership/models.py
@@ -1045,6 +1045,29 @@ class Member(models.Model):
         for capability in desired - current:
             self.admin_capabilities.create(capability=capability, granted_by=granted_by)
 
+    def set_admin_capability(self, capability: str, enabled: bool, *, granted_by: "User | None" = None) -> None:
+        """Grant or revoke a single :class:`AdminCapability` on this member.
+
+        A capability is a scoped admin duty (approve classes, spaces, discount codes,
+        calendar proposals, billing alerts, or issue refunds) that decouples one duty
+        from the all-or-nothing ``fog_role == admin`` tier. Unlike
+        :meth:`sync_admin_capabilities`, which reconciles the whole set, this flips
+        exactly one capability and leaves every other grant untouched — it backs the
+        quick self-service toggles in the "View As" dropdown.
+
+        Args:
+            capability: One of :class:`AdminCapability.Capability` values.
+            enabled: ``True`` to grant (idempotent: a duplicate grant is a no-op, so
+                the existing ``granted_by`` is preserved), ``False`` to revoke
+                (idempotent: revoking an absent grant is a no-op).
+            granted_by: The user performing the grant, recorded for audit. Applied
+                only when a new grant row is created.
+        """
+        if enabled:
+            self.admin_capabilities.get_or_create(capability=capability, defaults={"granted_by": granted_by})
+        else:
+            self.admin_capabilities.filter(capability=capability).delete()
+
     def can_edit_guild(self, guild: Guild) -> bool:
         """True when this member may edit the given guild.
 

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -2593,6 +2593,27 @@ a:hover { color: var(--hub-link-hover); }
     margin-top: 4px;
 }
 
+.pl-view-as-popover__duties {
+    min-width: 252px;
+    margin-top: 4px;
+    border-top: 1px solid var(--hub-dropdown-border);
+}
+
+.pl-view-as-popover__duty {
+    padding: 6px 8px;
+    gap: 12px;
+    border-bottom: none;
+}
+
+.pl-view-as-popover__duty .pl-toggle-label {
+    font-size: 13px;
+    font-weight: 400;
+}
+
+.pl-view-as-popover__duties .pl-view-as-popover__hint {
+    border-top: 1px solid var(--hub-dropdown-border);
+}
+
 .hub-sidebar__icons {
     display: flex;
     justify-content: center;

--- a/templates/hub/base.html
+++ b/templates/hub/base.html
@@ -414,6 +414,26 @@
                     </button>
                     {% endfor %}
                     <div class="pl-view-as-popover__hint">Preview the hub as a different role. Session-only.</div>
+                    {% if request.view_as.actual_is_admin %}
+                    {# Real self-service capability grants (not a preview) — admin-only. #}
+                    <div class="pl-view-as-popover__duties">
+                        <div class="pl-view-as-popover__header">Your admin duties</div>
+                        {% for cap in view_as_capabilities %}
+                        <div class="pl-toggle-row pl-view-as-popover__duty">
+                            <div class="pl-toggle-info">
+                                <div class="pl-toggle-label">{{ cap.label }}</div>
+                            </div>
+                            <label class="pl-toggle">
+                                <input type="checkbox" {% if cap.checked %}checked{% endif %}
+                                       @change="setCapability('{{ cap.value }}', $event.target.checked, $event.target)"
+                                       aria-label="{{ cap.label }}">
+                                <span class="pl-toggle__slider"></span>
+                            </label>
+                        </div>
+                        {% endfor %}
+                        <div class="pl-view-as-popover__hint">Grant or revoke your own admin duties (real changes, applied right away).</div>
+                    </div>
+                    {% endif %}
                 </div>
             </div>
             {% endif %}
@@ -558,6 +578,25 @@
                     });
                     if (response.ok) {
                         window.location.reload();
+                    }
+                },
+                async setCapability(capability, enabled, el) {
+                    const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value
+                        || document.cookie.split('; ').find(c => c.startsWith('csrftoken='))?.split('=')[1];
+                    const response = await fetch("{% url 'hub_view_as_capability_set' %}", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            "X-CSRFToken": csrfToken || "",
+                        },
+                        body: JSON.stringify({ capability, enabled }),
+                    });
+                    if (response.ok) {
+                        // Reload so nav/sidebar a capability unlocks (e.g. the Payments dashboard) refreshes.
+                        window.location.reload();
+                    } else if (el) {
+                        // Revert the toggle so it never lies about the real grant state.
+                        el.checked = !enabled;
                     }
                 },
             };

--- a/tests/hub/view_as_spec.py
+++ b/tests/hub/view_as_spec.py
@@ -228,6 +228,97 @@ def describe_view_as_set_endpoint():
 
 
 @pytest.mark.django_db
+def describe_view_as_capability_set_endpoint():
+    def it_lets_an_admin_grant_their_own_capability(client):
+        user, member = _make_user_member(Member.FogRole.ADMIN, username="cap_grant")
+        client.login(username=user.username, password="p")
+
+        response = client.post(
+            "/view-as/capability/set/",
+            data=json.dumps({"capability": "billing_approver", "enabled": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        row = member.admin_capabilities.get(capability="billing_approver")
+        assert row.granted_by == user
+
+    def it_lets_an_admin_revoke_their_own_capability(client):
+        user, member = _make_user_member(Member.FogRole.ADMIN, username="cap_revoke")
+        member.admin_capabilities.create(capability="refunds")
+        client.login(username=user.username, password="p")
+
+        response = client.post(
+            "/view-as/capability/set/",
+            data=json.dumps({"capability": "refunds", "enabled": False}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert member.admin_capabilities.filter(capability="refunds").exists() is False
+
+    def it_rejects_a_non_admin_member_and_creates_no_row(client):
+        user, member = _make_user_member(Member.FogRole.MEMBER, username="cap_attacker")
+        client.login(username=user.username, password="p")
+
+        response = client.post(
+            "/view-as/capability/set/",
+            data=json.dumps({"capability": "billing_approver", "enabled": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert member.admin_capabilities.count() == 0
+
+    def it_does_not_let_a_view_as_admin_preview_escalate_a_non_admin(client):
+        # A non-admin with a crafted session view-as of "admin" still can't grant:
+        # the gate reads the ACTUAL role, so the preview illusion grants nothing.
+        user, member = _make_user_member(Member.FogRole.MEMBER, username="cap_preview")
+        client.login(username=user.username, password="p")
+        session = client.session
+        session["view_as_role"] = "admin"
+        session.save()
+
+        response = client.post(
+            "/view-as/capability/set/",
+            data=json.dumps({"capability": "billing_approver", "enabled": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert member.admin_capabilities.count() == 0
+
+    def it_rejects_an_unknown_capability(client):
+        user, member = _make_user_member(Member.FogRole.ADMIN, username="cap_bad")
+        client.login(username=user.username, password="p")
+
+        response = client.post(
+            "/view-as/capability/set/",
+            data=json.dumps({"capability": "not_a_capability", "enabled": True}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert member.admin_capabilities.count() == 0
+
+    def it_only_touches_the_callers_own_member(client):
+        user, member = _make_user_member(Member.FogRole.ADMIN, username="cap_self")
+        _, other_member = _make_user_member(Member.FogRole.ADMIN, username="cap_other")
+        client.login(username=user.username, password="p")
+
+        # A smuggled target member id must be ignored — only the caller's own member changes.
+        response = client.post(
+            "/view-as/capability/set/",
+            data=json.dumps({"capability": "billing_approver", "enabled": True, "member": other_member.pk}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert member.has_admin_capability("billing_approver") is True
+        assert other_member.has_admin_capability("billing_approver") is False
+
+
+@pytest.mark.django_db
 def describe_dropdown_in_hub_template():
     def it_renders_dropdown_for_admins(client):
         user, _ = _make_user_member(Member.FogRole.ADMIN, username="tmpl_admin")
@@ -247,3 +338,25 @@ def describe_dropdown_in_hub_template():
 
         assert response.status_code == 200
         assert b"pl-view-as-popover" not in response.content
+
+    def it_renders_capability_toggles_for_an_actual_admin(client):
+        user, _ = _make_user_member(Member.FogRole.ADMIN, username="tmpl_cap_admin")
+        client.login(username=user.username, password="p")
+
+        response = client.get("/guilds/voting/")
+
+        assert response.status_code == 200
+        assert b"Your admin duties" in response.content
+        assert b"Billing Administrator" in response.content
+
+    def it_omits_capability_toggles_for_a_non_admin_who_still_sees_the_dropdown(client):
+        # A guild officer gets the view-as dropdown (a downgrade tool) but is NOT an
+        # actual admin, so the self-service duty toggles must be absent.
+        user, _ = _make_user_member(Member.FogRole.GUILD_OFFICER, username="tmpl_cap_officer")
+        client.login(username=user.username, password="p")
+
+        response = client.get("/guilds/voting/")
+
+        assert response.status_code == 200
+        assert b"pl-view-as-popover" in response.content
+        assert b"Your admin duties" not in response.content

--- a/tests/membership/admin_capability_spec.py
+++ b/tests/membership/admin_capability_spec.py
@@ -90,3 +90,37 @@ def describe_sync_admin_capabilities():
         member.admin_capabilities.create(capability=AdminCapability.Capability.CLASS_APPROVER)
         member.sync_admin_capabilities([])
         assert member.admin_capabilities.count() == 0
+
+
+def describe_set_admin_capability():
+    def it_grants_the_capability_and_records_the_granter():
+        member = _member("set1")
+        granter = User.objects.create_user(username="setgranter", email="setgranter@example.com")
+        member.set_admin_capability(AdminCapability.Capability.BILLING_APPROVER, True, granted_by=granter)
+        row = member.admin_capabilities.get(capability="billing_approver")
+        assert row.granted_by == granter
+
+    def it_is_idempotent_when_granting_twice():
+        member = _member("set2")
+        granter = User.objects.create_user(username="setgranter2", email="setgranter2@example.com")
+        member.set_admin_capability(AdminCapability.Capability.REFUNDS, True, granted_by=granter)
+        member.set_admin_capability(AdminCapability.Capability.REFUNDS, True, granted_by=granter)
+        assert member.admin_capabilities.filter(capability="refunds").count() == 1
+
+    def it_revokes_the_capability():
+        member = _member("set3")
+        member.admin_capabilities.create(capability=AdminCapability.Capability.SPACE_APPROVER)
+        member.set_admin_capability(AdminCapability.Capability.SPACE_APPROVER, False)
+        assert member.admin_capabilities.filter(capability="space_approver").exists() is False
+
+    def it_is_idempotent_when_revoking_an_absent_grant():
+        member = _member("set4")
+        member.set_admin_capability(AdminCapability.Capability.SPACE_APPROVER, False)
+        assert member.admin_capabilities.count() == 0
+
+    def it_leaves_other_capabilities_untouched():
+        member = _member("set5")
+        member.admin_capabilities.create(capability=AdminCapability.Capability.CLASS_APPROVER)
+        member.set_admin_capability(AdminCapability.Capability.EVENTS_APPROVER, True)
+        held = set(member.admin_capabilities.values_list("capability", flat=True))
+        assert held == {"class_approver", "events_approver"}

--- a/tests/membership/admin_capability_spec.py
+++ b/tests/membership/admin_capability_spec.py
@@ -124,3 +124,9 @@ def describe_set_admin_capability():
         member.set_admin_capability(AdminCapability.Capability.EVENTS_APPROVER, True)
         held = set(member.admin_capabilities.values_list("capability", flat=True))
         assert held == {"class_approver", "events_approver"}
+
+    def it_raises_on_an_unknown_capability():
+        member = _member("set6")
+        with pytest.raises(ValueError, match="Unknown admin capability"):
+            member.set_admin_capability("not_a_real_capability", True)
+        assert member.admin_capabilities.count() == 0


### PR DESCRIPTION
Item 3b. Adds a "Your admin duties" section to the View As dropdown (actual-admin only) where a full admin flips their own scoped capabilities (Class Approver, Refunds, Billing, Spaces, Discounts, Calendar) on/off without visiting their member-edit page. Real grants, not a preview (a full admin must still opt into each capability to get its notifications/actions).

## Security (the load-bearing part)
- Endpoint `view_as_capability_set` (`POST /view-as/capability/set/`, `@require_POST @login_required`) is gated on `view_as.has_actual(ROLE_ADMIN)` — the caller's ACTUAL role set from `compute_actual_roles(request.user)`, never the view-as *effective* (previewed) set. A view-as preview only narrows `effective`; it can't add to `actual`, so a non-admin (or an admin previewing down) gets 403.
- Capability is validated against `AdminCapability.Capability.values` (else 400).
- Only ever applied to the caller's OWN linked member (`_get_member(request)`); no target member id is read from the body.
- `_coerce_enabled` normalizes the flag so a truthy string can't force-enable.

## Change
`Member.set_admin_capability(cap, enabled, *, granted_by)` grants/revokes one capability idempotently (model method, no migration). Context processor surfaces the toggle rows for actual admins only. Template section + Alpine `setCapability()` handler (CSRF, reload on success, revert on failure). Compact theme-token CSS.

## Tests
Security-rejection specs: non-admin POST -> 403 + 0 rows; crafted `session["view_as_role"]="admin"` on a non-admin -> 403 + 0 rows; unknown capability -> 400; smuggled `member` id ignored (only caller's own member touched); grant/revoke-as-self records granted_by=self; template toggles present for actual admin, absent otherwise. 55 view_as/capability specs + 19 regression green; ruff, mypy (pre-push), django check, template lint, makemigrations --check all clean.

VERSION held at 1.21.0 (demo freeze).

https://claude.ai/code/session_01Vfk5tQtVqopZVUqMdKu3GT