### PR TITLE
feat(spaces): edit a space inline from the detail modal (admin)

### DIFF
--- a/hub/forms.py
+++ b/hub/forms.py
@@ -3077,6 +3077,54 @@ class MapHotspotEditForm(MapHotspotForm):
             self.fields["status"].initial = self.instance.space.status
 
 
+class SpaceDetailEditForm(forms.ModelForm):
+    """The in-modal, trimmed editor for one marker, opened from the public Spaces map popup.
+
+    The routine-edit path (item 9): an admin edits exactly the four things members read on the
+    space-detail card — ``status``, the ``guild`` link, the ``label`` and the ``description`` —
+    straight from the popup, without opening the full "Edit This Map" placement editor. It is a
+    strict subset of :class:`MapHotspotEditForm`: ``kind``/``shape``/``space`` stay structural
+    (full editor only) and price/size stay read-only (Airtable owns them), so none of them are
+    fields here. Like the placement editor, ``status`` is not a marker field — it lives on the
+    linked :class:`Space` (Airtable's system of record), so the *view* applies it after ``save()``
+    via ``_apply_marker_status`` and the field is ignored for a marker with no space.
+    """
+
+    status = forms.ChoiceField(
+        required=False,
+        choices=Space.Status.choices,
+        label="Status",
+        help_text="Only a marker linked to a space carries a status.",
+    )
+
+    class Meta:
+        model = MapHotspot
+        fields = ["label", "description", "guild"]
+        widgets = {"description": forms.Textarea(attrs={"rows": 3})}
+        labels = {"label": "Marker label", "guild": "Links to guild"}
+        help_texts = {
+            "guild": "Optional — link this marker straight to a guild's page.",
+        }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        guild_field = cast(forms.ModelChoiceField, self.fields["guild"])
+        guild_field.queryset = Guild.objects.filter(is_active=True).order_by("name")
+        if self.instance.pk and self.instance.space_id:
+            self.fields["status"].initial = self.instance.space.status
+
+    def clean(self) -> dict[str, Any]:
+        cleaned = cast(dict[str, Any], super().clean())
+        label = (cleaned.get("label") or "").strip()
+        # A space-bound marker shows its space's code, so its label is free to be blank; a
+        # facility/info marker shows its label, so that label can't be blanked away here.
+        # Walls are decorative and never edited from the popup, but stay exempt for safety.
+        needs_label = self.instance.space_id is None and self.instance.kind not in MapHotspot.DECORATIVE_KINDS
+        if needs_label and not label:
+            self.add_error("label", "Give this marker a label so members know what it is.")
+        return cleaned
+
+
 class MapHotspotPositionForm(forms.Form):
     """The visual editor's drag/resize payload for ONE marker, in image percentages.
 

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -272,6 +272,11 @@ urlpatterns = [
     path("spaces/map/markers/<int:pk>/position/", views.map_hotspot_position, name="hub_map_hotspot_position"),
     path("spaces/map/markers/<int:pk>/status/", views.map_hotspot_status, name="hub_map_hotspot_status"),
     path("spaces/map/markers/<int:pk>/edit/", views.map_hotspot_edit, name="hub_map_hotspot_edit"),
+    path(
+        "spaces/map/markers/<int:pk>/inline-edit/",
+        views.map_hotspot_inline_edit,
+        name="hub_map_hotspot_inline_edit",
+    ),
     path("spaces/map/markers/<int:pk>/delete/", views.map_hotspot_delete, name="hub_map_hotspot_delete"),
     path("spaces/map/markers/<int:pk>/", views.map_hotspot_detail, name="hub_map_hotspot_detail"),
     path("spaces/map/markers/<int:pk>/request/", views.space_request_create, name="hub_space_request_create"),

--- a/hub/views.py
+++ b/hub/views.py
@@ -6770,6 +6770,9 @@ def _hotspot_detail_context(request: HttpRequest, hotspot: Any) -> dict[str, Any
         "viewer_is_member": member is not None,
         "viewer_is_active": is_active_member,
         "can_request": can_request,
+        # The in-modal pencil editor is admin-only — the same gate as the "Edit the map" link
+        # on the Spaces page and the placement editor (``org_map_edit`` → ``_require_admin``).
+        "can_edit_map": _viewing_as_admin(request),
         # Always an unbound form when a request is possible, so the panel renders the
         # field through components/form_field.html rather than hand-rolled markup.
         "request_form": (SpaceRequestForm(hotspot=hotspot, member=cast(Member, member)) if can_request else None),
@@ -7154,6 +7157,53 @@ def map_hotspot_edit(request: HttpRequest, pk: int) -> HttpResponse:
         _apply_marker_status(request, hotspot.space, form.cleaned_data["status"])
     response = render(request, "hub/partials/_editor_marker.html", {"h": hotspot, "oob_swap": "true"})
     response["HX-Trigger"] = "close-marker-edit"
+    return response
+
+
+def _render_space_detail_editor(request: HttpRequest, hotspot: Any, form: Any) -> HttpResponse:
+    """Render the trimmed in-modal marker editor into the space-detail modal body (#space-detail-body)."""
+    return render(request, "hub/partials/_space_detail_edit.html", {"hotspot": hotspot, "form": form})
+
+
+@login_required
+def map_hotspot_inline_edit(request: HttpRequest, pk: int) -> HttpResponse:
+    """Open or save the in-modal editor for one marker on the public Spaces map. Admin only.
+
+    Item 9's routine-edit path: an admin edits a marker's status, guild link, label and
+    description straight from the space-detail popup, without opening the full placement editor.
+    Same admin gate as that editor (``_require_admin``) — a non-admin gets a 403 on both GET and
+    POST. GET renders the trimmed :class:`~hub.forms.SpaceDetailEditForm` into the modal body. A
+    valid POST saves the marker's guild/label/description, then (for a space-bound marker) applies
+    the chosen status through the SAME ``_apply_marker_status`` path the placement editor uses —
+    writing ``Space.status`` and pushing to Airtable (the system of record). It answers with the
+    re-rendered detail panel (so the modal shows the new values) carrying ``swap_marker``, which
+    ships an ``hx-swap-oob`` copy of the marker tile and its list row so the map recolours and
+    relabels live. An invalid POST re-renders the edit form with its errors, so the modal stays in
+    edit mode. Only ever edits marker ``pk``; price/size/kind/shape/space are never touched
+    (Airtable-owned or structural), and coordinates stay with the drag endpoint.
+    """
+    from hub.forms import SpaceDetailEditForm
+    from membership.models import MapHotspot
+
+    forbidden = _require_admin(request)
+    if forbidden is not None:
+        return forbidden
+    hotspot = get_object_or_404(MapHotspot.objects.select_related("space", "floorplan"), pk=pk)
+    if request.method != "POST":
+        return _render_space_detail_editor(request, hotspot, SpaceDetailEditForm(instance=hotspot))
+    form = SpaceDetailEditForm(request.POST, instance=hotspot)
+    if not form.is_valid():
+        return _render_space_detail_editor(request, hotspot, form)
+    hotspot = form.save()
+    if hotspot.space_id and form.cleaned_data["status"]:
+        _apply_marker_status(request, hotspot.space, form.cleaned_data["status"])
+    ctx = _hotspot_detail_context(request, hotspot)
+    response = render(
+        request,
+        "hub/partials/_space_detail.html",
+        {**ctx, "swap_marker": True, "pending_space_ids": [], "my_space_requests": []},
+    )
+    trigger_toast(response, "Space updated.", "success")
     return response
 
 

--- a/static/css/hub.css
+++ b/static/css/hub.css
@@ -5857,6 +5857,8 @@ mark { background: color-mix(in srgb, var(--color-tuscan-yellow) 30%, transparen
   margin-bottom: 0.75rem;
 }
 .pl-map-detail__title { margin: 0; font-size: 1.125rem; }
+.pl-map-detail__edit { margin-left: auto; }
+.pl-map-detail__edit svg { margin-right: 0.3rem; }
 .pl-map-detail__photo {
   display: block;
   width: 100%;

--- a/templates/hub/partials/_space_detail.html
+++ b/templates/hub/partials/_space_detail.html
@@ -2,10 +2,13 @@
 The space-detail panel, loaded by HTMX into #space-detail-body.
 
 Context (from _hotspot_detail_context): hotspot, open_request, viewer_is_member,
-viewer_is_active, can_request, request_form. When ``swap_marker`` is set (the response
-to a successful request) it also carries hx-swap-oob copies of the marker and the list
-row, so the map, this panel, and the accessible list can never disagree about whether a
-request is pending.
+viewer_is_active, can_request, request_form, can_edit_map. When ``swap_marker`` is set
+(the response to a successful request OR an admin inline edit) it also carries hx-swap-oob
+copies of the marker and the list row, so the map, this panel, and the accessible list can
+never disagree about a space's status/label or whether a request is pending.
+
+can_edit_map (admin only) shows a pencil "Edit" button that swaps the trimmed inline editor
+(_space_detail_edit.html) into this same #space-detail-body.
 {% endcomment %}
 <div class="pl-map-detail" id="space-detail-panel">
     <div class="pl-map-detail__head">
@@ -18,6 +21,15 @@ request is pending.
             <span class="hub-pill hub-pill--neutral">Occupied</span>
         {% else %}
             <span class="hub-pill hub-pill--neutral">Facility</span>
+        {% endif %}
+        {% if can_edit_map %}
+        {# Admin-only: edit status / guild / label / description inline, no full-map editor needed. #}
+        <button type="button" class="pl-btn pl-btn--secondary pl-btn--sm pl-map-detail__edit"
+                hx-get="{% url 'hub_map_hotspot_inline_edit' hotspot.pk %}"
+                hx-target="#space-detail-body" hx-swap="innerHTML">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+            Edit
+        </button>
         {% endif %}
     </div>
 

--- a/templates/hub/partials/_space_detail_edit.html
+++ b/templates/hub/partials/_space_detail_edit.html
@@ -1,0 +1,51 @@
+{% comment %}
+The trimmed, in-modal marker editor, loaded by HTMX into #space-detail-body from the
+space-detail popup's pencil "Edit" button (admin only).
+
+Context (from map_hotspot_inline_edit): hotspot (the MapHotspot), form (SpaceDetailEditForm).
+It edits exactly the four things members read on the detail card — status, guild link, label,
+description — and nothing structural (kind/shape/space stay in the full "Edit This Map" editor)
+or Airtable-owned (price/size are read-only). A valid save answers elsewhere with the re-rendered
+detail panel plus an hx-swap-oob copy of the marker tile (so the map recolours/relabels live);
+an invalid save re-renders this partial with field errors, so the modal stays in edit mode.
+Cancel reloads the read-only detail into the same body.
+{% endcomment %}
+<div class="pl-map-detail" id="space-detail-panel">
+    <div class="pl-map-detail__head">
+        <h3 class="pl-map-detail__title">Edit {{ hotspot.display_label }}</h3>
+    </div>
+
+    <form class="hub-form pl-marker-edit"
+          hx-post="{% url 'hub_map_hotspot_inline_edit' hotspot.pk %}"
+          hx-target="#space-detail-body" hx-swap="innerHTML">
+        {% csrf_token %}
+        {% for error in form.non_field_errors %}<p class="pl-field-error">{{ error }}</p>{% endfor %}
+
+        {% if hotspot.space_id %}
+        <fieldset class="pl-marker-edit__status">
+            <legend class="pl-form-label">Status</legend>
+            <p class="pl-form-hint">Sets the colour members see, and pushes to Airtable.</p>
+            {% for error in form.status.errors %}<p class="pl-field-error">{{ error }}</p>{% endfor %}
+            <div class="pl-marker-edit__chips" role="radiogroup" aria-label="Space status">
+                {% for value, label in form.status.field.choices %}
+                <label class="pl-chip pl-chip--status-{{ value }}">
+                    <input type="radio" name="{{ form.status.html_name }}" value="{{ value }}"{% if form.status.value|stringformat:'s' == value|stringformat:'s' %} checked{% endif %}>
+                    <span>{{ label }}</span>
+                </label>
+                {% endfor %}
+            </div>
+        </fieldset>
+        {% endif %}
+
+        {% include "components/form_field.html" with field=form.guild %}
+        {% include "components/form_field.html" with field=form.label field_hint="Shown when no space is linked — e.g. 'Wood Shop'." %}
+        {% include "components/form_field.html" with field=form.description field_hint="The blurb members read in this space's pop-up." %}
+
+        <div class="pl-marker-edit__actions">
+            <button type="submit" class="pl-btn pl-btn--primary">Save</button>
+            <button type="button" class="pl-btn pl-btn--secondary"
+                    hx-get="{% url 'hub_map_hotspot_detail' hotspot.pk %}"
+                    hx-target="#space-detail-body" hx-swap="innerHTML">Cancel</button>
+        </div>
+    </form>
+</div>

--- a/tests/hub/space_map_forms_spec.py
+++ b/tests/hub/space_map_forms_spec.py
@@ -11,6 +11,7 @@ from hub.forms import (
     MapHotspotEditForm,
     MapHotspotForm,
     MapHotspotPositionForm,
+    SpaceDetailEditForm,
     SpaceRequestDecisionForm,
     SpaceRequestForm,
 )
@@ -262,4 +263,80 @@ def describe_MapHotspotEditForm():
     def it_accepts_a_blank_status():
         hotspot = MapHotspotFactory()
         form = MapHotspotEditForm(_edit_data(space=str(hotspot.space_id), status=""), instance=hotspot)
+        assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def describe_SpaceDetailEditForm():
+    """The trimmed in-modal editor: exactly status + guild + label + description, prefilling
+    status from the linked space, ignoring it for a marker with no space, and never exposing
+    the structural (kind/shape/space) or Airtable-owned (price/size) fields."""
+
+    def _detail_data(**overrides):
+        data = {"label": "", "description": "", "guild": "", "status": ""}
+        data.update(overrides)
+        return data
+
+    def it_exposes_only_status_guild_label_description():
+        form = SpaceDetailEditForm(instance=MapHotspotFactory())
+        assert set(form.fields) == {"status", "guild", "label", "description"}
+
+    def it_prefills_status_from_the_linked_space():
+        hotspot = MapHotspotFactory(space=SpaceFactory(status=Space.Status.MAINTENANCE))
+        form = SpaceDetailEditForm(instance=hotspot)
+        assert form.fields["status"].initial == Space.Status.MAINTENANCE
+
+    def it_has_no_status_for_a_marker_with_no_space():
+        hotspot = MapHotspotFactory(kind=MapHotspot.Kind.FACILITY, space=None, label="Wood Shop")
+        form = SpaceDetailEditForm(instance=hotspot)
+        assert form.fields["status"].initial is None
+
+    def it_saves_the_info_fields():
+        guild = GuildFactory()
+        hotspot = MapHotspotFactory()
+        form = SpaceDetailEditForm(
+            _detail_data(description="Now with a kiln.", guild=str(guild.pk)),
+            instance=hotspot,
+        )
+        assert form.is_valid(), form.errors
+        saved = form.save()
+        assert saved.description == "Now with a kiln."
+        assert saved.guild_id == guild.pk
+
+    def it_allows_a_blank_guild_link():
+        hotspot = MapHotspotFactory(guild=GuildFactory())
+        form = SpaceDetailEditForm(_detail_data(guild=""), instance=hotspot)
+        assert form.is_valid(), form.errors
+        assert form.save().guild_id is None
+
+    def it_accepts_a_blank_status():
+        hotspot = MapHotspotFactory()
+        form = SpaceDetailEditForm(_detail_data(status=""), instance=hotspot)
+        assert form.is_valid(), form.errors
+
+    def it_rejects_an_unknown_status():
+        hotspot = MapHotspotFactory()
+        form = SpaceDetailEditForm(_detail_data(status="nonsense"), instance=hotspot)
+        assert not form.is_valid()
+        assert "status" in form.errors
+
+    def it_offers_only_active_guilds():
+        active = GuildFactory(name="Active Guild", is_active=True)
+        GuildFactory(name="Retired Guild", is_active=False)
+        form = SpaceDetailEditForm(instance=MapHotspotFactory())
+        names = {g.name for g in form.fields["guild"].queryset}
+        assert "Active Guild" in names
+        assert "Retired Guild" not in names
+        assert active  # bind the created guild
+
+    def it_requires_a_label_for_a_facility_marker_with_no_space():
+        hotspot = MapHotspotFactory(kind=MapHotspot.Kind.FACILITY, space=None, label="Wood Shop")
+        form = SpaceDetailEditForm(_detail_data(label=""), instance=hotspot)
+        assert not form.is_valid()
+        assert "Give this marker a label so members know what it is." in form.errors["label"]
+
+    def it_allows_a_blank_label_for_a_space_bound_marker():
+        # A studio shows its space code, so a blank label is fine — it's never displayed.
+        hotspot = MapHotspotFactory()
+        form = SpaceDetailEditForm(_detail_data(label=""), instance=hotspot)
         assert form.is_valid(), form.errors

--- a/tests/hub/space_map_views_spec.py
+++ b/tests/hub/space_map_views_spec.py
@@ -260,6 +260,27 @@ def describe_hotspot_detail():
         response = client.get(reverse("hub_map_hotspot_detail", args=[hotspot.pk]))
         assert b"pl-map-detail__guild-link" not in response.content
 
+    def it_shows_an_admin_the_inline_edit_pencil(client: Client):
+        _user_with_role("pen-adm", fog_role=Member.FogRole.ADMIN)
+        hotspot = MapHotspotFactory()
+        client.login(username="pen-adm", password="pass")
+        body = client.get(reverse("hub_map_hotspot_detail", args=[hotspot.pk])).content.decode()
+        assert reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]) in body
+        assert "pl-map-detail__edit" in body
+
+    def it_hides_the_inline_edit_pencil_from_a_member(client: Client):
+        _user_with_role("pen-mem")
+        hotspot = MapHotspotFactory()
+        client.login(username="pen-mem", password="pass")
+        body = client.get(reverse("hub_map_hotspot_detail", args=[hotspot.pk])).content.decode()
+        assert reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]) not in body
+        assert "pl-map-detail__edit" not in body
+
+    def it_hides_the_inline_edit_pencil_from_a_guest(client: Client):
+        hotspot = MapHotspotFactory()
+        body = client.get(reverse("hub_map_hotspot_detail", args=[hotspot.pk])).content.decode()
+        assert "pl-map-detail__edit" not in body
+
 
 @pytest.mark.django_db
 def describe_editor_gating():
@@ -859,3 +880,150 @@ def describe_marker_editing():
         _user_with_role("adm-del2", fog_role=Member.FogRole.ADMIN)
         client.login(username="adm-del2", password="pass")
         assert client.post(reverse("hub_map_hotspot_delete", args=[99999])).status_code == 404
+
+
+@pytest.mark.django_db
+def describe_inline_space_editing():
+    """Item 9's in-modal editor (map_hotspot_inline_edit): an admin edits status / guild / label /
+    description straight from the space-detail popup. Admin-only on both GET and POST; a valid save
+    writes Space.status via the shared Airtable path and answers with the re-rendered detail panel
+    plus an out-of-band marker tile so the map recolours live without a reload."""
+
+    def _payload(hotspot, **overrides):
+        data = {
+            "label": hotspot.label,
+            "description": hotspot.description,
+            "guild": str(hotspot.guild_id or ""),
+            "status": "",
+        }
+        data.update(overrides)
+        return data
+
+    def it_403s_a_plain_member_opening_the_editor(client: Client):
+        _user_with_role("pm-ie")
+        hotspot = MapHotspotFactory()
+        client.login(username="pm-ie", password="pass")
+        assert client.get(reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk])).status_code == 403
+
+    def it_403s_a_plain_member_saving_and_changes_nothing(client: Client):
+        _user_with_role("pm-ie2")
+        guild = GuildFactory()
+        hotspot = MapHotspotFactory(description="Untouched", space=SpaceFactory(status=Space.Status.AVAILABLE))
+        client.login(username="pm-ie2", password="pass")
+        response = client.post(
+            reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]),
+            _payload(hotspot, label="Hacked", description="Hacked", guild=str(guild.pk), status=Space.Status.OCCUPIED),
+        )
+        assert response.status_code == 403
+        hotspot.refresh_from_db()
+        assert hotspot.description == "Untouched"
+        assert hotspot.guild_id is None
+        hotspot.space.refresh_from_db()
+        assert hotspot.space.status == Space.Status.AVAILABLE
+
+    def it_redirects_an_anonymous_visitor_to_login(client: Client):
+        hotspot = MapHotspotFactory()
+        response = client.get(reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]))
+        assert response.status_code == 302
+        assert "/accounts/login/" in response["Location"]
+
+    def it_opens_the_editor_for_an_admin(client: Client):
+        _user_with_role("adm-ie", fog_role=Member.FogRole.ADMIN)
+        hotspot = MapHotspotFactory(description="A cosy corner studio.")
+        client.login(username="adm-ie", password="pass")
+        response = client.get(reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]))
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert ">Save<" in body
+        assert 'name="status"' in body  # a space-bound marker shows the status chips
+        assert 'name="guild"' in body
+        assert 'name="label"' in body
+        assert "A cosy corner studio." in body  # description prefilled
+
+    def it_hides_status_for_a_marker_with_no_space(client: Client):
+        _user_with_role("adm-ie2", fog_role=Member.FogRole.ADMIN)
+        hotspot = MapHotspotFactory(kind=MapHotspot.Kind.FACILITY, space=None, label="Wood Shop")
+        client.login(username="adm-ie2", password="pass")
+        body = client.get(reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk])).content.decode()
+        assert 'name="status"' not in body
+
+    def it_saves_the_status_and_pushes_to_airtable_and_recolours_live(client: Client, monkeypatch):
+        _user_with_role("adm-ie3", fog_role=Member.FogRole.ADMIN)
+        hotspot = MapHotspotFactory(space=SpaceFactory(status=Space.Status.AVAILABLE))
+        pushed: list[int] = []
+        monkeypatch.setattr(
+            "airtable_sync.service.sync_space_to_airtable",
+            lambda space: pushed.append(space.pk) or "recX",
+        )
+        client.login(username="adm-ie3", password="pass")
+        response = client.post(
+            reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]),
+            _payload(hotspot, status=Space.Status.OCCUPIED),
+        )
+        assert response.status_code == 200
+        hotspot.space.refresh_from_db()
+        assert hotspot.space.status == Space.Status.OCCUPIED
+        assert pushed == [hotspot.space_id]  # the Airtable push was attempted
+        body = response.content.decode()
+        # The re-rendered detail panel shows the new status...
+        assert "Occupied" in body
+        # ...and an out-of-band, recoloured marker tile keeps the map in sync without a reload.
+        assert f'id="hotspot-{hotspot.pk}"' in body
+        assert 'hx-swap-oob="true"' in body
+        assert "pl-map-marker--occupied" in body
+        # The pencil is back, so the admin can keep editing.
+        assert reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]) in body
+
+    def it_saves_the_guild_label_and_description(client: Client):
+        _user_with_role("adm-ie4", fog_role=Member.FogRole.ADMIN)
+        guild = GuildFactory(name="Ceramics Guild")
+        hotspot = MapHotspotFactory(kind=MapHotspot.Kind.FACILITY, space=None, label="Wood Shop")
+        client.login(username="adm-ie4", password="pass")
+        response = client.post(
+            reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]),
+            _payload(hotspot, label="Ceramics Studio", description="Kilns and wheels.", guild=str(guild.pk)),
+        )
+        assert response.status_code == 200
+        hotspot.refresh_from_db()
+        assert hotspot.label == "Ceramics Studio"
+        assert hotspot.description == "Kilns and wheels."
+        assert hotspot.guild_id == guild.pk
+        body = response.content.decode()
+        assert "Ceramics Studio" in body  # the detail panel re-renders with the new values
+        assert "Kilns and wheels." in body
+        assert f'id="hotspot-{hotspot.pk}"' in body  # out-of-band marker
+
+    def it_skips_the_airtable_push_when_the_status_is_unchanged(client: Client, monkeypatch):
+        _user_with_role("adm-ie5", fog_role=Member.FogRole.ADMIN)
+        hotspot = MapHotspotFactory(space=SpaceFactory(status=Space.Status.AVAILABLE))
+        pushed: list[int] = []
+        monkeypatch.setattr("airtable_sync.service.sync_space_to_airtable", lambda space: pushed.append(space.pk))
+        client.login(username="adm-ie5", password="pass")
+        client.post(
+            reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]),
+            _payload(hotspot, status=Space.Status.AVAILABLE, description="Only the blurb changed."),
+        )
+        assert pushed == []
+        hotspot.refresh_from_db()
+        assert hotspot.description == "Only the blurb changed."
+
+    def it_rerenders_the_form_with_errors_on_an_invalid_save(client: Client):
+        _user_with_role("adm-ie6", fog_role=Member.FogRole.ADMIN)
+        hotspot = MapHotspotFactory(kind=MapHotspot.Kind.FACILITY, space=None, label="Keep Me")
+        client.login(username="adm-ie6", password="pass")
+        response = client.post(
+            reverse("hub_map_hotspot_inline_edit", args=[hotspot.pk]),
+            _payload(hotspot, label="", description="Changed but invalid"),
+        )
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "Give this marker a label so members know what it is." in body
+        assert ">Save<" in body  # the edit form is re-rendered (modal stays in edit mode)
+        assert f'id="hotspot-{hotspot.pk}"' not in body  # no out-of-band marker on a failed save
+        hotspot.refresh_from_db()
+        assert hotspot.label == "Keep Me"  # nothing saved
+
+    def it_404s_an_unknown_marker(client: Client):
+        _user_with_role("adm-ie7", fog_role=Member.FogRole.ADMIN)
+        client.login(username="adm-ie7", password="pass")
+        assert client.get(reverse("hub_map_hotspot_inline_edit", args=[99999])).status_code == 404


### PR DESCRIPTION
Item 9 (the in-modal edit half; the map height + guild links + cubby heading shipped in #260). Admins can now edit a space's status, guild link, label, and description straight from the space-detail popup on /spaces/, behind a pencil Edit button, instead of opening the separate "Edit This Map" view.

## Scope
Editable inline: STATUS (available/occupied/maintenance), GUILD link, LABEL, DESCRIPTION. Deliberately NOT price/size (Airtable-owned, read-only) or kind/shape/space (structural, stay in the full map editor). `SpaceDetailEditForm` is a trimmed ModelForm over exactly those four fields.

## Security / integration
- Both GET (render editor) and POST (save) use the SAME admin gate as the existing map editor (`_require_admin` / `_viewing_as_admin` = `request.view_as.is_admin`), so a logged-in non-admin gets 403 and anon gets the login redirect — identical to the placement editor on the same page. A non-admin can't reach it via view-as (the view-as system won't grant a non-admin an admin effective role). Only edits the marker addressed by the URL pk.
- Status changes reuse the existing `_apply_marker_status` helper, so the Space.status write + Airtable push happen exactly as in the map editor (warns, never 500s, on an Airtable outage). No new Airtable code.
- On save the endpoint re-renders the detail panel plus an `hx-swap-oob` map marker and list row, so map + popup + listings stay in sync.
- Note: an actual admin *previewing as a member* sees no pencil (view-as-aware, matching the sibling "Edit the map" link). Intentional for consistency.

## Tests
`describe_inline_space_editing` + `describe_SpaceDetailEditForm`: non-admin GET/POST both 403 and change nothing; admin opens editor + saves status (Airtable push patched + asserted, Space.status changed, recoloured oob marker, panel shows "Occupied") / guild / label / description; status hidden for space-less markers; unchanged status skips the push; invalid save re-renders with errors and saves nothing; 404 unknown; pencil visible to admin, absent for member/guest. 144 space-map specs + 25 space-request specs green; ruff, mypy (pre-push), django check, template lint, makemigrations --check clean. Form only, no migration.

VERSION held at 1.21.0 (demo freeze).

https://claude.ai/code/session_01Vfk5tQtVqopZVUqMdKu3GT